### PR TITLE
Performance browser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,7 @@
             "console": "integratedTerminal",
             "args": [
                 "${workspaceFolder}\\index.ts",
+                "-p",
                 "./testes/exemplos/testes.egua"
             ],
             "runtimeExecutable": "node",

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -1,5 +1,5 @@
 import tiposDeSimbolos from '../tipos-de-simbolos';
-import { performance } from 'perf_hooks';
+import hrtime from 'browser-process-hrtime';
 import { AvaliadorSintaticoInterface, SimboloInterface } from '../interfaces';
 import {
     AtribuicaoSobrescrita,
@@ -1115,7 +1115,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
     }
 
     analisar(retornoLexador: RetornoLexador): RetornoAvaliadorSintatico {
-        const inicioAnalise: number = performance.now();
+        const inicioAnalise: [number, number] = hrtime();
         this.erros = [];
         this.atual = 0;
         this.ciclos = 0;
@@ -1127,9 +1127,9 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
             declaracoes.push(this.declaracao());
         }
 
-        const fimAnalise: number = performance.now();
+        const deltaAnalise: [number, number] = hrtime(inicioAnalise);
         if (this.performance) {
-            console.log(`[Avaliador Sintático] Tempo para análise: ${fimAnalise - inicioAnalise}ms`);
+            console.log(`[Avaliador Sintático] Tempo para análise: ${deltaAnalise[0] * 1e9 + deltaAnalise[1]}ns`);
         }
         
         return { 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-eguap.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-eguap.ts
@@ -1,4 +1,4 @@
-import { performance } from 'perf_hooks';
+import hrtime from 'browser-process-hrtime';
 
 import {
     AcessoIndiceVariavel,
@@ -1139,7 +1139,7 @@ export class AvaliadorSintaticoEguaP implements AvaliadorSintaticoInterface {
     }
 
     analisar(retornoLexador: RetornoLexador): RetornoAvaliadorSintatico {
-        const inicioAnalise: number = performance.now();
+        const inicioAnalise: [number, number] = hrtime();
         this.erros = [];
         this.atual = 0;
         this.ciclos = 0;
@@ -1153,12 +1153,12 @@ export class AvaliadorSintaticoEguaP implements AvaliadorSintaticoInterface {
             declaracoes.push(this.declaracao());
         }
 
-        const fimAnalise: number = performance.now();
+        const deltaAnalise: [number, number] = hrtime(inicioAnalise);
         if (this.performance) {
             console.log(
                 `[Avaliador Sintático] Tempo para análise: ${
-                    fimAnalise - inicioAnalise
-                }ms`
+                    deltaAnalise[0] * 1e9 + deltaAnalise[1]
+                }ns`
             );
         }
 

--- a/fontes/interpretador/index.ts
+++ b/fontes/interpretador/index.ts
@@ -1,6 +1,6 @@
 import * as caminho from 'path';
 import * as fs from 'fs';
-import { performance } from 'perf_hooks';
+import hrtime from 'browser-process-hrtime';
 
 import tiposDeSimbolos from '../lexador/tipos-de-simbolos';
 
@@ -931,7 +931,7 @@ export class Interpretador implements InterpretadorInterface {
         this.locais = locais;
         this.erros = [];
 
-        const inicioInterpretacao: number = performance.now();
+        const inicioInterpretacao: [number, number] = hrtime();
         try {
             const declaracoes = objeto.declaracoes || objeto;
             if (declaracoes.length === 1) {
@@ -948,12 +948,12 @@ export class Interpretador implements InterpretadorInterface {
         } catch (erro: any) {
             this.erros.push(erro);
         } finally {
-            const fimInterpretacao: number = performance.now();
+            const deltaInterpretacao: [number, number] = hrtime(inicioInterpretacao);
             if (this.performance) {
                 console.log(
                     `[Interpretador] Tempo para interpretaçao: ${
-                        fimInterpretacao - inicioInterpretacao
-                    }ms`
+                        deltaInterpretacao[0] * 1e9 + deltaInterpretacao[1]
+                    }ns`
                 );
             }
         }

--- a/fontes/lexador/dialetos/lexador-eguap.ts
+++ b/fontes/lexador/dialetos/lexador-eguap.ts
@@ -1,4 +1,4 @@
-import { performance } from 'perf_hooks';
+import hrtime from 'browser-process-hrtime';
 
 import { LexadorInterface, SimboloInterface } from "../../interfaces";
 import tiposDeSimbolos from "./tipos-de-simbolos-eguap";
@@ -452,7 +452,7 @@ export class LexadorEguaP implements LexadorInterface {
     }
 
     mapear(codigo?: string[]): RetornoLexador {
-        const inicioMapeamento: number = performance.now();
+        const inicioMapeamento: [number, number] = hrtime();
         this.simbolos = [];
         this.erros = [];
         this.pragmas = {};
@@ -470,9 +470,9 @@ export class LexadorEguaP implements LexadorInterface {
             this.analisarToken();
         }
 
-        const fimMapeamento: number = performance.now();
+        const deltaMapeamento: [number, number] = hrtime(inicioMapeamento);
         if (this.performance) {
-            console.log(`[Lexador] Tempo para mapeamento: ${fimMapeamento - inicioMapeamento}ms`);
+            console.log(`[Lexador] Tempo para mapeamento: ${deltaMapeamento[0] * 1e9 + deltaMapeamento[1]}ns`);
         }
 
         return {

--- a/fontes/lexador/lexador.ts
+++ b/fontes/lexador/lexador.ts
@@ -1,4 +1,4 @@
-import { performance } from 'perf_hooks';
+import hrtime from 'browser-process-hrtime';
 import { LexadorInterface, SimboloInterface } from "../interfaces";
 import tiposDeSimbolos from "../tipos-de-simbolos";
 import { ErroLexador } from "./erro-lexador";
@@ -406,7 +406,7 @@ export class Lexador implements LexadorInterface {
     }
 
     mapear(codigo?: string[]): RetornoLexador {
-        const inicioMapeamento: number = performance.now();
+        const inicioMapeamento: [number, number] = hrtime();
         this.erros = [];
         this.simbolos = [];
 
@@ -417,9 +417,9 @@ export class Lexador implements LexadorInterface {
             this.analisarToken();
         }
 
-        const fimMapeamento: number = performance.now();
+        const deltaMapeamento: [number, number] = hrtime(inicioMapeamento);
         if (this.performance) {
-            console.log(`[Lexador] Tempo para mapeamento: ${fimMapeamento - inicioMapeamento}ms`);
+            console.log(`[Lexador] Tempo para mapeamento: ${deltaMapeamento[0] * 1e9 + deltaMapeamento[1]}ns`);
         }
         
         return { 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
+    "browser-process-hrtime": "^1.0.0",
     "chalk": "4.1.2",
     "commander": "^8.3.0"
   }


### PR DESCRIPTION
Aparentemente não tem perf_hooks no browser. Instalado pacote para que indicador de performance também seja possível de usar no browser.

Resolve https://github.com/DesignLiquido/delegua/issues/76