### PR TITLE
Separação entre execução e preparação para depuração na carga de arquivo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": ["<node_internals>/**", "node_modules/**"],
             "cwd": "${workspaceRoot}",
             "console": "integratedTerminal",
-            "args": ["${workspaceFolder}\\index.ts", "--depurador"],
+            "args": ["${workspaceFolder}\\index.ts"],
             "runtimeExecutable": "node",
             "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"]
         },

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -154,6 +154,10 @@ export class Delegua implements DeleguaInterface {
     executarUmaLinha(linha: string): RetornoExecucaoInterface {
         const retornoLexador = this.lexador.mapear([linha], -1);
         const retornoAvaliadorSintatico = this.avaliadorSintatico.analisar(retornoLexador);
+        if (this.afericaoErros({ retornoLexador, retornoAvaliadorSintatico } as RetornoImportador)) {
+            return { resultado: [] } as RetornoExecucaoInterface;
+        }
+
         return this.executar({
             retornoLexador,
             retornoAvaliadorSintatico

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -133,13 +133,14 @@ export class Delegua implements DeleguaInterface {
             prompt: '\ndelegua> ',
         });
 
-        leiaLinha.prompt();
+        const isto = this;
 
+        leiaLinha.prompt();
         leiaLinha.on('line', (linha: string) => {
-            const retornoInterpretacao = this.executarUmaLinha(linha);
+            const retornoInterpretacao = isto.executarUmaLinha(linha);
             const resultado = retornoInterpretacao.resultado[0];
             if (resultado !== undefined) {
-                this.funcaoDeRetorno(resultado);
+                isto.funcaoDeRetorno(resultado);
             }
             
             leiaLinha.prompt();

--- a/fontes/depuracao/servidor-depuracao.ts
+++ b/fontes/depuracao/servidor-depuracao.ts
@@ -9,7 +9,7 @@ import { PontoParada } from './ponto-parada';
 export class ServidorDepuracao {
     instanciaDelegua: DeleguaInterface;
     servidor: net.Server;
-    conexoes: {[chave: number]: any}
+    conexoes: {[chave: number]: any};
     contadorConexoes: number;
     interpretador: InterpretadorComDepuracaoInterface;
 

--- a/fontes/interfaces/interpretador-com-depuracao-interface.ts
+++ b/fontes/interfaces/interpretador-com-depuracao-interface.ts
@@ -1,3 +1,4 @@
+import { Declaracao } from "../declaracoes";
 import { PontoParada } from "../depuracao";
 import { InterpretadorInterface } from "./interpretador-interface";
 
@@ -11,4 +12,5 @@ export interface InterpretadorComDepuracaoInterface extends InterpretadorInterfa
     continuarInterpretacao(): void;
     interpretacaoApenasUmaInstrucao(): void;
     proximoESair(): void;
+    prepararParaDepuracao(declaracoes: Declaracao[]): void;
 }

--- a/fontes/interfaces/retornos/retorno-execucao-interface.ts
+++ b/fontes/interfaces/retornos/retorno-execucao-interface.ts
@@ -1,12 +1,6 @@
-import { ErroAvaliadorSintatico } from "../../avaliador-sintatico";
 import { ErroInterpretador } from "../../interpretador";
-import { ErroLexador } from "../../lexador/erro-lexador";
 
 export interface RetornoExecucaoInterface {
-    erros: {
-        avaliadorSintatico?: Array<ErroAvaliadorSintatico>
-        lexador?: Array<ErroLexador>
-        interpretador?: Array<ErroInterpretador>
-    }
+    erros: Array<ErroInterpretador>;
     resultado: Array<string>;
 }

--- a/fontes/interpretador/interpretador-com-depuracao.ts
+++ b/fontes/interpretador/interpretador-com-depuracao.ts
@@ -330,12 +330,27 @@ export class InterpretadorComDepuracao
     }
 
     /**
+     * Prepara a pilha de escopos para uma situação de depuração.
+     * Não há execução de código neste caso.
+     * @param declaracoes Um vetor de declarações.
+     */
+    prepararParaDepuracao(declaracoes: Declaracao[]): void {
+        this.declaracoes = declaracoes;
+
+        const escopoExecucao: EscopoExecucao = {
+            declaracoes: declaracoes,
+            declaracaoAtual: 0,
+            ambiente: new Ambiente(),
+        };
+        this.pilhaEscoposExecucao.empilhar(escopoExecucao);
+        this.escopoAtual++;
+    }
+
+    /**
      * Interpretação utilizada pelo depurador. Pode encerrar ao encontrar um
      * ponto de parada ou não.
      * Diferentemente da interpretação tradicional, não possui indicadores
      * de performance porque eles não fazem sentido aqui.
-     * Até então essa função não executa imediatamente, porque a depuração é
-     * controlada pelo servidor de depuração.
      * @param declaracoes Um vetor de declarações.
      * @returns Um objeto de retorno, com erros encontrados se houverem.
      */
@@ -353,6 +368,8 @@ export class InterpretadorComDepuracao
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
         this.escopoAtual++;
+
+        this.executarUltimoEscopo(manterAmbiente);
 
         const retorno = {
             erros: this.erros,

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ const principal = () => {
         )
         .option(
             '-D, --depurador',
-            'Habilita o depurador, permitindo depuração em um ambiente como o VSCode',
+            'Habilita o depurador, permitindo depuração em um ambiente como o VSCode. Sempre desabilitada em modo LAIR.',
             false
         )
         .option(
@@ -31,7 +31,7 @@ const principal = () => {
     analisadorArgumentos.parse();
     const opcoes = analisadorArgumentos.opts();
 
-    const delegua = new Delegua(opcoes.dialeto, opcoes.performance, opcoes.depurador);
+    const delegua = new Delegua(opcoes.dialeto, opcoes.performance, !!nomeArquivo ? opcoes.depurador : false);
 
     if (!nomeArquivo) {
         delegua.iniciarLairDelegua();


### PR DESCRIPTION
- Processos de avaliação de código pelo servidor de depuração passavam por `interpretar`;
- `interpretar`, dentro do interpretador com depuração, não estava exatamente interpretando (e, obviamente, essa foi uma ideia terrível minha);
- Na carga de arquivo, a solução foi separar o processo de depuração do processo de interpretação. Os dois ocorrem durante a depuração:
- A interpretação pura e simples ocorre quando uma variável é avaliada (watch), ou quando o usuário deseja executar uma expressão hipotética pra ver o valor, ou colocando o mouse em cima da variável (hover).
- A depuração, quando solicitada pela extensão, apenas lê os arquivos e organiza todas as estruturas antes de executar.