### PR TITLE
Vários ajustes para fazer a multiplicação exemplo do VisuAlg funcionar.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -911,6 +911,22 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "VisuAlg > Multiplicar",
+            "skipFiles": ["<node_internals>/**", "node_modules/**"],
+            "cwd": "${workspaceRoot}",
+            "console": "integratedTerminal",
+            "args": [
+                "${workspaceFolder}${pathSeparator}execucao.ts",
+                "--dialeto",
+                "visualg",
+                "./exemplos/dialetos/visualg/multiplicar.alg"
+            ],
+            "runtimeExecutable": "node",
+            "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "VisuAlg > Olá Mundo",
             "skipFiles": ["<node_internals>/**", "node_modules/**"],
             "cwd": "${workspaceRoot}",

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -85,6 +85,12 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
      * @returns Vetor de Construtos para inicialização de variáveis.
      */
     private validarSegmentoVar(): Construto[] {
+        // Podem haver linhas de comentários acima de `var`, que geram
+        // quebras de linha. 
+        while (this.simbolos[this.atual].tipo === tiposDeSimbolos.QUEBRA_LINHA) {
+            this.avancarEDevolverAnterior();
+        }
+
         if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.VAR)) {
             return [];
         }
@@ -581,18 +587,18 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
     declaracaoLeia(): Leia {
         const simboloAtual = this.avancarEDevolverAnterior();
 
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos argumentos em instrução `leia`.");
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes do argumento em instrução `leia`.");
 
-        const valor = this.declaracao();
+        const argumento = this.declaracao();
 
-        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os argumentos em instrução `leia`.");
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após o argumento em instrução `leia`.");
 
         this.consumir(
             tiposDeSimbolos.QUEBRA_LINHA,
             'Esperado quebra de linha após fechamento de parênteses pós instrução `leia`.'
         );
 
-        return new Leia(simboloAtual.hashArquivo, Number(simboloAtual.linha), []);
+        return new Leia(simboloAtual.hashArquivo, Number(simboloAtual.linha), [argumento]);
     }
 
     declaracaoPara(): Para {

--- a/fontes/delegua.ts
+++ b/fontes/delegua.ts
@@ -34,7 +34,7 @@ import { AvaliadorSintaticoVisuAlg } from './avaliador-sintatico/dialetos/avalia
 import { LexadorBirl } from './lexador/dialetos/lexador-birl';
 import { AvaliadorSintaticoBirl } from './avaliador-sintatico/dialetos/avaliador-sintatico-birl';
 import { TradutorJavaScript, TradutorReversoJavaScript } from './tradutores';
-import { InterpretadorVisuAlg } from './interpretador/dialetos/visualg';
+import { InterpretadorVisuAlg } from './interpretador/dialetos/visualg/interpretador-visualg';
 import { ErroInterpretador } from './interpretador';
 import { InterpretadorVisuAlgComDepuracao } from './interpretador/dialetos';
 import { LexadorPortugolStudio } from './lexador/dialetos/lexador-portugol-studio';

--- a/fontes/interpretador/dialetos/index.ts
+++ b/fontes/interpretador/dialetos/index.ts
@@ -1,3 +1,3 @@
 export * from './egua-classico';
-export * from './visualg';
-export * from './visualg-com-depuracao';
+export * from './visualg/interpretador-visualg';
+export * from './visualg/interpretador-visualg-com-depuracao';

--- a/fontes/interpretador/dialetos/visualg/interpretador-visualg.ts
+++ b/fontes/interpretador/dialetos/visualg/interpretador-visualg.ts
@@ -1,7 +1,8 @@
-import { Construto } from '../../construtos';
-import { Escreva, EscrevaMesmaLinha } from '../../declaracoes';
-import { ImportadorInterface } from '../../interfaces';
-import { Interpretador } from '../interpretador';
+import { Construto, Variavel } from '../../../construtos';
+import { Escreva, EscrevaMesmaLinha, Fazer, Leia } from '../../../declaracoes';
+import { ImportadorInterface } from '../../../interfaces';
+import { Interpretador } from '../..';
+import { ContinuarQuebra, Quebra } from '../../../quebras';
 
 /**
  * O Interpretador VisuAlg possui algumas diferenças em relação ao
@@ -30,6 +31,29 @@ export class InterpretadorVisuAlg extends Interpretador {
         }
 
         return formatoTexto;
+    }
+
+    /**
+     * No VisuAlg, o bloco de condição executa se falso.
+     * Por isso a reimplementação aqui.
+     * @param declaracao A declaração `Fazer`
+     * @returns Só retorna em caso de erro na execução, e neste caso, o erro.
+     */
+    async visitarDeclaracaoFazer(declaracao: Fazer): Promise<any> {
+        let retornoExecucao: any;
+        do {
+            try {
+                retornoExecucao = await this.executar(declaracao.caminhoFazer);
+                if (retornoExecucao instanceof ContinuarQuebra) {
+                    retornoExecucao = null;
+                }
+            } catch (erro: any) {
+                return Promise.reject(erro);
+            }
+        } while (
+            !(retornoExecucao instanceof Quebra) &&
+            !this.eVerdadeiro(await this.avaliar(declaracao.condicaoEnquanto))
+        );
     }
 
     /**
@@ -62,5 +86,24 @@ export class InterpretadorVisuAlg extends Interpretador {
         } catch (erro: any) {
             this.erros.push(erro);
         }
+    }
+
+    /**
+     * Execução da leitura de valores da entrada configurada no
+     * início da aplicação.
+     * @param expressao Expressão do tipo Leia
+     * @returns Promise com o resultado da leitura.
+     */
+    async visitarExpressaoLeia(expressao: Leia): Promise<any> {
+        const mensagem = '> ';
+        const argumento = (expressao.argumentos[0] as Variavel).simbolo.lexema;
+        const promessaLeitura: Function = () => new Promise((resolucao) =>
+            this.interfaceEntradaSaida.question(mensagem, (resposta: any) => {
+                resolucao(resposta);
+            })
+        );
+
+        const valorLido = await promessaLeitura();
+        this.pilhaEscoposExecucao.definirVariavel(argumento, valorLido);
     }
 }

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -329,7 +329,21 @@ export class Interpretador implements InterpretadorInterface {
 
                 case tiposDeSimbolos.MULTIPLICACAO:
                 case tiposDeSimbolos.MULTIPLICACAO_IGUAL:
-                    this.verificarOperandosNumeros(expressao.operador, esquerda, direita);
+                    if (tipoEsquerdo === 'texto' || tipoDireito === 'texto') {
+                        // Sem ambos os valores resolvem como texto, multiplica normal.
+                        // Se apenas um resolve como texto, o outro repete o 
+                        // texto n vezes, sendo n o valor do outro.
+                        if (tipoEsquerdo === 'texto' && tipoDireito === 'texto') {
+                            return Number(valorEsquerdo) * Number(valorDireito);    
+                        } 
+                        
+                        if (tipoEsquerdo === 'texto') {
+                            return valorEsquerdo.repeat(Number(valorDireito));
+                        }
+
+                        return valorDireito.repeat(Number(valorEsquerdo));
+                    }
+                    
                     return Number(valorEsquerdo) * Number(valorDireito);
 
                 case tiposDeSimbolos.MODULO:
@@ -1235,7 +1249,7 @@ export class Interpretador implements InterpretadorInterface {
      * Método que efetivamente inicia o processo de interpretação.
      * @param declaracoes Um vetor de declarações gerado pelo Avaliador Sintático.
      * @param manterAmbiente Se ambiente de execução (variáveis, classes, etc.) deve ser mantido. Normalmente usado
-     *                       pelo modo REPL (LEIA).
+     *                       pelo modo REPL (LAIR).
      * @returns Um objeto com o resultado da interpretação.
      */
     async interpretar(declaracoes: Declaracao[], manterAmbiente = false): Promise<RetornoInterpretador> {

--- a/fontes/interpretador/pilha-escopos-execucao.ts
+++ b/fontes/interpretador/pilha-escopos-execucao.ts
@@ -40,9 +40,14 @@ export class PilhaEscoposExecucao implements PilhaEscoposExecucaoInterface {
     }
 
     definirVariavel(nomeVariavel: string, valor: any) {
+        const variavel = this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel];
+        const tipo = variavel && variavel.hasOwnProperty('tipo') ? 
+            variavel.tipo : 
+            inferirTipoVariavel(valor);
+
         this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel] = {
             valor,
-            tipo: inferirTipoVariavel(valor),
+            tipo: tipo
         };
     }
 


### PR DESCRIPTION
- Inferência passa a considerar tipo da variável já declarada, se houver;
- `repita` em VisuAlg funciona quando condição é falsa;
- Operador `*` passa a verificar tipo de texto. Quando há tipo de texto, ocorre o comportamento descrito em https://github.com/DesignLiquido/delegua/discussions/125#discussioncomment-3600409