### PR TITLE
Importador, Resolvedor dentro do Interpretador

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -95,7 +95,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
         return excecao;
     }
 
-    consumir(tipo: any, mensagemDeErro: string): any {
+    consumir(tipo: any, mensagemDeErro: string): SimboloInterface {
         if (this.verificarTipoSimboloAtual(tipo)) return this.avancarEDevolverAnterior();
         throw this.erro(this.simboloAtual(), mensagemDeErro);
     }
@@ -992,7 +992,9 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
     }
 
     corpoDaFuncao(tipo: string): Funcao {
-        this.consumir(
+        // O parêntese esquerdo é considerado o símbolo inicial para
+        // fins de pragma.
+        const parenteseEsquerdo = this.consumir(
             tiposDeSimbolos.PARENTESE_ESQUERDO,
             `Esperado '(' após o nome ${tipo}.`
         );
@@ -1048,7 +1050,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
 
         const corpo = this.blocoEscopo();
 
-        return new Funcao(0, parametros, corpo);
+        return new Funcao(Number(parenteseEsquerdo.linha), parametros, corpo);
     }
 
     declaracaoDeClasse(): Classe {

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -54,13 +54,14 @@ export class Delegua implements DeleguaInterface {
 
         switch (this.dialeto) {
             case 'egua':
+                this.resolvedor = new ResolvedorEguaClassico();
+                this.lexador = new LexadorEguaClassico();
+                this.avaliadorSintatico = new AvaliadorSintaticoEguaClassico();
+                this.importador = new Importador(this.lexador, this.avaliadorSintatico);
                 this.interpretador = new InterpretadorEguaClassico(
                     this,
                     process.cwd()
                 );
-                this.lexador = new LexadorEguaClassico();
-                this.avaliadorSintatico = new AvaliadorSintaticoEguaClassico();
-                this.resolvedor = new ResolvedorEguaClassico();
                 
                 console.log('Usando dialeto: Égua');
                 break;
@@ -124,31 +125,20 @@ export class Delegua implements DeleguaInterface {
     }
 
     carregarArquivo(caminhoRelativoArquivo: string): void {
-        /* this.nomeArquivo = caminho.basename(caminhoRelativoArquivo);
-
-        const dadosDoArquivo: Buffer = fs.readFileSync(caminhoRelativoArquivo);
-        const conteudoDoArquivo: string[] = dadosDoArquivo
-            .toString()
-            .split('\n');
-        this.executar(conteudoDoArquivo); */
         const retornoImportador = this.importador.importar(caminhoRelativoArquivo);
-        this.executar2(retornoImportador);
+        this.executar(retornoImportador);
 
         if (this.teveErro) process.exit(65);
         if (this.teveErroEmTempoDeExecucao) process.exit(70);
     }
 
-    executar2(retornoImportador: RetornoImportador) {
-        // const retornoLexador = this.lexador.mapear(codigo);
-
+    executar(retornoImportador: RetornoImportador) {
         if (retornoImportador.retornoLexador.erros.length > 0) {
             for (const erroLexador of retornoImportador.retornoLexador.erros) {
                 this.reportar(erroLexador.linha, ` no '${erroLexador.caractere}'`, erroLexador.mensagem);
             }
             return;
         }
-
-        // const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador);
 
         if (retornoImportador.retornoAvaliadorSintatico.erros.length > 0) {
             for (const erroAvaliadorSintatico of retornoImportador.retornoAvaliadorSintatico.erros) {
@@ -166,51 +156,7 @@ export class Delegua implements DeleguaInterface {
             return;
         } */
 
-        // const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
         const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes);
-
-        if (retornoInterpretador.erros.length > 0) {
-            for (const erroInterpretador of retornoInterpretador.erros) {
-                if (erroInterpretador.simbolo) {
-                    this.erroEmTempoDeExecucao(erroInterpretador.simbolo);
-                } else {
-                    const erroEmJavaScript: any = erroInterpretador as any;
-                    console.error(chalk.red(`Erro em JavaScript: `) + `${erroEmJavaScript.message}`);
-                    console.error(chalk.red(`Pilha de execução: `) + `${erroEmJavaScript.stack}`);
-                }
-            }
-        }
-    }
-
-    executar(codigo: string[]) {
-        const retornoLexador = this.lexador.mapear(codigo);
-
-        if (retornoLexador.erros.length > 0) {
-            for (const erroLexador of retornoLexador.erros) {
-                this.reportar(erroLexador.linha, ` no '${erroLexador.caractere}'`, erroLexador.mensagem);
-            }
-            return;
-        }
-
-        const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador);
-
-        if (retornoAvaliadorSintatico.erros.length > 0) {
-            for (const erroAvaliadorSintatico of retornoAvaliadorSintatico.erros) {
-                this.erro(erroAvaliadorSintatico.simbolo, erroAvaliadorSintatico.message);
-            }
-            return;
-        }
-
-        const retornoResolvedor = this.resolvedor.resolver(retornoAvaliadorSintatico.declaracoes);
-
-        if (retornoResolvedor.erros.length > 0) {
-            for (const erroResolvedor of retornoResolvedor.erros) {
-                this.erro(erroResolvedor.simbolo, erroResolvedor.message);
-            }
-            return;
-        }
-
-        const retornoInterpretador = this.interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
 
         if (retornoInterpretador.erros.length > 0) {
             for (const erroInterpretador of retornoInterpretador.erros) {

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -51,6 +51,7 @@ export class Delegua implements DeleguaInterface {
         this.teveErroEmTempoDeExecucao = false;
 
         this.dialeto = dialeto;
+
         switch (this.dialeto) {
             case 'egua':
                 this.interpretador = new InterpretadorEguaClassico(
@@ -60,29 +61,33 @@ export class Delegua implements DeleguaInterface {
                 this.lexador = new LexadorEguaClassico();
                 this.avaliadorSintatico = new AvaliadorSintaticoEguaClassico();
                 this.resolvedor = new ResolvedorEguaClassico();
+                
                 console.log('Usando dialeto: Égua');
                 break;
             case 'eguap':
-                this.interpretador = new Interpretador(this, process.cwd());
+                this.resolvedor = new Resolvedor();
                 this.lexador = new LexadorEguaP();
                 this.avaliadorSintatico = new AvaliadorSintaticoEguaP();
-                this.resolvedor = new Resolvedor();
+                this.importador = new Importador(this.lexador, this.avaliadorSintatico);
+                this.interpretador = new Interpretador(this.importador, this.resolvedor, process.cwd());
+
                 console.log('Usando dialeto: ÉguaP');
                 break;
             default:
+                this.resolvedor = new Resolvedor();
+                this.lexador = new Lexador(performance);
+                this.avaliadorSintatico = new AvaliadorSintatico(performance);
+                this.importador = new Importador(this.lexador, this.avaliadorSintatico);
                 this.interpretador = new Interpretador(
-                    this,
+                    this.importador,
+                    this.resolvedor,
                     process.cwd(),
                     performance
                 );
-                this.lexador = new Lexador(performance);
-                this.avaliadorSintatico = new AvaliadorSintatico(performance);
-                this.resolvedor = new Resolvedor();
+                
                 console.log('Usando dialeto: padrão');
                 break;
         }
-
-        this.importador = new Importador(this.lexador, this.avaliadorSintatico);
     }
 
     versao(): string {
@@ -152,16 +157,17 @@ export class Delegua implements DeleguaInterface {
             return;
         }
 
-        const retornoResolvedor = this.resolvedor.resolver(retornoImportador.retornoAvaliadorSintatico.declaracoes);
+        /* const retornoResolvedor = this.resolvedor.resolver(retornoImportador.retornoAvaliadorSintatico.declaracoes);
 
         if (retornoResolvedor.erros.length > 0) {
             for (const erroResolvedor of retornoResolvedor.erros) {
                 this.erro(erroResolvedor.simbolo, erroResolvedor.message);
             }
             return;
-        }
+        } */
 
-        const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
+        // const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes, retornoResolvedor.locais);
+        const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes);
 
         if (retornoInterpretador.erros.length > 0) {
             for (const erroInterpretador of retornoInterpretador.erros) {

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -119,7 +119,13 @@ export class Delegua implements DeleguaInterface {
             this.teveErro = false;
             this.teveErroEmTempoDeExecucao = false;
 
-            this.executar([linha]);
+            const retornoLexador = this.lexador.mapear([linha]);
+            const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador);
+            this.executar({
+                codigo: [linha],
+                retornoLexador,
+                retornoAvaliadorSintatico
+            } as RetornoImportador);
             leiaLinha.prompt();
         });
     }
@@ -146,15 +152,6 @@ export class Delegua implements DeleguaInterface {
             }
             return;
         }
-
-        /* const retornoResolvedor = this.resolvedor.resolver(retornoImportador.retornoAvaliadorSintatico.declaracoes);
-
-        if (retornoResolvedor.erros.length > 0) {
-            for (const erroResolvedor of retornoResolvedor.erros) {
-                this.erro(erroResolvedor.simbolo, erroResolvedor.message);
-            }
-            return;
-        } */
 
         const retornoInterpretador = this.interpretador.interpretar(retornoImportador.retornoAvaliadorSintatico.declaracoes);
 

--- a/fontes/importador/importador.ts
+++ b/fontes/importador/importador.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as caminho from 'path';
+import { ErroEmTempoDeExecucao } from '../excecoes';
 import { AvaliadorSintaticoInterface, LexadorInterface } from '../interfaces';
 
 import { ImportadorInterface } from "../interfaces/importador-interface";
@@ -16,6 +17,15 @@ export class Importador implements ImportadorInterface {
 
     importar(caminhoRelativoArquivo: string): RetornoImportador {
         const nomeArquivo = caminho.basename(caminhoRelativoArquivo);
+        // const hashArquivo = 
+
+        if (!fs.existsSync(nomeArquivo)) {
+            /* throw new ErroEmTempoDeExecucao(
+                declaracao.simboloFechamento,
+                'Não foi possível encontrar arquivo importado.',
+                declaracao.linha
+            ); */
+        }
 
         const dadosDoArquivo: Buffer = fs.readFileSync(caminhoRelativoArquivo);
         const conteudoDoArquivo: string[] = dadosDoArquivo

--- a/fontes/importador/importador.ts
+++ b/fontes/importador/importador.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as caminho from 'path';
+import { AvaliadorSintaticoInterface, LexadorInterface } from '../interfaces';
+
+import { ImportadorInterface } from "../interfaces/importador-interface";
+import { RetornoImportador } from './retorno-importador';
+
+export class Importador implements ImportadorInterface {
+    lexador: LexadorInterface;
+    avaliadorSintatico: AvaliadorSintaticoInterface;
+
+    constructor(lexador: LexadorInterface, avaliadorSintatico: AvaliadorSintaticoInterface) {
+        this.lexador = lexador;
+        this.avaliadorSintatico = avaliadorSintatico;
+    }
+
+    importar(caminhoRelativoArquivo: string): RetornoImportador {
+        const nomeArquivo = caminho.basename(caminhoRelativoArquivo);
+
+        const dadosDoArquivo: Buffer = fs.readFileSync(caminhoRelativoArquivo);
+        const conteudoDoArquivo: string[] = dadosDoArquivo
+            .toString()
+            .split('\n');
+
+        const retornoLexador = this.lexador.mapear(conteudoDoArquivo);
+        const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador);
+        
+        return {
+            nomeArquivo,
+            codigo: conteudoDoArquivo,
+            retornoLexador,
+            retornoAvaliadorSintatico
+        } as RetornoImportador;
+    }
+}

--- a/fontes/importador/index.ts
+++ b/fontes/importador/index.ts
@@ -1,0 +1,2 @@
+export * from './importador';
+export * from './retorno-importador';

--- a/fontes/importador/retorno-importador.ts
+++ b/fontes/importador/retorno-importador.ts
@@ -3,6 +3,7 @@ import { RetornoLexador } from "../lexador/retorno-lexador";
 
 export interface RetornoImportador {
     nomeArquivo: string;
+    hashArquivo: number;
     codigo: string[];
     retornoLexador: RetornoLexador;
     retornoAvaliadorSintatico: RetornoAvaliadorSintatico;

--- a/fontes/importador/retorno-importador.ts
+++ b/fontes/importador/retorno-importador.ts
@@ -1,0 +1,9 @@
+import { RetornoAvaliadorSintatico } from "../avaliador-sintatico/retorno-avaliador-sintatico";
+import { RetornoLexador } from "../lexador/retorno-lexador";
+
+export interface RetornoImportador {
+    nomeArquivo: string;
+    codigo: string[];
+    retornoLexador: RetornoLexador;
+    retornoAvaliadorSintatico: RetornoAvaliadorSintatico;
+}

--- a/fontes/interfaces/delegua-interface.ts
+++ b/fontes/interfaces/delegua-interface.ts
@@ -1,3 +1,3 @@
 export interface DeleguaInterface {
-    executar(codigo: string[], nomeArquivo: string): void;
+    executar(retornoImportador: RetornoImportador): void;
 }

--- a/fontes/interfaces/importador-interface.ts
+++ b/fontes/interfaces/importador-interface.ts
@@ -1,0 +1,5 @@
+import { RetornoImportador } from "../importador";
+
+export interface ImportadorInterface {
+    importar(caminhoRelativoArquivo: string): RetornoImportador;
+}

--- a/fontes/interfaces/interpretador-interface.ts
+++ b/fontes/interfaces/interpretador-interface.ts
@@ -50,5 +50,5 @@ export interface InterpretadorInterface {
     visitarExpressaoSuper(expressao: any): any;
     paraTexto(objeto: any): any;
     executar(declaracao: any, mostrarResultado: boolean): void;
-    interpretar(declaracoes: any, locais: Map<Construto, number>): RetornoInterpretador;
+    interpretar(declaracoes: any, locais?: Map<Construto, number>): RetornoInterpretador;
 }

--- a/fontes/interpretador/dialetos/egua-classico.ts
+++ b/fontes/interpretador/dialetos/egua-classico.ts
@@ -32,13 +32,17 @@ import { ErroInterpretador } from '../erro-interpretador';
  */
 export class InterpretadorEguaClassico implements InterpretadorInterface {
     Delegua: Delegua;
+
     diretorioBase: any;
     global: Ambiente;
     ambiente: Ambiente;
     locais: Map<Construto, number>;
     erros: ErroInterpretador[];
 
-    constructor(Delegua: Delegua, diretorioBase: string) {
+    constructor(
+        Delegua: Delegua,
+        diretorioBase: string
+    ) {
         this.Delegua = Delegua;
         this.diretorioBase = diretorioBase;
 
@@ -908,9 +912,11 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
         declaracao.aceitar(this);
     }
 
-    interpretar(declaracoes: any, locais: Map<Construto, number>): RetornoInterpretador {
-        this.locais = locais;
+    interpretar(declaracoes: any): RetornoInterpretador {
         this.erros = [];
+
+        const retornoResolvedor = this.Delegua.resolvedor.resolver(declaracoes);
+        this.locais = retornoResolvedor.locais;
         
         try {
             for (let i = 0; i < declaracoes.length; i++) {

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -35,7 +35,6 @@ import { ImportadorInterface } from '../interfaces/importador-interface';
  * e de fato executa a lógica de programação descrita no código.
  */
 export class Interpretador implements InterpretadorInterface {
-    // Delegua: Delegua;
     importador: ImportadorInterface;
     resolvedor: ResolvedorInterface;
 
@@ -47,13 +46,11 @@ export class Interpretador implements InterpretadorInterface {
     performance: boolean;
 
     constructor(
-        // Delegua: Delegua, 
         importador: ImportadorInterface,
         resolvedor: ResolvedorInterface,
         diretorioBase: string,
         performance: boolean = false
     ) {
-        // this.Delegua = Delegua;
         this.importador = importador;
         this.resolvedor = resolvedor;
         this.diretorioBase = diretorioBase;
@@ -563,34 +560,7 @@ export class Interpretador implements InterpretadorInterface {
             return carregarBibliotecaNode(caminhoRelativo);
         }
 
-        /* try {
-            if (!fs.existsSync(caminhoTotal)) {
-                throw new ErroEmTempoDeExecucao(
-                    declaracao.simboloFechamento,
-                    'Não foi possível encontrar arquivo importado.',
-                    declaracao.linha
-                );
-            }
-        } catch (erro) {
-            throw new ErroEmTempoDeExecucao(
-                declaracao.simboloFechamento,
-                'Não foi possível ler o arquivo.',
-                declaracao.linha
-            );
-        } */
-        
-        /* const conteudoImportacao: string[] = fs.readFileSync(caminhoTotal)
-            .toString()
-            .split('\n'); */
         const conteudoImportacao = this.importador.importar(caminhoRelativo);
-
-        /* const delegua: Delegua = new Delegua(
-            this.Delegua.dialeto,
-            this.performance,
-            nomeArquivo
-        ); 
-
-        delegua.executar(conteudoImportacao); */
         const retornoInterpretador = this.interpretar(conteudoImportacao.retornoAvaliadorSintatico);
 
         let funcoesDeclaradas = this.global.obterTodasDeleguaFuncao();
@@ -937,9 +907,7 @@ export class Interpretador implements InterpretadorInterface {
         }
     }
 
-    // interpretar(objeto: any, locais: Map<Construto, number>): RetornoInterpretador {
     interpretar(objeto: any): RetornoInterpretador {
-        // this.locais = locais;
         this.erros = [];
 
         const retornoResolvedor = this.resolvedor.resolver(objeto);

--- a/index.ts
+++ b/index.ts
@@ -1,30 +1,30 @@
 import { Delegua } from "./fontes/delegua";
 import { Command } from "commander";
 
-const principal = function () {
-  const analisadorArgumentos = new Command();
-  let nomeArquivo: string;
+const principal = () => {
+    const analisadorArgumentos = new Command();
+    let nomeArquivo: string;
 
-  analisadorArgumentos
-    .option("-d, --dialeto <dialeto>", "Dialeto a ser usado. Padrão: delegua",  "delegua")
-    .option("-p, --performance", "Visualizar indicadores de performance. Desabilitado por padrão",  false)
-    .argument('[arquivos...]', 'Nomes dos arquivos (opcional)')
-    .action((arquivos) => {
-        if (arquivos.length > 0) {
-            nomeArquivo = arquivos[0];
-        }
-    });
+    analisadorArgumentos
+        .option("-d, --dialeto <dialeto>", "Dialeto a ser usado. Padrão: delegua", "delegua")
+        .option("-p, --performance", "Visualizar indicadores de performance. Desabilitado por padrão", false)
+        .argument('[arquivos...]', 'Nomes dos arquivos (opcional)')
+        .action((arquivos) => {
+            if (arquivos.length > 0) {
+                nomeArquivo = arquivos[0];
+            }
+        });
 
-  analisadorArgumentos.parse();
-  const opcoes = analisadorArgumentos.opts();
+    analisadorArgumentos.parse();
+    const opcoes = analisadorArgumentos.opts();
 
-  const delegua = new Delegua(opcoes.dialeto, opcoes.performance);
+    const delegua = new Delegua(opcoes.dialeto, opcoes.performance);
 
-  if (!nomeArquivo) {
-    delegua.iniciarDelegua();
-  } else {
-    delegua.carregarArquivo(nomeArquivo);
-  }
+    if (!nomeArquivo) {
+        delegua.iniciarDelegua();
+    } else {
+        delegua.carregarArquivo(nomeArquivo);
+    }
 };
 
 principal();

--- a/testes/exemplos/dialetos/egua-classico/bhaskara.egua
+++ b/testes/exemplos/dialetos/egua-classico/bhaskara.egua
@@ -1,4 +1,4 @@
-funcao bhaskara(a,b,c){
+função bhaskara(a,b,c){
   //A variável "d" vai simbolizar o Delta.
   //"a", "b", e "c" irão representar os coeficientes da equação.
   var d = b**2;


### PR DESCRIPTION
- Não faz muito sentido ter um resolvedor autônomo. Como o resolvedor é uma peça fundamental para o interpretador, passa a depender diretamente do interpretador em todos os dialetos. Portanto, a etapa de resolução de escopos passa a ser parte da interpretação, para um dia ser removida completamente;
- Delégua e EguaP passam a ter um importador, usado para lexação e avaliação sintática. Com isso, não é preciso ter uma referência circular para o núcleo da linguagem dentro do interpretador;
- Para Égua Clássico, a referência circular se mantém, e o procedimento padrão de importação também. 