### PR TITLE
Mais ajustes no VisuAlg.

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -713,10 +713,7 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
     declaracaoSe(): Se {
         const simboloSe: SimboloInterface = this.avancarEDevolverAnterior();
 
-        // Parênteses são opcionais para delimitar o identificador.
-        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARENTESE_ESQUERDO);
         const condicao = this.expressao();
-        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARENTESE_DIREITO);
 
         this.consumir(tiposDeSimbolos.ENTAO, "Esperado palavra reservada 'entao' após condição em declaração 'se'.");
         this.consumir(

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -612,6 +612,10 @@ export class InterpretadorBase implements InterpretadorInterface {
 
     async visitarDeclaracaoEscolha(declaracao: Escolha): Promise<any> {
         const condicaoEscolha = await this.avaliar(declaracao.identificadorOuLiteral);
+        const valorCondicaoEscolha = condicaoEscolha.hasOwnProperty('valor') ? 
+            condicaoEscolha.valor :
+            condicaoEscolha;
+
         const caminhos = declaracao.caminhos;
         const caminhoPadrao = declaracao.caminhoPadrao;
 
@@ -621,7 +625,8 @@ export class InterpretadorBase implements InterpretadorInterface {
                 const caminho = caminhos[i];
 
                 for (let j = 0; j < caminho.condicoes.length; j++) {
-                    if ((await this.avaliar(caminho.condicoes[j])) === condicaoEscolha) {
+                    const condicaoAvaliada = await this.avaliar(caminho.condicoes[j]);
+                    if (condicaoAvaliada === valorCondicaoEscolha) {
                         encontrado = true;
 
                         try {

--- a/fontes/interpretador/pilha-escopos-execucao.ts
+++ b/fontes/interpretador/pilha-escopos-execucao.ts
@@ -39,6 +39,19 @@ export class PilhaEscoposExecucao implements PilhaEscoposExecucaoInterface {
         return this.pilha.pop();
     }
 
+    private converterValor(tipo: string, valor: any) {
+        switch (tipo) {
+            case 'texto':
+                return String(valor);
+            case 'número':
+                return Number(valor);
+            case 'lógico':
+                return Boolean(valor);
+            default:
+                return valor;
+        }
+    }
+
     definirVariavel(nomeVariavel: string, valor: any) {
         const variavel = this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel];
         const tipo = variavel && variavel.hasOwnProperty('tipo') ? 
@@ -68,8 +81,9 @@ export class PilhaEscoposExecucao implements PilhaEscoposExecucaoInterface {
                     variavel.tipo : 
                     inferirTipoVariavel(valor);
 
+                const valorResolvido = this.converterValor(tipo, valor);
                 ambiente.valores[simbolo.lexema] = {
-                    valor,
+                    valor: valorResolvido,
                     tipo
                 };
                 return;


### PR DESCRIPTION
- `escreval()` sem argumentos;
- Correções na forma de interpretar `escolha` no VisuAlg;
- Se variável já foi instanciada, reatribuição de valores converte para o tipo inferenciado na primeira vez.