### PR TITLE
Ajustando tipagens, Voltando lógica original do dialeto egua

### DIFF
--- a/src/avaliador-sintatico/dialetos/egua-classico.ts
+++ b/src/avaliador-sintatico/dialetos/egua-classico.ts
@@ -60,7 +60,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     this.ciclos = 0;
   }
 
-  sincronizar() {
+  sincronizar(): void {
     this.avancar();
 
     while (!this.estaNoFinal()) {
@@ -82,48 +82,48 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     }
   }
 
-  erro(simbolo: any, mensagemDeErro: any) {
+  erro(simbolo: any, mensagemDeErro: any): any {
     this.Delegua.erro(simbolo, mensagemDeErro);
     return new ErroAvaliador();
   }
 
-  consumir(tipo: any, mensagemDeErro: any) {
+  consumir(tipo: any, mensagemDeErro: any): any {
     if (this.verificar(tipo)) return this.avancar();
     else throw this.erro(this.peek(), mensagemDeErro);
   }
 
-  verificar(tipo: any) {
+  verificar(tipo: any): boolean {
     if (this.estaNoFinal()) return false;
     return this.peek().tipo === tipo;
   }
 
-  verificarProximo(tipo: any) {
+  verificarProximo(tipo: any): boolean {
     if (this.estaNoFinal()) return false;
     return this.simbolos[this.atual + 1].tipo === tipo;
   }
 
-  peek() {
+  peek(): any {
     return this.simbolos[this.atual];
   }
 
-  voltar() {
+  voltar(): any {
     return this.simbolos[this.atual - 1];
   }
 
-  seek(posicao: number) {
+  seek(posicao: number): any {
     return this.simbolos[this.atual + posicao];
   }
 
-  estaNoFinal() {
+  estaNoFinal(): boolean {
     return this.peek().tipo === tiposDeSimbolos.EOF;
   }
 
-  avancar() {
+  avancar(): any {
     if (!this.estaNoFinal()) this.atual += 1;
     return this.voltar();
   }
 
-  match(...argumentos: any[]) {
+  match(...argumentos: any[]): boolean {
     for (let i = 0; i < argumentos.length; i++) {
       const tipoAtual = argumentos[i];
       if (this.verificar(tipoAtual)) {
@@ -135,7 +135,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return false;
   }
 
-  primario() {
+  primario(): any {
     if (this.match(tiposDeSimbolos.SUPER)) {
       const palavraChave = this.voltar();
       this.consumir(tiposDeSimbolos.DOT, "Esperado '.' após 'super'.");
@@ -212,7 +212,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     throw this.erro(this.peek(), "Esperado expressão.");
   }
 
-  finalizarChamada(callee: any) {
+  finalizarChamada(callee: any): any {
     const argumentos = [];
     if (!this.verificar(tiposDeSimbolos.PARENTESE_DIREITO)) {
       do {
@@ -234,7 +234,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Call(callee, parenteseDireito, argumentos);
   }
 
-  chamar() {
+  chamar(): any {
     let expr = this.primario();
 
     while (true) {
@@ -261,7 +261,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  unario() {
+  unario(): any {
     if (
       this.match(
         tiposDeSimbolos.NEGACAO,
@@ -277,7 +277,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return this.chamar();
   }
 
-  exponent() {
+  exponent(): any {
     let expr = this.unario();
 
     while (this.match(tiposDeSimbolos.EXPONENCIACAO)) {
@@ -289,7 +289,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  multiplicar() {
+  multiplicar(): any {
     let expr = this.exponent();
 
     while (
@@ -307,7 +307,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  adicionar() {
+  adicionar(): any {
     let expr = this.multiplicar();
 
     while (this.match(tiposDeSimbolos.SUBTRACAO, tiposDeSimbolos.ADICAO)) {
@@ -319,7 +319,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitFill() {
+  bitFill(): any {
     let expr = this.adicionar();
 
     while (
@@ -333,7 +333,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitE() {
+  bitE(): any {
     let expr = this.bitFill();
 
     while (this.match(tiposDeSimbolos.BIT_AND)) {
@@ -345,7 +345,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitOu() {
+  bitOu(): any {
     let expr = this.bitE();
 
     while (this.match(tiposDeSimbolos.BIT_OR, tiposDeSimbolos.BIT_XOR)) {
@@ -357,7 +357,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  comparar() {
+  comparar(): any {
     let expr = this.bitOu();
 
     while (
@@ -376,7 +376,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  equality() {
+  equality(): any {
     let expr = this.comparar();
 
     while (this.match(tiposDeSimbolos.DIFERENTE, tiposDeSimbolos.IGUAL_IGUAL)) {
@@ -388,7 +388,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  em() {
+  em(): any {
     let expr = this.equality();
 
     while (this.match(tiposDeSimbolos.EM)) {
@@ -400,7 +400,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  e() {
+  e(): any {
     let expr = this.em();
 
     while (this.match(tiposDeSimbolos.E)) {
@@ -412,7 +412,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  ou() {
+  ou(): any {
     let expr = this.e();
 
     while (this.match(tiposDeSimbolos.OU)) {
@@ -424,7 +424,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  atribuir() {
+  atribuir(): any {
     const expr = this.ou();
 
     if (
@@ -449,11 +449,11 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  expressao() {
+  expressao(): any {
     return this.atribuir();
   }
 
-  declaracaoMostrar() {
+  declaracaoMostrar(): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       "Esperado '(' antes dos valores em escreva."
@@ -474,7 +474,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Escreva(valor);
   }
 
-  expressionStatement() {
+  expressionStatement(): any {
     const expr = this.expressao();
     this.consumir(
       tiposDeSimbolos.PONTO_E_VIRGULA,
@@ -483,7 +483,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Expressao(expr);
   }
 
-  block() {
+  block(): any {
     const declaracoes = [];
 
     while (
@@ -497,7 +497,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return declaracoes;
   }
 
-  declaracaoSe() {
+  declaracaoSe(): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       "Esperado '(' após 'se'."
@@ -538,7 +538,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Se(condicao, thenBranch, elifBranches, elseBranch);
   }
 
-  whileStatement() {
+  whileStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -559,7 +559,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     }
   }
 
-  forStatement() {
+  forStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -605,7 +605,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     }
   }
 
-  breakStatement() {
+  breakStatement(): any {
     if (this.ciclos < 1) {
       this.erro(this.voltar(), "'pausa' deve estar dentro de um loop.");
     }
@@ -617,7 +617,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Pausa();
   }
 
-  declaracaoContinue() {
+  declaracaoContinue(): any {
     if (this.ciclos < 1) {
       this.erro(
         this.voltar(),
@@ -632,7 +632,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Continua();
   }
 
-  declaracaoRetorna() {
+  declaracaoRetorna(): any {
     const palavraChave = this.voltar();
     let valor = null;
 
@@ -647,7 +647,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Retorna(palavraChave, valor);
   }
 
-  declaracaoEscolha() {
+  declaracaoEscolha(): any {
     try {
       this.ciclos += 1;
 
@@ -732,7 +732,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     }
   }
 
-  importStatement() {
+  importStatement(): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       "Esperado '(' após declaração."
@@ -748,7 +748,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Importar(caminho, closeBracket);
   }
 
-  tryStatement() {
+  tryStatement(): any {
     this.consumir(
       tiposDeSimbolos.CHAVE_ESQUERDA,
       "Esperado '{' após a declaração 'tente'."
@@ -789,7 +789,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Tente(tryBlock, catchBlock, elseBlock, finallyBlock);
   }
 
-  doStatement() {
+  doStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -834,7 +834,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return this.expressionStatement();
   }
 
-  declaracaoDeVariavel() {
+  declaracaoDeVariavel(): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       "Esperado nome de variável."
@@ -855,7 +855,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Var(nome, inicializador);
   }
 
-  funcao(kind: any) {
+  funcao(kind: any): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       `Esperado nome ${kind}.`
@@ -863,7 +863,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Funcao(nome, this.corpoDaFuncao(kind));
   }
 
-  corpoDaFuncao(kind: any) {
+  corpoDaFuncao(kind: any): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       `Esperado '(' após o nome ${kind}.`
@@ -914,7 +914,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Funcao(parametros, corpo);
   }
 
-  declaracaoDeClasse() {
+  declaracaoDeClasse(): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       "Esperado nome da classe."
@@ -949,7 +949,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     return new Classe(nome, superClasse, metodos);
   }
 
-  declaracao() {
+  declaracao(): any {
     try {
       if (
         this.verificar(tiposDeSimbolos.FUNCAO) &&
@@ -968,7 +968,7 @@ export class ParserEguaClassico implements AvaliadorSintaticoInterface {
     }
   }
 
-  analisar(simbolos?: SimboloInterface[]) {
+  analisar(simbolos?: SimboloInterface[]): any {
     if (simbolos) {
       this.simbolos = simbolos;
     }

--- a/src/avaliador-sintatico/index.ts
+++ b/src/avaliador-sintatico/index.ts
@@ -82,48 +82,48 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  erro(simbolo: any, mensagemDeErro: any) {
+  erro(simbolo: any, mensagemDeErro: any): any {
     this.Delegua.erro(simbolo, mensagemDeErro);
     return new ErroAvaliador();
   }
 
-  consumir(tipo: any, mensagemDeErro: any) {
+  consumir(tipo: any, mensagemDeErro: any): any {
     if (this.verificar(tipo)) return this.avancar();
     else throw this.erro(this.peek(), mensagemDeErro);
   }
 
-  verificar(tipo: any) {
+  verificar(tipo: any): boolean {
     if (this.estaNoFinal()) return false;
     return this.peek().tipo === tipo;
   }
 
-  verificarProximo(tipo: any) {
+  verificarProximo(tipo: any): boolean {
     if (this.estaNoFinal()) return false;
     return this.simbolos[this.atual + 1].tipo === tipo;
   }
 
-  peek() {
+  peek(): any {
     return this.simbolos[this.atual];
   }
 
-  voltar() {
+  voltar(): any {
     return this.simbolos[this.atual - 1];
   }
 
-  seek(posicao: number) {
+  seek(posicao: number): any {
     return this.simbolos[this.atual + posicao];
   }
 
-  estaNoFinal() {
+  estaNoFinal(): boolean {
     return this.peek().tipo === tiposDeSimbolos.EOF;
   }
 
-  avancar() {
+  avancar(): any {
     if (!this.estaNoFinal()) this.atual += 1;
     return this.voltar();
   }
 
-  match(...argumentos: any[]) {
+  match(...argumentos: any[]): boolean {
     for (let i = 0; i < argumentos.length; i++) {
       const tipoAtual = argumentos[i];
       if (this.verificar(tipoAtual)) {
@@ -135,7 +135,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return false;
   }
 
-  primario() {
+  primario(): any {
     if (this.match(tiposDeSimbolos.SUPER)) {
       const palavraChave = this.voltar();
       this.consumir(tiposDeSimbolos.DOT, "Esperado '.' após 'super'.");
@@ -212,7 +212,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     throw this.erro(this.peek(), "Esperado expressão.");
   }
 
-  finalizarChamada(callee: any) {
+  finalizarChamada(callee: any): any {
     const argumentos = [];
     if (!this.verificar(tiposDeSimbolos.PARENTESE_DIREITO)) {
       do {
@@ -234,7 +234,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Call(callee, parenteseDireito, argumentos);
   }
 
-  chamar() {
+  chamar(): any {
     let expr = this.primario();
 
     while (true) {
@@ -261,7 +261,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  unario() {
+  unario(): any {
     if (
       this.match(
         tiposDeSimbolos.NEGACAO,
@@ -277,7 +277,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return this.chamar();
   }
 
-  exponent() {
+  exponent(): any {
     let expr = this.unario();
 
     while (this.match(tiposDeSimbolos.EXPONENCIACAO)) {
@@ -289,7 +289,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  multiplicar() {
+  multiplicar(): any {
     let expr = this.exponent();
 
     while (
@@ -307,7 +307,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  adicionar() {
+  adicionar(): any {
     let expr = this.multiplicar();
 
     while (this.match(tiposDeSimbolos.SUBTRACAO, tiposDeSimbolos.ADICAO)) {
@@ -319,7 +319,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitFill() {
+  bitFill(): any {
     let expr = this.adicionar();
 
     while (
@@ -333,7 +333,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitE() {
+  bitE(): any {
     let expr = this.bitFill();
 
     while (this.match(tiposDeSimbolos.BIT_AND)) {
@@ -345,7 +345,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  bitOu() {
+  bitOu(): any {
     let expr = this.bitE();
 
     while (this.match(tiposDeSimbolos.BIT_OR, tiposDeSimbolos.BIT_XOR)) {
@@ -357,7 +357,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  comparar() {
+  comparar(): any {
     let expr = this.bitOu();
 
     while (
@@ -376,7 +376,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  equality() {
+  equality(): any {
     let expr = this.comparar();
 
     while (this.match(tiposDeSimbolos.DIFERENTE, tiposDeSimbolos.IGUAL_IGUAL)) {
@@ -388,7 +388,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  em() {
+  em(): any {
     let expr = this.equality();
 
     while (this.match(tiposDeSimbolos.EM)) {
@@ -400,7 +400,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  e() {
+  e(): any {
     let expr = this.em();
 
     while (this.match(tiposDeSimbolos.E)) {
@@ -412,7 +412,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  ou() {
+  ou(): any {
     let expr = this.e();
 
     while (this.match(tiposDeSimbolos.OU)) {
@@ -424,7 +424,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  atribuir() {
+  atribuir(): any {
     const expr = this.ou();
 
     if (
@@ -449,7 +449,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return expr;
   }
 
-  expressao() {
+  expressao(): any {
     return this.atribuir();
   }
 
@@ -474,7 +474,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Escreva(valor);
   }
 
-  expressionStatement() {
+  expressionStatement(): any {
     const expr = this.expressao();
     this.consumir(
       tiposDeSimbolos.PONTO_E_VIRGULA,
@@ -483,7 +483,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Expressao(expr);
   }
 
-  block() {
+  block(): any {
     const declaracoes = [];
 
     while (
@@ -497,7 +497,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return declaracoes;
   }
 
-  declaracaoSe() {
+  declaracaoSe(): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       "Esperado '(' após 'se'."
@@ -538,7 +538,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Se(condicao, thenBranch, elifBranches, elseBranch);
   }
 
-  whileStatement() {
+  whileStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -559,7 +559,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  forStatement() {
+  forStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -605,7 +605,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  breakStatement() {
+  breakStatement(): any {
     if (this.ciclos < 1) {
       this.erro(this.voltar(), "'pausa' deve estar dentro de um loop.");
     }
@@ -617,7 +617,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Pausa();
   }
 
-  declaracaoContinue() {
+  declaracaoContinue(): any {
     if (this.ciclos < 1) {
       this.erro(
         this.voltar(),
@@ -632,7 +632,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Continua();
   }
 
-  declaracaoRetorna() {
+  declaracaoRetorna(): any {
     const palavraChave = this.voltar();
     let valor = null;
 
@@ -647,7 +647,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Retorna(palavraChave, valor);
   }
 
-  declaracaoEscolha() {
+  declaracaoEscolha(): any {
     try {
       this.ciclos += 1;
 
@@ -732,7 +732,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  importStatement() {
+  importStatement(): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       "Esperado '(' após declaração."
@@ -748,7 +748,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Importar(caminho, closeBracket);
   }
 
-  tryStatement() {
+  tryStatement(): any {
     this.consumir(
       tiposDeSimbolos.CHAVE_ESQUERDA,
       "Esperado '{' após a declaração 'tente'."
@@ -789,7 +789,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Tente(tryBlock, catchBlock, elseBlock, finallyBlock);
   }
 
-  doStatement() {
+  doStatement(): any {
     try {
       this.ciclos += 1;
 
@@ -817,7 +817,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  statement() {
+  statement(): any {
     if (this.match(tiposDeSimbolos.FAZER)) return this.doStatement();
     if (this.match(tiposDeSimbolos.TENTE)) return this.tryStatement();
     if (this.match(tiposDeSimbolos.ESCOLHA)) return this.declaracaoEscolha();
@@ -834,7 +834,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return this.expressionStatement();
   }
 
-  declaracaoDeVariavel() {
+  declaracaoDeVariavel(): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       "Esperado nome de variável."
@@ -855,7 +855,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Var(nome, inicializador);
   }
 
-  funcao(kind: any) {
+  funcao(kind: any): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       `Esperado nome ${kind}.`
@@ -863,7 +863,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Funcao(nome, this.corpoDaFuncao(kind));
   }
 
-  corpoDaFuncao(kind: any) {
+  corpoDaFuncao(kind: any): any {
     this.consumir(
       tiposDeSimbolos.PARENTESE_ESQUERDO,
       `Esperado '(' após o nome ${kind}.`
@@ -914,7 +914,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Funcao(parametros, corpo);
   }
 
-  declaracaoDeClasse() {
+  declaracaoDeClasse(): any {
     const nome = this.consumir(
       tiposDeSimbolos.IDENTIFICADOR,
       "Esperado nome da classe."
@@ -949,7 +949,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     return new Classe(nome, superClasse, metodos);
   }
 
-  declaracao() {
+  declaracao(): any {
     try {
       if (
         this.verificar(tiposDeSimbolos.FUNCAO) &&
@@ -968,7 +968,7 @@ export class Parser implements AvaliadorSintaticoInterface {
     }
   }
 
-  analisar(simbolos?: SimboloInterface[]) {
+  analisar(simbolos?: SimboloInterface[]): any {
     if (simbolos) {
       this.simbolos = simbolos;
     }

--- a/src/declaracoes/index.ts
+++ b/src/declaracoes/index.ts
@@ -1,5 +1,5 @@
 export class Stmt {
-    aceitar(visitor) { }
+    aceitar(visitor: any): any { }
 }
 
 export class Expressao extends Stmt {
@@ -10,7 +10,7 @@ export class Expressao extends Stmt {
         this.expressao = expressao;
     }
 
-    aceitar(visitor: any) {
+    aceitar(visitor: any): any {
         return visitor.visitExpressionStmt(this)
     }
 }
@@ -25,7 +25,7 @@ export class Funcao extends Stmt {
         this.funcao = funcao;
     }
 
-    aceitar(visitor: any) {
+    aceitar(visitor: any): any {
         return visitor.visitFunctionStmt(this);
     }
 }
@@ -34,13 +34,13 @@ export class Retorna extends Stmt {
     palavraChave: string;
     valor: any;
 
-    constructor(palavraChave, valor) {
+    constructor(palavraChave: any, valor: any) {
         super();
         this.palavraChave = palavraChave;
         this.valor = valor;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitReturnStmt(this);
     }
 }
@@ -57,7 +57,7 @@ export class Classe extends Stmt {
         this.metodos = metodos;
     }
 
-    aceitar(visitor: any) {
+    aceitar(visitor: any): any {
         return visitor.visitClassStmt(this);
     }
 }
@@ -65,12 +65,12 @@ export class Classe extends Stmt {
 export class Block extends Stmt {
     declaracoes: any;
 
-    constructor(declaracoes) {
+    constructor(declaracoes: any) {
         super();
         this.declaracoes = declaracoes;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitBlockStmt(this);
     }
 }
@@ -78,12 +78,12 @@ export class Block extends Stmt {
 export class Escreva extends Stmt {
     expressao: any;
 
-    constructor(expressao) {
+    constructor(expressao: any) {
         super();
         this.expressao = expressao;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitPrintStmt(this);
     }
 }
@@ -92,13 +92,13 @@ export class Importar extends Stmt {
     caminho: string;
     closeBracket: any;
 
-    constructor(caminho, closeBracket) {
+    constructor(caminho: any, closeBracket: any) {
         super();
         this.caminho = caminho;
         this.closeBracket = closeBracket;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitImportStmt(this);
     }
 }
@@ -107,13 +107,13 @@ export class Fazer extends Stmt {
     doBranch: any;
     whileCondition: any;
 
-    constructor(doBranch, whileCondition) {
+    constructor(doBranch: any, whileCondition: any) {
         super();
         this.doBranch = doBranch;
         this.whileCondition = whileCondition;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitDoStmt(this);
     }
 }
@@ -122,13 +122,13 @@ export class Enquanto extends Stmt {
     condicao: any;
     corpo: any;
 
-    constructor(condicao, corpo) {
+    constructor(condicao: any, corpo: any) {
         super();
         this.condicao = condicao;
         this.corpo = corpo;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitWhileStmt(this);
     }
 }
@@ -139,7 +139,7 @@ export class Para extends Stmt {
     incrementar: any;
     corpo: any;
 
-    constructor(inicializador, condicao, incrementar, corpo) {
+    constructor(inicializador: any, condicao: any, incrementar: any, corpo: any) {
         super();
         this.inicializador = inicializador;
         this.condicao = condicao;
@@ -147,7 +147,7 @@ export class Para extends Stmt {
         this.corpo = corpo;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitForStmt(this);
     }
 }
@@ -166,7 +166,7 @@ export class Tente extends Stmt {
         this.finallyBranch = finallyBranch;
     }
 
-    aceitar(visitor: any) {
+    aceitar(visitor: any): any {
         return visitor.visitTryStmt(this);
     }
 }
@@ -177,7 +177,7 @@ export class Se extends Stmt {
     elifBranches: any;
     elseBranch: any;
 
-    constructor(condicao, thenBranch, elifBranches, elseBranch) {
+    constructor(condicao: any, thenBranch: any, elifBranches: any, elseBranch: any) {
         super();
         this.condicao = condicao;
         this.thenBranch = thenBranch;
@@ -185,7 +185,7 @@ export class Se extends Stmt {
         this.elseBranch = elseBranch;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitIfStmt(this);
     }
 }
@@ -195,14 +195,14 @@ export class Escolha extends Stmt {
     branches: any;
     defaultBranch: any;
 
-    constructor(condicao, branches, defaultBranch) {
+    constructor(condicao: any, branches: any, defaultBranch: any) {
         super();
         this.condicao = condicao;
         this.branches = branches;
         this.defaultBranch = defaultBranch;
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitSwitchStmt(this);
     }
 }
@@ -212,7 +212,7 @@ export class Pausa extends Stmt {
         super();
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitBreakStmt(this);
     }
 }
@@ -222,7 +222,7 @@ export class Continua extends Stmt {
         super();
     }
 
-    aceitar(visitor) {
+    aceitar(visitor: any): any {
         return visitor.visitContinueStmt(this);
     }
 }
@@ -237,7 +237,7 @@ export class Var extends Stmt {
         this.inicializador = inicializador;
     }
 
-    aceitar(visitor: any) {
+    aceitar(visitor: any): any {
         return visitor.visitVarStmt(this);
     }
 }

--- a/src/estruturas/callable.ts
+++ b/src/estruturas/callable.ts
@@ -1,11 +1,11 @@
 export class Callable {
     valorAridade: any;
 
-    aridade() {
+    aridade(): any {
         return this.valorAridade;
     }
 
-    chamar(interpretador?: any, argumentos?: any, simbolo?: any) {
+    chamar(interpretador?: any, argumentos?: any, simbolo?: any): any {
         throw new Error("Este método não deveria ser chamado.");
     }
 }

--- a/src/estruturas/classe.ts
+++ b/src/estruturas/classe.ts
@@ -13,7 +13,7 @@ export class DeleguaClasse extends Callable {
         this.metodos = metodos;
     }
 
-    encontrarMetodo(nome: any) {
+    encontrarMetodo(nome: any): any {
         if (this.metodos.hasOwnProperty(nome)) {
             return this.metodos[nome];
         }
@@ -25,16 +25,16 @@ export class DeleguaClasse extends Callable {
         return undefined;
     }
 
-    toString() {
+    toString(): string {
         return `<classe ${this.nome}>`;
     }
 
-    aridade() {
+    aridade(): any {
         let inicializador = this.encontrarMetodo("construtor");
         return inicializador ? inicializador.aridade() : 0;
     }
 
-    chamar(interpretador: any, argumentos: any) {
+    chamar(interpretador: any, argumentos: any): any {
         let instancia = new DeleguaInstancia(this);
 
         let inicializador = this.encontrarMetodo("construtor");

--- a/src/estruturas/funcao-padrao.ts
+++ b/src/estruturas/funcao-padrao.ts
@@ -11,12 +11,12 @@ export class FuncaoPadrao extends Callable {
         this.funcao = funcao;
     }
 
-    chamar(interpretador: any, argumentos: any, simbolo: any) {
+    chamar(interpretador: any, argumentos: any, simbolo: any): any {
         this.simbolo = simbolo;
         return this.funcao.apply(this, argumentos);
     }
 
-    toString() {
+    toString(): string {
         return "<função>";
     }
 }

--- a/src/estruturas/funcao.ts
+++ b/src/estruturas/funcao.ts
@@ -16,16 +16,16 @@ export class DeleguaFuncao extends Callable {
         this.eInicializador = eInicializador;
     }
 
-    aridade() {
+    aridade(): any {
         return this.declaracao?.parametros?.length || 0;
     }
 
-    toString() {
+    toString(): string {
         if (this.nome === null) return "<função>";
         return `<função ${this.nome}>`;
     }
 
-    chamar(interpretador: any, argumentos: any) {
+    chamar(interpretador: any, argumentos: any): any {
         let ambiente = new Ambiente(this.closure);
         let parametros = this.declaracao.parametros;
 
@@ -57,7 +57,7 @@ export class DeleguaFuncao extends Callable {
         return null;
     }
 
-    bind(instancia: any) {
+    bind(instancia: any): any {
         let ambiente = new Ambiente(this.closure);
         ambiente.definirVariavel("isto", instancia);
         return new DeleguaFuncao(

--- a/src/estruturas/instancia.ts
+++ b/src/estruturas/instancia.ts
@@ -9,7 +9,7 @@ export class DeleguaInstancia {
         this.campos = {};
     }
 
-    get(nome: any) {
+    get(nome: any): any {
         if (this.campos.hasOwnProperty(nome.lexema)) {
             return this.campos[nome.lexema];
         }
@@ -20,11 +20,11 @@ export class DeleguaInstancia {
         throw new ErroEmTempoDeExecucao(nome, "Método indefinido não recuperado.");
     }
 
-    set(nome: any, valor: any) {
+    set(nome: any, valor: any): void {
         this.campos[nome.lexema] = valor;
     }
 
-    toString() {
+    toString(): string {
         return "<Objeto " + this.criarClasse.nome + ">";
     }
 }

--- a/src/estruturas/modulo.ts
+++ b/src/estruturas/modulo.ts
@@ -5,7 +5,7 @@ export class DeleguaModulo {
         if (nome) this.nome = nome;
     }
 
-    toString() {
+    toString(): string {
         return this.nome ? `<modulo ${this.nome}>` : "<modulo>";
     }
 }

--- a/src/interfaces/avaliador-sintatico-interface.ts
+++ b/src/interfaces/avaliador-sintatico-interface.ts
@@ -54,5 +54,5 @@ export interface AvaliadorSintaticoInterface {
     corpoDaFuncao(kind: any): any;
     declaracaoDeClasse(): any;
     declaracao(): any;
-    analisar(): any;
+    analisar(simbolos?: SimboloInterface[]): any
 }

--- a/src/interfaces/lexador-interface.ts
+++ b/src/interfaces/lexador-interface.ts
@@ -20,5 +20,5 @@ export interface LexadorInterface {
     analisarNumero(): void;
     identificarPalavraChave(): void;
     scanToken(): void;
-    scan(): any;
+    scan(codigo?: any): any;
 }

--- a/src/interpretador/dialetos/egua-classico.ts
+++ b/src/interpretador/dialetos/egua-classico.ts
@@ -144,9 +144,12 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
           typeof direita === "string"
         ) {
           return String(esquerda) + String(direita);
-        } else {
-          return String(esquerda) + String(direita);
         }
+
+        throw new ErroEmTempoDeExecucao(
+          expr.operador,
+          "Operadores precisam ser dois números ou duas strings."
+        );
 
       case tiposDeSimbolos.DIVISAO:
         this.checkNumberOperands(expr.operador, esquerda, direita);
@@ -807,14 +810,6 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
 
   interpretar(declaracoes: any) {
     try {
-      if (declaracoes.length === 1) {
-        const eObjetoExpressao =
-          declaracoes[0].constructor.name === "Expressao";
-        if (eObjetoExpressao) {
-          this.executar(declaracoes[0], eObjetoExpressao);
-          return;
-        }
-      }
       for (let i = 0; i < declaracoes.length; i++) {
         this.executar(declaracoes[i]);
       }


### PR DESCRIPTION
Essa PR volta ao original implementação da linguagem égua, que não permite:

- Concatenar número e texto.
- Operações diretamente no console.
- Adiciona mais tipagem do tipo any com base nas interfaces.