### PR TITLE
Melhora de mensagem de erro em avaliadores sintáticos para instrução `leia`.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -503,7 +503,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
     declaracaoLeia(): Leia {
         const simboloAtual = this.simbolos[this.atual];
 
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos valores em leia.");
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos argumentos em instrução `leia`.");
 
         const argumentos: Construto[] = [];
 
@@ -513,7 +513,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
             } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
         }
 
-        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os valores em leia.");
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os argumentos em instrução `leia`.");
 
         return new Leia(simboloAtual.hashArquivo, Number(simboloAtual.linha), argumentos);
     }

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -443,15 +443,15 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
     declaracaoLeia(): Leia {
         const simboloAtual = this.avancarEDevolverAnterior();
 
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos valores em leia.");
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos argumentos em instrução `leia`.");
 
         const valor = this.declaracao();
 
-        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os valores em leia.");
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os argumentos em instrução `leia`.");
 
         this.consumir(
             tiposDeSimbolos.QUEBRA_LINHA,
-            "Esperado quebra de linha após fechamento de parênteses pós instrução 'leia'."
+            "Esperado quebra de linha após fechamento de parênteses pós instrução `leia`."
         );
 
         return new Leia(simboloAtual.hashArquivo, Number(simboloAtual.linha), []);


### PR DESCRIPTION
- Resolve #209 