### PR TITLE
#21 Egua não permite concatenação e operações diretamento no console

### DIFF
--- a/src/avaliador-sintatico/index.ts
+++ b/src/avaliador-sintatico/index.ts
@@ -968,7 +968,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  analisar(simbolos?: SimboloInterface[]) {
+  analisar(simbolos?: SimboloInterface[]): any {
     if (simbolos) {
       this.simbolos = simbolos;
     }

--- a/src/delegua.ts
+++ b/src/delegua.ts
@@ -70,7 +70,6 @@ export class Delegua {
     }
 
     iniciarDelegua() {
-        const interpretador = new Interpretador(this, process.cwd());
         console.log(`Console da Linguagem Delégua v${this.versao()}`);
         const leiaLinha = readline.createInterface({
             input: process.stdin,
@@ -84,39 +83,35 @@ export class Delegua {
             this.teveErro = false;
             this.teveErroEmTempoDeExecucao = false;
 
-            this.run(linha, interpretador);
+            this.run(linha);
             leiaLinha.prompt();
         });
     }
 
     carregarArquivo(nomeArquivo: any) {
         this.nomeArquivo = caminho.basename(nomeArquivo);
-        const interpretador = new Interpretador(this, process.cwd());
 
         const dadosDoArquivo = fs.readFileSync(nomeArquivo).toString();
-        this.run(dadosDoArquivo, interpretador);
+        this.run(dadosDoArquivo);
 
         if (this.teveErro) process.exit(65);
         if (this.teveErroEmTempoDeExecucao) process.exit(70);
     }
 
-    run(codigo: any, interpretador: any) {
-        const lexer = new Lexer(this);
-        const simbolos = lexer.scan(codigo);
+    run(codigo: any) {
+        const simbolos = this.lexador.scan(codigo);
 
         if (this.teveErro === true) return;
 
-        const analisar = new Parser(this);
-        const declaracoes = analisar.analisar(simbolos);
+        const declaracoes = this.avaliadorSintatico.analisar(simbolos);
 
         if (this.teveErro === true) return;
 
-        const resolver = new Resolver(this, interpretador);
-        resolver.resolver(declaracoes);
+        this.resolvedor.resolver(declaracoes);
 
         if (this.teveErro === true) return;
 
-        interpretador.interpretar(declaracoes);
+        this.interpretador.interpretar(declaracoes);
     }
 
     reportar(linha: any, onde: any, mensagem: any) {

--- a/src/interfaces/avaliador-sintatico-interface.ts
+++ b/src/interfaces/avaliador-sintatico-interface.ts
@@ -54,5 +54,5 @@ export interface AvaliadorSintaticoInterface {
     corpoDaFuncao(kind: any): any;
     declaracaoDeClasse(): any;
     declaracao(): any;
-    analisar(): any;
+    analisar(simbolos?: SimboloInterface[]): any
 }

--- a/src/interfaces/lexador-interface.ts
+++ b/src/interfaces/lexador-interface.ts
@@ -20,5 +20,5 @@ export interface LexadorInterface {
     analisarNumero(): void;
     identificarPalavraChave(): void;
     scanToken(): void;
-    scan(): any;
+    scan(codigo?: any): any
 }

--- a/src/interpretador/dialetos/egua-classico.ts
+++ b/src/interpretador/dialetos/egua-classico.ts
@@ -478,7 +478,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
     const delegua = new Delegua(nomeArquivo);
     const interpretador = new InterpretadorEguaClassico(delegua, pastaTotal);
 
-    delegua.run(dados, interpretador);
+    delegua.run(dados);
 
     let exportar = interpretador.global.valores.exports;
 

--- a/src/interpretador/dialetos/egua-classico.ts
+++ b/src/interpretador/dialetos/egua-classico.ts
@@ -144,9 +144,12 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
           typeof direita === "string"
         ) {
           return String(esquerda) + String(direita);
-        } else {
-          return String(esquerda) + String(direita);
         }
+
+        throw new ErroEmTempoDeExecucao(
+          expr.operador,
+          "Operadores precisam ser dois números ou duas strings."
+        );
 
       case tiposDeSimbolos.DIVISAO:
         this.checkNumberOperands(expr.operador, esquerda, direita);
@@ -807,14 +810,6 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
 
   interpretar(declaracoes: any) {
     try {
-      if (declaracoes.length === 1) {
-        const eObjetoExpressao =
-          declaracoes[0].constructor.name === "Expressao";
-        if (eObjetoExpressao) {
-          this.executar(declaracoes[0], eObjetoExpressao);
-          return;
-        }
-      }
       for (let i = 0; i < declaracoes.length; i++) {
         this.executar(declaracoes[i]);
       }

--- a/src/interpretador/index.ts
+++ b/src/interpretador/index.ts
@@ -139,12 +139,7 @@ export class Interpretador implements InterpretadorInterface {
       case tiposDeSimbolos.ADICAO:
         if (typeof esquerda === "number" && typeof direita === "number") {
           return Number(esquerda) + Number(direita);
-        } else if (
-          typeof esquerda === "string" &&
-          typeof direita === "string"
-        ) {
-          return String(esquerda) + String(direita);
-        } else {
+        }else {
           return String(esquerda) + String(direita);
         }
 

--- a/src/lexador/index.ts
+++ b/src/lexador/index.ts
@@ -316,7 +316,7 @@ export class Lexer implements LexadorInterface {
         }
     }
 
-    scan(codigo?: any) {
+    scan(codigo?: any): any {
         if (codigo) {
             this.codigo = codigo;
         }


### PR DESCRIPTION
Essa PR volta ao original implementação da linguagem égua, que não permite:

- Concatenar número e texto
- Operações diretamente no console.

E resolve problema na definição do dialeto.