### PR TITLE
Ajustes de importação relativa

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -99,6 +99,21 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "Delégua > Importação",
+            "skipFiles": ["<node_internals>/**", "node_modules/**"],
+            "cwd": "${workspaceRoot}",
+            "console": "integratedTerminal",
+            "args": [
+                "${workspaceFolder}${pathSeparator}execucao.ts",
+                // "--depurador",
+                "./testes/exemplos/importacao/inicial.delegua"
+            ],
+            "runtimeExecutable": "node",
+            "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "Delégua > Leia",
             "skipFiles": ["<node_internals>/**", "node_modules/**"],
             "cwd": "${workspaceRoot}",
@@ -353,21 +368,6 @@
                 "--dialeto",
                 "egua",
                 "./testes/exemplos/classes/construtor-classe.egua"
-            ],
-            "runtimeExecutable": "node",
-            "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Importação (Delégua)",
-            "skipFiles": ["<node_internals>/**", "node_modules/**"],
-            "cwd": "${workspaceRoot}",
-            "console": "integratedTerminal",
-            "args": [
-                "${workspaceFolder}${pathSeparator}execucao.ts",
-                "--depurador",
-                "./testes/exemplos/importacao/importacao-1.egua"
             ],
             "runtimeExecutable": "node",
             "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"]

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -257,7 +257,14 @@ export class Delegua implements DeleguaInterface {
      * @param caminhoRelativoArquivo O caminho no sistema operacional do arquivo a ser aberto.
      */
     async carregarArquivo(caminhoRelativoArquivo: string): Promise<any> {
-        const retornoImportador = this.importador.importar(caminhoRelativoArquivo);
+        const caminhoAbsolutoPrimeiroArquivo = caminho.resolve(caminhoRelativoArquivo);
+        const novoDiretorioBase = caminho.dirname(caminhoAbsolutoPrimeiroArquivo);
+
+        this.importador.diretorioBase = novoDiretorioBase;
+        this.interpretador.diretorioBase = novoDiretorioBase;
+
+        const retornoImportador = this.importador.importar(caminhoRelativoArquivo, true);
+
         if (this.afericaoErros(retornoImportador)) {
             process.exit(65); // Código para erro de avaliação antes da execução
         }

--- a/fontes/importador/importador.ts
+++ b/fontes/importador/importador.ts
@@ -16,6 +16,7 @@ import { RetornoImportador } from './retorno-importador';
  *
  */
 export class Importador implements ImportadorInterface {
+    diretorioBase: string = process.cwd();
     lexador: LexadorInterface;
     avaliadorSintatico: AvaliadorSintaticoInterface;
     arquivosAbertos: { [identificador: string]: string };
@@ -36,9 +37,13 @@ export class Importador implements ImportadorInterface {
         this.depuracao = depuracao;
     }
 
-    importar(caminhoRelativoArquivo: string): RetornoImportador {
+    importar(caminhoRelativoArquivo: string, importacaoInicial: boolean = false): RetornoImportador {
         const nomeArquivo = caminho.basename(caminhoRelativoArquivo);
-        const caminhoAbsolutoArquivo = caminho.resolve(caminhoRelativoArquivo);
+        let caminhoAbsolutoArquivo = caminho.resolve(this.diretorioBase, caminhoRelativoArquivo);
+        if (importacaoInicial) {
+            caminhoAbsolutoArquivo = caminho.resolve(caminhoRelativoArquivo);
+        }
+
         const hashArquivo = cyrb53(caminhoAbsolutoArquivo.toLowerCase());
 
         if (!fs.existsSync(nomeArquivo)) {
@@ -50,7 +55,7 @@ export class Importador implements ImportadorInterface {
             ); */
         }
 
-        const dadosDoArquivo: Buffer = fs.readFileSync(caminhoRelativoArquivo);
+        const dadosDoArquivo: Buffer = fs.readFileSync(caminhoAbsolutoArquivo);
         const conteudoDoArquivo: string[] = dadosDoArquivo
             .toString()
             .replace(sistemaOperacional.EOL, '\n')

--- a/fontes/interfaces/importador-interface.ts
+++ b/fontes/interfaces/importador-interface.ts
@@ -1,5 +1,6 @@
 import { RetornoImportador } from '../importador';
 
 export interface ImportadorInterface {
-    importar(caminhoRelativoArquivo: string): RetornoImportador;
+    diretorioBase: string;
+    importar(caminhoRelativoArquivo: string, importacaoInicial: boolean): RetornoImportador;
 }

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -767,8 +767,8 @@ export class Interpretador implements InterpretadorInterface {
             }
         }
 
-        const conteudoImportacao = this.importador.importar(caminhoRelativo);
-        const retornoInterpretador = this.interpretar(
+        const conteudoImportacao = this.importador.importar(caminhoRelativo, false);
+        const retornoInterpretador = await this.interpretar(
             conteudoImportacao.retornoAvaliadorSintatico.declaracoes,
             true
         );

--- a/fontes/interpretador/pilha-escopos-execucao.ts
+++ b/fontes/interpretador/pilha-escopos-execucao.ts
@@ -136,8 +136,9 @@ export class PilhaEscoposExecucao implements PilhaEscoposExecucaoInterface {
         const retorno = {};
         const ambiente = this.pilha[this.pilha.length - 1].ambiente;
         for (const [nome, corpo] of Object.entries(ambiente.valores)) {
-            if (corpo instanceof DeleguaFuncao) {
-                retorno[nome] = corpo;
+            const corpoValor = corpo.hasOwnProperty('valor') ? corpo.valor : corpo;
+            if (corpoValor instanceof DeleguaFuncao) {
+                retorno[nome] = corpoValor;
             }
         }
 

--- a/testes/exemplos/importacao/funcoes.delegua
+++ b/testes/exemplos/importacao/funcoes.delegua
@@ -1,0 +1,3 @@
+função soma(valor1, valor2){
+    retorna valor1 + valor2;
+}

--- a/testes/exemplos/importacao/inicial.delegua
+++ b/testes/exemplos/importacao/inicial.delegua
@@ -1,0 +1,4 @@
+var funcoesMatematicas = importar('./funcoes.delegua')
+
+var soma = funcoesMatematicas.soma(1, 2)
+escreva(soma)


### PR DESCRIPTION
- Correção de bug na inferência de módulo;
- Importador deve considerar `process.cwd()` apenas na importação do primeiro arquivo. Próximas importações devem considerar o diretório do primeiro arquivo aberto;
- Ajuste do diretório de execução do interpretador quando primeiro arquivo é carregado.

Resolve parte de https://github.com/DesignLiquido/delegua/issues/175.