### PR TITLE
Desacoplar resolvedor do interpretador

### DIFF
--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -52,14 +52,14 @@ export class Delegua {
                 );
                 this.lexador = new LexadorEguaClassico();
                 this.avaliadorSintatico = new AvaliadorSintaticoEguaClassico();
-                this.resolvedor = new ResolvedorEguaClassico(this.interpretador);
+                this.resolvedor = new ResolvedorEguaClassico();
                 console.log('Usando dialeto: Égua');
                 break;
             case 'eguap':
                 this.interpretador = new Interpretador(this, process.cwd());
                 this.lexador = new Lexador();
                 this.avaliadorSintatico = new AvaliadorSintatico(performance);
-                this.resolvedor = new Resolvedor(this.interpretador);
+                this.resolvedor = new Resolvedor();
                 console.log('Usando dialeto: ÉguaP');
                 break;
             default:
@@ -70,7 +70,7 @@ export class Delegua {
                 );
                 this.lexador = new Lexador(performance);
                 this.avaliadorSintatico = new AvaliadorSintatico(performance);
-                this.resolvedor = new Resolvedor(this.interpretador);
+                this.resolvedor = new Resolvedor();
                 console.log('Usando dialeto: padrão');
                 break;
         }
@@ -150,7 +150,7 @@ export class Delegua {
             return;
         }
 
-        this.interpretador.interpretar(retornoAvaliadorSintatico);
+        this.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
     }
 
     reportar(linha: number, onde: any, mensagem: string) {

--- a/fontes/interfaces/interpretador-interface.ts
+++ b/fontes/interfaces/interpretador-interface.ts
@@ -1,14 +1,12 @@
 import { Ambiente } from "../ambiente";
-import { Delegua } from "../delegua";
+import { Construto } from "../construtos";
 
 export interface InterpretadorInterface {
-    Delegua: Delegua;
     diretorioBase: any;
     global: Ambiente;
     ambiente: Ambiente;
-    locais: any;
+    locais: Map<Construto, number>;
 
-    resolver(expressao: any, profundidade: number): void;
     visitarExpressaoLiteral(expressao: any): any;
     avaliar(expressao: any): any;
     visitarExpressaoAgrupamento(expressao: any): any;
@@ -51,5 +49,5 @@ export interface InterpretadorInterface {
     visitarExpressaoSuper(expressao: any): any;
     paraTexto(objeto: any): any;
     executar(declaracao: any, mostrarResultado: boolean): void;
-    interpretar(declaracoes: any): void;
+    interpretar(declaracoes: any, locais: Map<Construto, number>): void;
 }

--- a/fontes/interfaces/pilha-interface.ts
+++ b/fontes/interfaces/pilha-interface.ts
@@ -1,7 +1,7 @@
-export interface PilhaInterface {
-    pilha: Array<any>;
-    empilhar(item: any);
-    eVazio(item: any): Boolean;
-    topoDaPilha(): Array<any>;
-    removerUltimo(): Array<any>;
+export interface PilhaInterface<T> {
+    pilha: Array<T>;
+    empilhar(item: T);
+    eVazio(item: T): Boolean;
+    topoDaPilha(): Array<T>;
+    removerUltimo(): Array<T>;
 }

--- a/fontes/interfaces/resolvedor-interface.ts
+++ b/fontes/interfaces/resolvedor-interface.ts
@@ -1,13 +1,13 @@
+import { Construto } from "../construtos";
 import { ErroResolvedor } from "../resolvedor/erro-resolvedor";
 import { PilhaEscopos } from "../resolvedor/pilha-escopos";
 import { RetornoResolvedor } from "../resolvedor/retorno-resolvedor";
-import { InterpretadorInterface } from "./interpretador-interface";
 import { SimboloInterface } from "./simbolo-interface";
 
 export interface ResolvedorInterface {
-    interpretador: InterpretadorInterface;
     erros: ErroResolvedor[];
     escopos: PilhaEscopos;
+    locais: Map<Construto, number>;
     funcaoAtual: any;
     classeAtual: any;
     cicloAtual: any;

--- a/fontes/interpretador/dialetos/egua-classico.ts
+++ b/fontes/interpretador/dialetos/egua-classico.ts
@@ -1,9 +1,10 @@
+import * as caminho from 'path';
+import * as fs from 'fs';
+
 import tiposDeSimbolos from '../../tiposDeSimbolos';
 import { Ambiente } from '../../ambiente';
 import { Delegua } from '../../delegua';
 import carregarBibliotecaGlobal from '../../bibliotecas/biblioteca-global';
-import * as caminho from 'path';
-import * as fs from 'fs';
 import carregarModulo from '../../bibliotecas/importar-biblioteca';
 
 import { Chamavel } from '../../estruturas/chamavel';
@@ -21,7 +22,7 @@ import {
 } from '../../excecoes';
 import { InterpretadorInterface, SimboloInterface } from '../../interfaces';
 import { Classe, Enquanto, Escolha, Escreva, Fazer, Funcao, Importar, Para, Se, Tente } from '../../declaracoes';
-import { Super } from '../../construtos';
+import { Construto, Super } from '../../construtos';
 
 /**
  * O Interpretador visita todos os elementos complexos gerados pelo analisador sintático (Parser)
@@ -43,10 +44,6 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
         this.locais = new Map();
 
         this.global = carregarBibliotecaGlobal(this, this.global);
-    }
-
-    resolver(expressao: any, profundidade: number) {
-        this.locais.set(expressao, profundidade);
     }
 
     visitarExpressaoLiteral(expressao: any) {
@@ -907,7 +904,8 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
         declaracao.aceitar(this);
     }
 
-    interpretar(declaracoes: any): void {
+    interpretar(declaracoes: any, locais: Map<Construto, number>): void {
+        this.locais = locais;
         try {
             for (let i = 0; i < declaracoes.length; i++) {
                 this.executar(declaracoes[i], false);

--- a/fontes/interpretador/index.ts
+++ b/fontes/interpretador/index.ts
@@ -25,7 +25,7 @@ import {
     DeleguaModulo,
     FuncaoPadrao,
 } from '../estruturas';
-import { Super } from '../construtos';
+import { Construto, Super } from '../construtos';
 
 /**
  * O Interpretador visita todos os elementos complexos gerados pelo analisador sintático (Parser),
@@ -36,7 +36,7 @@ export class Interpretador implements InterpretadorInterface {
     diretorioBase: any;
     global: Ambiente;
     ambiente: Ambiente;
-    locais: any;
+    locais: Map<Construto, number>;
     performance: boolean;
 
     constructor(
@@ -923,7 +923,8 @@ export class Interpretador implements InterpretadorInterface {
         }
     }
 
-    interpretar(objeto: any): void {
+    interpretar(objeto: any, locais: Map<Construto, number>): void {
+        this.locais = locais;
         const inicioInterpretacao: number = performance.now();
         try {
             const declaracoes = objeto.declaracoes || objeto;

--- a/fontes/resolvedor/dialetos/egua-classico.ts
+++ b/fontes/resolvedor/dialetos/egua-classico.ts
@@ -1,7 +1,7 @@
 import { ResolvedorInterface } from '../../interfaces/resolvedor-interface';
 import { PilhaEscopos } from '../pilha-escopos';
 import { ErroResolvedor } from '../erro-resolvedor';
-import { InterpretadorInterface, SimboloInterface } from '../../interfaces';
+import { SimboloInterface } from '../../interfaces';
 import { Bloco, Declaracao, Expressao, Se } from '../../declaracoes';
 import { AcessoMetodo, Construto, Super, Variavel } from '../../construtos';
 import { RetornoResolvedor } from '../retorno-resolvedor';
@@ -34,17 +34,17 @@ const LoopType = {
  * No entanto, todas as variáveis declaradas dentro da classe A podem ser vistas tanto por M quanto por N.
  */
 export class ResolvedorEguaClassico implements ResolvedorInterface {
-    interpretador: InterpretadorInterface;
     erros: ErroResolvedor[];
     escopos: PilhaEscopos;
+    locais: Map<Construto, number>;
     funcaoAtual: any;
     classeAtual: any;
     cicloAtual: any;
 
-    constructor(interpretador: InterpretadorInterface) {
-        this.interpretador = interpretador;
+    constructor() {
         this.erros = [];
         this.escopos = new PilhaEscopos();
+        this.locais = new Map();
 
         this.funcaoAtual = TipoFuncao.NENHUM;
         this.classeAtual = TipoClasse.NENHUM;
@@ -81,10 +81,7 @@ export class ResolvedorEguaClassico implements ResolvedorInterface {
     resolverLocal(expressao: Construto, simbolo: SimboloInterface): void {
         for (let i = this.escopos.pilha.length - 1; i >= 0; i--) {
             if (this.escopos.pilha[i].hasOwnProperty(simbolo.lexema)) {
-                this.interpretador.resolver(
-                    expressao,
-                    this.escopos.pilha.length - 1 - i
-                );
+                this.locais.set(expressao, this.escopos.pilha.length - 1 - i);
             }
         }
     }
@@ -445,7 +442,8 @@ export class ResolvedorEguaClassico implements ResolvedorInterface {
         }
 
         return {
-            erros: this.erros
+            erros: this.erros,
+            locais: this.locais
         } as RetornoResolvedor;
     }
 }

--- a/fontes/resolvedor/index.ts
+++ b/fontes/resolvedor/index.ts
@@ -16,7 +16,7 @@ import {
     Variavel,
     Vetor,
 } from '../construtos';
-import { InterpretadorInterface, SimboloInterface } from '../interfaces';
+import { SimboloInterface } from '../interfaces';
 import {
     Bloco,
     Classe,
@@ -62,17 +62,17 @@ const LoopType = {
  * No entanto, todas as variáveis declaradas dentro da classe A podem ser vistas tanto por M quanto por N.
  */
 export class Resolvedor implements ResolvedorInterface {
-    interpretador: InterpretadorInterface;
     erros: ErroResolvedor[];
     escopos: PilhaEscopos;
+    locais: Map<Construto, number>;
     funcaoAtual: any;
     classeAtual: any;
     cicloAtual: any;
 
-    constructor(interpretador: InterpretadorInterface) {
-        this.interpretador = interpretador;
+    constructor() {
         this.erros = [];
         this.escopos = new PilhaEscopos();
+        this.locais = new Map();
 
         this.funcaoAtual = TipoFuncao.NENHUM;
         this.classeAtual = TipoClasse.NENHUM;
@@ -109,10 +109,7 @@ export class Resolvedor implements ResolvedorInterface {
     resolverLocal(expressao: Construto, simbolo: SimboloInterface): void {
         for (let i = this.escopos.pilha.length - 1; i >= 0; i--) {
             if (this.escopos.pilha[i].hasOwnProperty(simbolo.lexema)) {
-                this.interpretador.resolver(
-                    expressao,
-                    this.escopos.pilha.length - 1 - i
-                );
+                this.locais.set(expressao, this.escopos.pilha.length - 1 - i);
             }
         }
     }
@@ -475,7 +472,8 @@ export class Resolvedor implements ResolvedorInterface {
         }
 
         return {
-            erros: this.erros
+            erros: this.erros,
+            locais: this.locais
         } as RetornoResolvedor;
     }
 }

--- a/fontes/resolvedor/pilha-escopos.ts
+++ b/fontes/resolvedor/pilha-escopos.ts
@@ -1,6 +1,6 @@
 import { PilhaInterface } from "../interfaces";
 
-export class PilhaEscopos implements PilhaInterface {
+export class PilhaEscopos implements PilhaInterface<any> {
     pilha: any[];
 
     constructor() {

--- a/fontes/resolvedor/retorno-resolvedor.ts
+++ b/fontes/resolvedor/retorno-resolvedor.ts
@@ -1,5 +1,7 @@
+import { Construto } from "../construtos";
 import { ErroResolvedor } from "./erro-resolvedor";
 
 export interface RetornoResolvedor {
     erros: ErroResolvedor[];
+    locais: Map<Construto, number>;
 }

--- a/testes/biblioteca-global.test.ts
+++ b/testes/biblioteca-global.test.ts
@@ -11,8 +11,8 @@ describe('Biblioteca Global', () => {
         it('Trivial', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(aleatorio())"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -22,8 +22,8 @@ describe('Biblioteca Global', () => {
         it('Sucesso', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(aleatorioEntre(1, 5))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -33,8 +33,8 @@ describe('Biblioteca Global', () => {
         it('Sucesso', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(inteiro(1))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -42,8 +42,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Não inteiro', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(inteiro('Oi'))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -51,8 +51,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Nulo', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(inteiro(nulo))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -66,8 +66,8 @@ describe('Biblioteca Global', () => {
             ];
             const retornoLexador = delegua.lexador.mapear(codigo);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -80,8 +80,8 @@ describe('Biblioteca Global', () => {
             ];
             const retornoLexador = delegua.lexador.mapear(codigo);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -91,8 +91,8 @@ describe('Biblioteca Global', () => {
         it('Sucesso', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(real(3.14))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -100,8 +100,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Não inteiro', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(real('Oi'))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -109,8 +109,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Nulo', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(real(nulo))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -120,8 +120,8 @@ describe('Biblioteca Global', () => {
         it('Sucesso', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(tamanho([1, 2, 3]))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });
@@ -129,8 +129,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Não lista', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(tamanho(1))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -138,8 +138,8 @@ describe('Biblioteca Global', () => {
         it('Falha - Nulo', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(tamanho(nulo))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
         });
@@ -149,8 +149,8 @@ describe('Biblioteca Global', () => {
         it('Trivial', () => {
             const retornoLexador = delegua.lexador.mapear(["escreva(texto(123))"]);
             const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-            delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+            delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
             expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
         });

--- a/testes/egua-classico/interpretador.test.ts
+++ b/testes/egua-classico/interpretador.test.ts
@@ -13,8 +13,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Trivial', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = 1;"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -22,8 +22,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Vetor', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = [1, 2, 3];"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -31,8 +31,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Dicionário', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = {'a': 1, 'b': 2};"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -42,8 +42,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Acesso a elementos de vetor', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = [1, 2, 3];\nescreva(a[1]);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -51,8 +51,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Acesso a elementos de dicionário', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = {'a': 1, 'b': 2};\nescreva(a['b']);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -62,8 +62,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Olá Mundo (escreva() e literal)', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva('Olá mundo');"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -71,8 +71,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('nulo', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(nulo);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -82,8 +82,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Operações matemáticas - Trivial', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(5 + 4 * 3 - 2 ** 1 / 6 % 10);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -93,8 +93,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Operações lógicas - ou', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(verdadeiro ou falso);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -102,8 +102,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Operações lógicas - e', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(verdadeiro e falso);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -111,8 +111,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Operações lógicas - em', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(2 em [1, 2, 3]);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -122,8 +122,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Condicionais - condição verdadeira', () => {
                     const retornoLexador = delegua.lexador.mapear(["se (1 < 2) { escreva('Um menor que dois'); } senão { escreva('Nunca será executado'); }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -131,8 +131,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Condicionais - condição falsa', () => {
                     const retornoLexador = delegua.lexador.mapear(["se (1 > 2) { escreva('Nunca acontece'); } senão { escreva('Um não é maior que dois'); }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -142,8 +142,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Laços de repetição - enquanto', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = 0;\nenquanto (a < 10) { a = a + 1; }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -151,8 +151,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Laços de repetição - fazer ... enquanto', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = 0;\nfazer { a = a + 1; } enquanto (a < 10)"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -160,8 +160,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Laços de repetição - para', () => {
                     const retornoLexador = delegua.lexador.mapear(["para (var i = 0; i < 10; i = i + 1) { escreva(i); }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -188,8 +188,8 @@ describe('Interpretador (Égua Clássico)', () => {
                     
                     const retornoLexador = delegua.lexador.mapear(codigo);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -226,8 +226,8 @@ describe('Interpretador (Égua Clássico)', () => {
                     ];
                     const retornoLexador = delegua.lexador.mapear(codigo);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -239,8 +239,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it('Acesso a elementos de vetor', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = [1, 2, 3];\nescreva(a[4]);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
                 });
@@ -248,8 +248,8 @@ describe('Interpretador (Égua Clássico)', () => {
                 it.skip('Acesso a elementos de dicionário', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = {'a': 1, 'b': 2};\nescreva(a['c']);"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
                 });

--- a/testes/interpretador.test.ts
+++ b/testes/interpretador.test.ts
@@ -13,8 +13,8 @@ describe('Interpretador', () => {
                 it('Trivial', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = 1"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -22,8 +22,8 @@ describe('Interpretador', () => {
                 it('Vetor', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = [1, 2, 3]"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -31,8 +31,8 @@ describe('Interpretador', () => {
                 it('Dicionário', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = {'a': 1, 'b': 2}"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -45,8 +45,8 @@ describe('Interpretador', () => {
                         "escreva(a[1])"
                     ]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -57,8 +57,8 @@ describe('Interpretador', () => {
                         "escreva(a['b'])"
                     ]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -68,8 +68,8 @@ describe('Interpretador', () => {
                 it('Olá Mundo (escreva() e literal)', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva('Olá mundo')"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -77,8 +77,8 @@ describe('Interpretador', () => {
                 it('nulo', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(nulo)"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -88,8 +88,8 @@ describe('Interpretador', () => {
                 it('Operações matemáticas - Trivial', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(5 + 4 * 3 - 2 ** 1 / 6 % 10)"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -99,8 +99,8 @@ describe('Interpretador', () => {
                 it('Operações lógicas - ou', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(verdadeiro ou falso)"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -108,8 +108,8 @@ describe('Interpretador', () => {
                 it('Operações lógicas - e', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(verdadeiro e falso)"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -117,8 +117,8 @@ describe('Interpretador', () => {
                 it('Operações lógicas - em', () => {
                     const retornoLexador = delegua.lexador.mapear(["escreva(2 em [1, 2, 3])"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 }); 
@@ -128,8 +128,8 @@ describe('Interpretador', () => {
                 it('Condicionais - condição verdadeira', () => {
                     const retornoLexador = delegua.lexador.mapear(["se (1 < 2) { escreva('Um menor que dois') } senão { escreva('Nunca será executado') }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -137,8 +137,8 @@ describe('Interpretador', () => {
                 it('Condicionais - condição falsa', () => {
                     const retornoLexador = delegua.lexador.mapear(["se (1 > 2) { escreva('Nunca acontece') } senão { escreva('Um não é maior que dois') }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -148,8 +148,8 @@ describe('Interpretador', () => {
                 it('Laços de repetição - enquanto', () => {
                     const retornoLexador = delegua.lexador.mapear(["var a = 0;\nenquanto (a < 10) { a = a + 1 }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -160,8 +160,8 @@ describe('Interpretador', () => {
                         "fazer { a = a + 1 } enquanto (a < 10)"
                     ]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -169,8 +169,8 @@ describe('Interpretador', () => {
                 it('Laços de repetição - para', () => {
                     const retornoLexador = delegua.lexador.mapear(["para (var i = 0; i < 10; i = i + 1) { escreva(i) }"]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -197,8 +197,8 @@ describe('Interpretador', () => {
                     
                     const retornoLexador = delegua.lexador.mapear(codigo);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -235,8 +235,8 @@ describe('Interpretador', () => {
                     ];
                     const retornoLexador = delegua.lexador.mapear(codigo);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(false);
                 });
@@ -251,8 +251,8 @@ describe('Interpretador', () => {
                         "escreva(a[4]);"
                     ]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
                 });
@@ -263,8 +263,8 @@ describe('Interpretador', () => {
                         "escreva(a['c']);"
                     ]);
                     const retornoAvaliadorSintatico = delegua.avaliadorSintatico.analisar(retornoLexador.simbolos);
-                    delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoResolvedor = delegua.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
+                    delegua.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         
                     expect(delegua.teveErroEmTempoDeExecucao).toBe(true);
                 });


### PR DESCRIPTION
Resolvedor passa a retornar objeto locais, e não mais chamar o interpretador. 