### PR TITLE
[Primitivas de Vetor e de Texto] Novas Implementações

### DIFF
--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -1,7 +1,7 @@
 export default {
+    'inclui': (texto: string, elemento: any) => texto.includes(elemento),
     'minusculo': (texto: string) => texto.toLowerCase(),
     'maiusculo': (texto: string) => texto.toUpperCase(),
-    'inclui': (texto: string, elemento: any) => texto.includes(elemento),
     "substituir": (texto: string, elemento: string, substituto: string) => texto.replace(elemento, substituto),
     "subtexto": (texto: string, inicio: number, fim: number) => texto.slice(inicio, fim),
     "dividir": (texto: string, divisor: any, limite: number) => ([...texto.split(divisor, limite)]),

--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -1,10 +1,16 @@
 export default {
     'inclui': (vetor: Array<any>, elemento: any) => vetor.includes(elemento),
-    'juntar': (vetor: Array<any>, separador: any) => vetor.join(separador),
-    'removerUltimo': (vetor: Array<any>) => vetor.pop(),
-    'removerPrimeiro': (vetor: Array<any>) => vetor.shift(),
-    'empilhar': (vetor: Array<any>, elemento: any) => vetor.push(elemento),
+    'juntar': (vetor: Array<any>, separador: string) => vetor.join(separador),
+    'removerUltimo': (vetor: Array<any>) => { vetor.pop(); return vetor; },
+    'removerPrimeiro': (vetor: Array<any>) => { vetor.shift(); return vetor; },
+    'empilhar': (vetor: Array<any>, elemento: any) => { vetor.push(elemento); return vetor; },
     'inverter': (vetor: Array<any>) => vetor.reverse(),
     'fatia': (vetor: Array<any>, inicio: number, fim: number) => vetor.slice(inicio, fim),
     'ordenar': (vetor: Array<any>) => vetor.sort(),
+    'somar': (vetor: Array<number>) => vetor.reduce((a, b) => a + b),
+    'remover': (vetor: Array<any>, elemento: any) => {
+        const index = vetor.indexOf(elemento);
+        if (index !== -1) vetor.splice(index, 1);
+        return vetor;
+    },
 }


### PR DESCRIPTION
### **RESUMO DAS ALTERAÇÕES**

### 1. Novas Primitivas de Vetor

### **somar()**
Adicionei às primitivas de vetor o novo método "somar", que atua como o **reduce()** do TypeScript, somando todos os elementos de uma lista de números e **retornando o total.**

`'somar': (vetor: Array<number>) => vetor.reduce((a, b) => a + b)`

Creio que "somar" seja o nome mais semântico para tal operação, porém, outras opções de nome que pensei foram:
- reduzir;
- totalizar;
- somarItens;
- somarTodos;


###  **remover()**
Já tínhamos métodos para remover o primeiro e o último item de uma lista. Mas e se o usuário desejasse **remover um item específico da lista?**

Para isso, criei o método **remover()**, que recebe como parâmetro **o próprio elemento** a ser removido. 
```
'remover': (vetor: Array<any>, elemento: any) => {
    const index = vetor.indexOf(elemento);
    if (index !== -1) vetor.splice(index, 1);
    return vetor;
},
```

- Na operação, primeiro encontramos o index do referido elemento. 
- Caso seja passado um elemento inexistente, a condição if não será executada e a lista não será afetada. 
- Depois, recorremos ao método **splice()** do TypeScript para remover esse elemento da lista. 
- Por fim, retornamos a nova lista atualizada. 

-------
### 2. Primitivas de Vetor Corrigidas

### **removerUltimo()**
**Antes**: o método **pop()** do TypeScript remove o último elemento da lista, porém, seu retorno padrão é **o próprio elemento removido**. Assim estava sendo com nosso método removerUltimo().

**Agora**: com a adição de uma linha, o método removerUltimo() **agora retorna a lista atualizada**, já com o elemento removido, uma vez que o novo trecho adicionado (_return vetor_;) é executado logo após a operação pop(). 


### **removerPrimeiro()**
**Antes**: tal qual o **pop()**, o método **shift()** do TypeScript também tem como retorno padrão o **elemento removido** - nesse caso, o primeiro da lista. 

**Agora**: recorrendo à mesma solução anterior, o método removerPrimeiro() agora **retorna a lista atualizada**, já com o primeiro elemento removido.


### **empilhar()**
**Antes**: o método **push()** do TypeScript adiciona um novo item à lista, porém, seu retorno padrão é o novo comprimento (**length**) da lista. Logo, se o usuário executasse o trecho abaixo, ele receberia a seguinte saída, que pode acabar sendo um pouco confusa:
```
var lista = ['Delegua','LMHT'];
lista.empilhar('FoLes'); // Saída: 3
```
**Agora**: tal qual os métodos anteriores, o empilhar() agora adiciona o novo elemento e depois **retorna a lista atualizada**, resultando no seguinte: 
```
var lista = ['Delegua','LMHT'];
lista.empilhar('FoLes'); // Saída: ['Delegua','LMHT', 'FoLes']
```

### **juntar()**

**Antes**: o segundo parâmetro (separador) estava tipado como 'any'. Porém, quando lemos a documentação do TypeScript sobre o método **join()**, temos o seguinte trecho:

> "O join() cria e retorna uma nova string concatenando todos os elementos em uma lista, separados por vírgulas ou **uma string separadora especificada**".

**Agora**: o segundo parâmetro (separador) está tipado como **string**, para atender ao critério da documentação de passar uma "string separadora especificada".

OBS.: O trecho da documentação que cita "separados por vírgulas" se refere ao retorno do join() para o caso de **nenhum parâmetro** ser passado. Exemplo da documentação:
```
const elements = ['Fire', 'Air', 'Water'];
console.log(elements.join());
// expected output: "Fire,Air,Water"
```
Ou seja, se o usuário tentar passar direto uma vírgula ( _join(,)_ ), ele recebe um erro como retorno. 

Portanto, para todos os casos, **o separador deve ser sempre uma string.**

-------
### 3. Primitivas de Texto

Pelos meus testes locais, o funcionamento das de Texto estão **corretas**. A única alteração feita foi subir o método 'inclui' para o topo da lista, tal qual a lista das Primitivas de Vetor. Porém, sigo com os testes e, caso encontre algum bug, abrirei um novo PR. 