### PR TITLE
Classe padrão chamável, inferenciador, etc.

### DIFF
--- a/fontes/bibliotecas/importar-biblioteca.ts
+++ b/fontes/bibliotecas/importar-biblioteca.ts
@@ -58,22 +58,15 @@ const modularizarBiblioteca = (dadosDoModulo: any, nome: string) => {
 
         if (typeof moduloAtual === 'function') {
             // Por definição, funções tradicionais e classes são identificadas em JavaScript como "functions".
-            // A forma de diferenciar é verificando a propriedade `prototype`.
-            // Se dentro dessa propriedade temos outras propriedades cujo tipo também seja `function`,
-            // podemos dizer que a "function" é uma classe.
+            // A primeira heurística era verificando a propriedade `prototype`, mas isso não funciona bem
+            // porque classes e funções avulsas todas possuem prototype.
+            // Uma heurística nova é converter `moduloAtual` para `string` e verificar se a declaração começa com `class`.
+            // Se sim, podemos dizer que a "function" é uma classe padrão.
             // Caso contrário, é uma função (`FuncaoPadrao`).
             if (
-                moduloAtual?.prototype && Object.entries(moduloAtual.prototype).some(
-                    (f: [string, any]) => typeof f[1] === 'function'
-                )
+                String(moduloAtual).startsWith('class')
             ) {
                 const classePadrao = new ClassePadrao(chaves[i], moduloAtual);
-                for (const [nome, corpoMetodo] of Object.entries(
-                    moduloAtual.prototype
-                )) {
-                    classePadrao.metodos[nome] = corpoMetodo;
-                }
-
                 novoModulo.componentes[chaves[i]] = classePadrao;
             } else {
                 novoModulo.componentes[chaves[i]] = new FuncaoPadrao(

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -382,16 +382,8 @@ export class Delegua implements DeleguaInterface {
     }
 
     erroEmTempoDeExecucao(erro: any): void {
-        if (erro && erro.simbolo && erro.simbolo.linha) {
-            // TODO: Voltar isso após revisar pragmas de Interpretador.
-            /* if (this.nomeArquivo)
-                console.error(
-                    chalk.red(`Erro: [Arquivo: ${this.nomeArquivo}] [Linha: ${erro.simbolo.linha}]`) + ` ${erro.mensagem}`
-                );
-            else */
-            console.error(chalk.red(`Erro: [Linha: ${erro.simbolo.linha}]`) + ` ${erro.mensagem}`);
-        } else {
-            console.error(chalk.red(`Erro: [Linha: ${erro.linha || 0}]`) + ` ${erro.mensagem}`);
-        }
+        const linha = erro?.simbolo?.linha || erro?.linha;
+        const mensagem = erro?.mensagem || erro?.message;
+        console.error(chalk.red(`Erro: [Linha: ${linha}]`) + ` ${mensagem}`);
     }
 }

--- a/fontes/estruturas/classe-padrao.ts
+++ b/fontes/estruturas/classe-padrao.ts
@@ -6,22 +6,12 @@ import { ObjetoPadrao } from './objeto-padrao';
  */
 export class ClassePadrao extends Chamavel {
     nome: string;
-    funcaoDeClasse: Function;
-    metodos: { [nome: string]: any };
+    funcaoDeClasse: any;
 
-    constructor(nome: string, funcaoDeClasse: Function) {
+    constructor(nome: string, funcaoDeClasse: any) {
         super();
         this.nome = nome;
         this.funcaoDeClasse = funcaoDeClasse;
-        this.metodos = {};
-    }
-
-    encontrarMetodo(nome: string): Function {
-        if (this.metodos.hasOwnProperty(nome)) {
-            return this.metodos[nome];
-        }
-
-        return undefined;
     }
 
     paraTexto(): string {
@@ -29,16 +19,13 @@ export class ClassePadrao extends Chamavel {
     }
 
     /**
-     * Para o caso de uma classe padrão, chamá-la na verdade é
-     * invocar o construtor e adicionar no corpo de propriedades
-     * os métodos implementados para a classe original.
+     * Para o caso de uma classe padrão, instanciá-la é chamá-la
+     * como função tendo a palavra 'new' na frente.
      * @param argumentos
      * @param simbolo
      */
     chamar(argumentos: any[], simbolo: any): any {
-        const novoObjeto: ObjetoPadrao = new ObjetoPadrao(this.nome);
-        this.funcaoDeClasse.apply(novoObjeto, argumentos);
-        Object.assign(novoObjeto, this.metodos);
+        const novoObjeto: any = new this.funcaoDeClasse();
         return novoObjeto;
     }
 }

--- a/fontes/estruturas/objeto-padrao.ts
+++ b/fontes/estruturas/objeto-padrao.ts
@@ -1,5 +1,6 @@
 /**
  * Um objeto padrão é uma instância de uma Classe Padrão (JavaScript).
+ * TODO: Marcado para depreciação na próxima versão.
  */
 export class ObjetoPadrao {
     classePadrao: string;

--- a/fontes/interfaces/variavel-interface.ts
+++ b/fontes/interfaces/variavel-interface.ts
@@ -10,5 +10,6 @@ export interface VariavelInterface {
         | 'lógico'
         | 'função'
         | 'símbolo'
-        | 'objeto';
+        | 'objeto'
+        | 'módulo';
 }

--- a/fontes/interpretador/inferenciador.ts
+++ b/fontes/interpretador/inferenciador.ts
@@ -1,3 +1,5 @@
+import { DeleguaModulo } from "../estruturas";
+
 export function inferirTipoVariavel(
     variavel: string | number | Array<any> | boolean | null | undefined
 ) {
@@ -16,6 +18,7 @@ export function inferirTipoVariavel(
         case 'object':
             if (Array.isArray(variavel)) return 'vetor';
             if (variavel === null) return 'nulo';
+            if (variavel.constructor.name === 'DeleguaModulo') return 'módulo';
             return 'dicionário';
         case 'function':
             return 'função';


### PR DESCRIPTION
- Essa PR permite ao Interpretador entender qualquer método de biblioteca importada, sem ter que ficar empacotando quilos de objetos que só inflam o uso de memória;
- `ClassePadrao` voltou a ter uso, agora que achei uma forma correta de achar quando uma classe é "construível" (longa história);
- Com isso, como o Interpretador faz `await` de toda e qualquer declaração interpretada, não teremos assincronicidade em Delégua. Os juninhos agradecerão por um nível de complexidade a menos. 