### PR TITLE
Removendo palavra reservada `senãose` de Delégua e EguaP.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -530,7 +530,10 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
         const caminhoEntao = this.resolverDeclaracao();
 
         const caminhosSeSenao = [];
-        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAOSE, tiposDeSimbolos.SENÃOSE)) {
+        // TODO: `senãose` não existe na língua portuguesa, e a forma separada, `senão se`,
+        // funciona do jeito que deveria.
+        // Marcando este código para ser removido em versões futuras.
+        /* while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAOSE, tiposDeSimbolos.SENÃOSE)) {
             this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após 'senaose' ou 'senãose'.");
             const condicaoSeSenao = this.expressao();
             this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após codição do 'senaose' ou 'senãose'.");
@@ -541,7 +544,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
                 condicao: condicaoSeSenao,
                 caminho: caminho,
             });
-        }
+        } */
 
         let caminhoSenao = null;
         if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAO, tiposDeSimbolos.SENÃO)) {

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-eguap.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-eguap.ts
@@ -558,7 +558,10 @@ export class AvaliadorSintaticoEguaP implements AvaliadorSintaticoInterface {
         const caminhoEntao = this.resolverDeclaracao();
 
         const caminhosSeSenao = [];
-        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAOSE, tiposDeSimbolos.SENÃOSE)) {
+        // TODO: `senãose` não existe na língua portuguesa, e a forma separada, `senão se`,
+        // funciona do jeito que deveria.
+        // Marcando este código para ser removido em versões futuras.
+        /* while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAOSE, tiposDeSimbolos.SENÃOSE)) {
             this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após 'senaose' ou 'senãose'.");
             const condicaoSeSenao = this.expressao();
             this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após codição do 'senaose' ou 'senãose'.");
@@ -569,7 +572,7 @@ export class AvaliadorSintaticoEguaP implements AvaliadorSintaticoInterface {
                 condicao: condicaoSeSenao,
                 caminho: caminho,
             });
-        }
+        } */
 
         // Se há algum escopo aberto, conferir antes do senão se símbolo
         // atual é um espaço de indentação

--- a/fontes/lexador/palavras-reservadas.ts
+++ b/fontes/lexador/palavras-reservadas.ts
@@ -26,8 +26,6 @@ export default {
     pegue: tiposDeSimbolos.PEGUE,
     retorna: tiposDeSimbolos.RETORNA,
     se: tiposDeSimbolos.SE,
-    senaose: tiposDeSimbolos.SENAOSE,
-    senãose: tiposDeSimbolos.SENÃOSE,
     senao: tiposDeSimbolos.SENAO,
     senão: tiposDeSimbolos.SENÃO,
     super: tiposDeSimbolos.SUPER,

--- a/fontes/tipos-de-simbolos/delegua.ts
+++ b/fontes/tipos-de-simbolos/delegua.ts
@@ -64,8 +64,6 @@ export default {
     SE: 'SE',
     SENAO: 'SENAO',
     SENÃO: 'SENÃO',
-    SENAOSE: 'SENAOSE',
-    SENÃOSE: 'SENÃOSE',
     SUPER: 'SUPER',
     SUSTAR: 'SUSTAR',
     TENTE: 'TENTE',

--- a/fontes/tipos-de-simbolos/eguap.ts
+++ b/fontes/tipos-de-simbolos/eguap.ts
@@ -60,8 +60,6 @@ export default {
     SE: 'SE',
     SENAO: 'SENAO',
     SENÃO: 'SENÃO',
-    SENAOSE: 'SENAOSE',
-    SENÃOSE: 'SENÃOSE',
     SUPER: 'SUPER',
     SUSTAR: 'SUSTAR',
     TENTE: 'TENTE',


### PR DESCRIPTION
Motivação:

- A forma separada, `senão se`, já funciona do jeito que deveria;
- `senãose` não existe em português.