### PR TITLE
Interface expr

### DIFF
--- a/src/construtos/atribuicao-sobrescrita.ts
+++ b/src/construtos/atribuicao-sobrescrita.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class AtribuicaoSobrescrita extends Expr {
+export class AtribuicaoSobrescrita implements Expr {
     objeto: any;
     valor: any;
     indice: any;
 
     constructor(objeto: any, indice: any, valor: any) {
-        super();
         this.objeto = objeto;
         this.indice = indice;
         this.valor = valor;

--- a/src/construtos/atribuir.ts
+++ b/src/construtos/atribuir.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Atribuir extends Expr {
+export class Atribuir implements Expr {
     nome: any;
     valor: any;
 
     constructor(nome: any, valor: any) {
-        super();
         this.nome = nome;
         this.valor = valor;
     }

--- a/src/construtos/binario.ts
+++ b/src/construtos/binario.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class Binario extends Expr {
+export class Binario implements Expr {
     esquerda: any;
     operador: any;
     direita: any;
 
     constructor(esquerda: any, operador: any, direita: any) {
-        super();
         this.esquerda = esquerda;
         this.operador = operador;
         this.direita = direita;

--- a/src/construtos/call.ts
+++ b/src/construtos/call.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class Call extends Expr {
+export class Call implements Expr {
     callee: any;
     argumentos: any;
     parentese: any;
 
     constructor(callee: any, parentese: any, argumentos: any) {
-        super();
         this.callee = callee;
         this.parentese = parentese;
         this.argumentos = argumentos;

--- a/src/construtos/conjunto.ts
+++ b/src/construtos/conjunto.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class Conjunto extends Expr {
+export class Conjunto implements Expr {
     objeto: any;
     nome: any;
     valor: any;
 
     constructor(objeto: any, nome: any, valor: any) {
-        super();
         this.objeto = objeto;
         this.nome = nome;
         this.valor = valor;

--- a/src/construtos/dicionario.ts
+++ b/src/construtos/dicionario.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Dicionario extends Expr {
+export class Dicionario implements Expr {
     chaves: any;
     valores: any;
 
     constructor(chaves: any, valores: any) {
-        super();
         this.chaves = chaves;
         this.valores = valores;
     }

--- a/src/construtos/expr.ts
+++ b/src/construtos/expr.ts
@@ -1,3 +1,3 @@
-export class Expr {
-    aceitar(visitante: any) { }
+export interface Expr {
+    aceitar(visitante: any): any;
 }

--- a/src/construtos/funcao.ts
+++ b/src/construtos/funcao.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Funcao extends Expr {
+export class Funcao implements Expr {
     parametros: any;
     corpo: any;
 
     constructor(parametros: any, corpo: any) {
-        super();
         this.parametros = parametros;
         this.corpo = corpo;
     }

--- a/src/construtos/get.ts
+++ b/src/construtos/get.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Get extends Expr {
+export class Get implements Expr {
     objeto: any;
     nome: any;
 
     constructor(objeto: any, nome: any) {
-        super();
         this.objeto = objeto;
         this.nome = nome;
     }

--- a/src/construtos/grouping.ts
+++ b/src/construtos/grouping.ts
@@ -1,11 +1,10 @@
 import { Expr } from "./expr";
 
 
-export class Grouping extends Expr {
+export class Grouping implements Expr {
     expressao: any;
 
     constructor(expressao: any) {
-        super();
         this.expressao = expressao;
     }
 

--- a/src/construtos/isto.ts
+++ b/src/construtos/isto.ts
@@ -1,11 +1,10 @@
 import { Expr } from "./expr";
 
 
-export class Isto extends Expr {
+export class Isto implements Expr {
     palavraChave: any;
 
     constructor(palavraChave?: any) {
-        super();
         this.palavraChave = palavraChave;
     }
 

--- a/src/construtos/literal.ts
+++ b/src/construtos/literal.ts
@@ -1,11 +1,10 @@
 import { Expr } from "./expr";
 
 
-export class Literal extends Expr {
+export class Literal implements Expr {
     valor: any;
 
     constructor(valor: any) {
-        super();
         this.valor = valor;
     }
 

--- a/src/construtos/logical.ts
+++ b/src/construtos/logical.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class Logical extends Expr {
+export class Logical implements Expr {
     esquerda: any;
     operador: any;
     direita: any;
 
     constructor(esquerda: any, operador: any, direita: any) {
-        super();
         this.esquerda = esquerda;
         this.operador = operador;
         this.direita = direita;

--- a/src/construtos/subscript.ts
+++ b/src/construtos/subscript.ts
@@ -1,13 +1,12 @@
 import { Expr } from "./expr";
 
 
-export class Subscript extends Expr {
+export class Subscript implements Expr {
     callee: any;
     closeBracket: any;
     indice: any;
 
     constructor(callee: any, indice: any, closeBracket: any) {
-        super();
         this.callee = callee;
         this.indice = indice;
         this.closeBracket = closeBracket;

--- a/src/construtos/super.ts
+++ b/src/construtos/super.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Super extends Expr {
+export class Super implements Expr {
     palavraChave: any;
     metodo: any;
 
     constructor(palavraChave: any, metodo: any) {
-        super();
         this.palavraChave = palavraChave;
         this.metodo = metodo;
     }

--- a/src/construtos/unario.ts
+++ b/src/construtos/unario.ts
@@ -1,12 +1,11 @@
 import { Expr } from "./expr";
 
 
-export class Unario extends Expr {
+export class Unario implements Expr {
     operador: any;
     direita: any;
 
     constructor(operador: any, direita: any) {
-        super();
         this.operador = operador;
         this.direita = direita;
     }

--- a/src/construtos/variavel.ts
+++ b/src/construtos/variavel.ts
@@ -1,11 +1,10 @@
 import { Expr } from "./expr";
 
 
-export class Variavel extends Expr {
+export class Variavel implements Expr {
     nome: any;
 
     constructor(nome: any) {
-        super();
         this.nome = nome;
     }
 

--- a/src/construtos/vetor.ts
+++ b/src/construtos/vetor.ts
@@ -1,11 +1,10 @@
 import { Expr } from "./expr";
 
 
-export class Vetor extends Expr {
+export class Vetor implements Expr {
     valores: any;
 
     constructor(valores: any) {
-        super();
         this.valores = valores;
     }
 

--- a/src/interpretador/dialetos/egua-classico.ts
+++ b/src/interpretador/dialetos/egua-classico.ts
@@ -473,7 +473,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
       );
     }
 
-    dados = fs.readFileSync(caminhoTotal).paraTexto();
+    dados = fs.readFileSync(caminhoTotal).toString();
 
     const delegua = new Delegua(this.Delegua.dialeto, nomeArquivo);
 
@@ -779,7 +779,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
     return metodo.definirEscopo(objeto);
   }
 
-  paraTexto(objeto: any) {
+  paraTexto(objeto: any): any {
     if (objeto === null) return "nulo";
     if (typeof objeto === "boolean") {
       return objeto ? "verdadeiro" : "falso";

--- a/src/interpretador/index.ts
+++ b/src/interpretador/index.ts
@@ -468,7 +468,7 @@ export class Interpretador implements InterpretadorInterface {
       );
     }
 
-    dados = fs.readFileSync(caminhoTotal).paraTexto();
+    dados = fs.readFileSync(caminhoTotal).toString();
 
     const delegua = new Delegua(this.Delegua.dialeto, nomeArquivo);
     // const interpretador = new Interpretador(delegua, pastaTotal);

--- a/src/lexador/dialetos/egua-classico.ts
+++ b/src/lexador/dialetos/egua-classico.ts
@@ -46,7 +46,7 @@ class Simbolo implements SimboloInterface {
         this.linha = linha;
     }
 
-    paraTexto() {
+    paraTexto(): string {
         return this.tipo + " " + this.lexema + " " + this.literal;
     }
 }

--- a/src/lexador/index.ts
+++ b/src/lexador/index.ts
@@ -39,14 +39,14 @@ class Simbolo implements SimboloInterface {
     literal: string;
     linha: string;
 
-    constructor(tipo, lexema, literal, linha) {
+    constructor(tipo: string, lexema: string, literal: string, linha: string) {
         this.tipo = tipo;
         this.lexema = lexema;
         this.literal = literal;
         this.linha = linha;
     }
 
-    paraTexto() {
+    paraTexto(): string {
         return this.tipo + " " + this.lexema + " " + this.literal;
     }
 }


### PR DESCRIPTION
Expr foi implementada como classe inicialmente porque JavaScript não tem suporte a interfaces. Isso não precisa continuar assim.