### PR TITLE
Birl

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -37,11 +37,6 @@ export abstract class AvaliadorSintaticoBase implements AvaliadorSintaticoInterf
     atual: number;
     blocos: number;
 
-    // Função util para birl onde o tipo int, short int e long int tem a mesma tratativa
-    consumirSemError(tipo: string): Boolean {
-        if (this.verificarTipoSimboloAtual(tipo)) return true;
-        return false;
-    }
 
     consumir(tipo: string, mensagemDeErro: string): SimboloInterface {
         if (this.verificarTipoSimboloAtual(tipo)) return this.avancarEDevolverAnterior();

--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -1,25 +1,25 @@
 import { Binario, Chamada, Construto, FuncaoConstruto, Logico, Unario } from '../construtos';
 import {
+    Classe,
+    Continua,
+    Declaracao,
+    Enquanto,
+    Escolha,
     Escreva,
     Expressao,
-    Se,
-    Enquanto,
-    Para,
-    Sustar,
-    Continua,
-    Retorna,
-    Escolha,
-    Importar,
-    Tente,
     Fazer,
-    Var,
-    FuncaoDeclaracao as FuncaoDeclaracao,
-    Classe,
-    Declaracao,
+    FuncaoDeclaracao,
+    Importar,
     Leia,
+    Para,
+    Retorna,
+    Se,
+    Sustar,
+    Tente,
+    Var,
 } from '../declaracoes';
 import { AvaliadorSintaticoInterface, ParametroInterface, SimboloInterface } from '../interfaces';
-import { RetornoLexador, RetornoAvaliadorSintatico } from '../interfaces/retornos';
+import { RetornoAvaliadorSintatico, RetornoLexador } from '../interfaces/retornos';
 import { ErroAvaliadorSintatico } from './erro-avaliador-sintatico';
 
 import tiposDeSimbolos from '../tipos-de-simbolos/comum';
@@ -36,6 +36,12 @@ export abstract class AvaliadorSintaticoBase implements AvaliadorSintaticoInterf
     hashArquivo: number;
     atual: number;
     blocos: number;
+
+    // Função util para birl onde o tipo int, short int e long int tem a mesma tratativa
+    consumirSemError(tipo: string): Boolean {
+        if (this.verificarTipoSimboloAtual(tipo)) return true;
+        return false;
+    }
 
     consumir(tipo: string, mensagemDeErro: string): SimboloInterface {
         if (this.verificarTipoSimboloAtual(tipo)) return this.avancarEDevolverAnterior();

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
@@ -221,6 +221,9 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
     }
 
     declaracaoCaracteres(): Var[] {
+        if (this.consumirSemError(tiposDeSimbolos.BICEPS)) {
+            this.consumir(tiposDeSimbolos.BICEPS, '');
+        }
         const simboloCaractere = this.consumir(tiposDeSimbolos.FRANGO, '');
 
         const inicializacoes = [];
@@ -235,7 +238,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
             );
 
             // Inicialização de variáveis que podem ter valor definido;
-            let valorInicializacao = '';
+            let valorInicializacao: string | Array<string>;
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
                 this.consumir(tiposDeSimbolos.TEXTO, "Esperado ' para começar o texto.");
                 const literalInicializacao = this.consumir(
@@ -243,7 +246,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
                     'Esperado literal de FRANGO após símbolo de igual em declaração de variável.'
                 );
                 this.consumir(tiposDeSimbolos.TEXTO, "Esperado ' para terminar o texto.");
-                valorInicializacao = String(literalInicializacao.literal); // Error nessa linha
+                valorInicializacao = String(literalInicializacao.literal);
             }
 
             inicializacoes.push(
@@ -389,6 +392,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
             case tiposDeSimbolos.MONSTRINHO:
             case tiposDeSimbolos.MONSTRAO:
                 return this.declaracaoInteiros();
+            case tiposDeSimbolos.BICEPS:
             case tiposDeSimbolos.FRANGO:
                 return this.declaracaoCaracteres();
             case tiposDeSimbolos.TRAPEZIO:

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
@@ -221,7 +221,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
     }
 
     declaracaoCaracteres(): Var[] {
-        if (this.consumirSemError(tiposDeSimbolos.BICEPS)) {
+        if (this.verificarTipoSimboloAtual(tiposDeSimbolos.BICEPS)) {
             this.consumir(tiposDeSimbolos.BICEPS, '');
         }
         const simboloCaractere = this.consumir(tiposDeSimbolos.FRANGO, '');
@@ -262,11 +262,11 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
 
     declaracaoInteiros(): Var[] {
         let simboloInteiro: SimboloInterface;
-        if (this.consumirSemError(tiposDeSimbolos.MONSTRO)) {
+        if (this.verificarTipoSimboloAtual(tiposDeSimbolos.MONSTRO)) {
             simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRO, '');
-        } else if (this.consumirSemError(tiposDeSimbolos.MONSTRINHO)) {
+        } else if (this.verificarTipoSimboloAtual(tiposDeSimbolos.MONSTRINHO)) {
             simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRINHO, '');
-        } else if (this.consumirSemError(tiposDeSimbolos.MONSTRAO)) {
+        } else if (this.verificarTipoSimboloAtual(tiposDeSimbolos.MONSTRAO)) {
             simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRAO, '');
         } else {
             throw new Error('Simbolo referente a inteiro não especificado.');
@@ -297,7 +297,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
 
     declaracaoPontoFlutuante(): Var[] {
         const simboloFloat = this.consumir(tiposDeSimbolos.TRAPEZIO, '');
-        if (this.consumirSemError(tiposDeSimbolos.DESCENDENTE)) {
+        if (this.verificarTipoSimboloAtual(tiposDeSimbolos.DESCENDENTE)) {
             this.consumir(tiposDeSimbolos.DESCENDENTE, '');
         }
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
@@ -277,7 +277,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
             );
             inicializacoes.push(new Var(identificador, new Literal(this.hashArquivo, Number(simboloInteiro.linha), 0)));
             // Inicializações de variáveis podem ter valores definidos.
-            let valorInicializacao = 0;
+            let valorInicializacao = 0x00;
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
                 const literalInicializacao = this.consumir(
                     tiposDeSimbolos.NUMERO,
@@ -294,6 +294,9 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
 
     declaracaoPontoFlutuante(): Var[] {
         const simboloFloat = this.consumir(tiposDeSimbolos.TRAPEZIO, '');
+        if (this.consumirSemError(tiposDeSimbolos.DESCENDENTE)) {
+            this.consumir(tiposDeSimbolos.DESCENDENTE, '');
+        }
 
         const inicializacoes = [];
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
@@ -258,31 +258,35 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
     }
 
     declaracaoInteiros(): Var[] {
-        const simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRO, '');
+        let simboloInteiro: SimboloInterface;
+        if (this.consumirSemError(tiposDeSimbolos.MONSTRO)) {
+            simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRO, '');
+        } else if (this.consumirSemError(tiposDeSimbolos.MONSTRINHO)) {
+            simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRINHO, '');
+        } else {
+            throw new Error('Simbolo referente a inteiro não especificado.');
+        }
 
         const inicializacoes = [];
         do {
             const identificador = this.consumir(
                 tiposDeSimbolos.IDENTIFICADOR,
-                "Esperado identificador após palavra reservada 'MONSTRO'."
+                `Esperado identificador após palavra reservada '${simboloInteiro.lexema}'.`
             );
             inicializacoes.push(new Var(identificador, new Literal(this.hashArquivo, Number(simboloInteiro.linha), 0)));
-
             // Inicializações de variáveis podem ter valores definidos.
             let valorInicializacao = 0;
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
                 const literalInicializacao = this.consumir(
                     tiposDeSimbolos.NUMERO,
-                    'Esperado literal de MONSTRO após símbolo de igual em declaração de variável.'
+                    `Esperado literal de ${simboloInteiro.lexema} após símbolo de igual em declaração de variável.`
                 );
                 valorInicializacao = Number(literalInicializacao.literal);
             }
-
             inicializacoes.push(
                 new Var(identificador, new Literal(this.hashArquivo, Number(simboloInteiro.linha), valorInicializacao))
             );
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
-
         return inicializacoes;
     }
 
@@ -377,6 +381,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
                 return this.declaracaoPara();
             // Declaração de inteiros
             case tiposDeSimbolos.MONSTRO:
+            case tiposDeSimbolos.MONSTRINHO:
                 return this.declaracaoInteiros();
             case tiposDeSimbolos.FRANGO:
                 return this.declaracaoCaracteres();

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-birl.ts
@@ -263,6 +263,8 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
             simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRO, '');
         } else if (this.consumirSemError(tiposDeSimbolos.MONSTRINHO)) {
             simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRINHO, '');
+        } else if (this.consumirSemError(tiposDeSimbolos.MONSTRAO)) {
+            simboloInteiro = this.consumir(tiposDeSimbolos.MONSTRAO, '');
         } else {
             throw new Error('Simbolo referente a inteiro não especificado.');
         }
@@ -382,6 +384,7 @@ export class AvaliadorSintaticoBirl extends AvaliadorSintaticoBase {
             // Declaração de inteiros
             case tiposDeSimbolos.MONSTRO:
             case tiposDeSimbolos.MONSTRINHO:
+            case tiposDeSimbolos.MONSTRAO:
                 return this.declaracaoInteiros();
             case tiposDeSimbolos.FRANGO:
                 return this.declaracaoCaracteres();

--- a/fontes/lexador/dialetos/palavras-reservadas/birl.ts
+++ b/fontes/lexador/dialetos/palavras-reservadas/birl.ts
@@ -19,6 +19,7 @@ export default {
     bambam: tiposDeSimbolos.BAMBAM,
     birl: tiposDeSimbolos.BIRL,
     bora: tiposDeSimbolos.BORA,
+    biceps: tiposDeSimbolos.BICEPS,
     ce: tiposDeSimbolos.CE,
     cumpade: tiposDeSimbolos.CUMPADE,
     da: tiposDeSimbolos.DA,

--- a/fontes/lexador/dialetos/palavras-reservadas/birl.ts
+++ b/fontes/lexador/dialetos/palavras-reservadas/birl.ts
@@ -25,6 +25,7 @@ export default {
     dar: tiposDeSimbolos.DAR,
     do: tiposDeSimbolos.DO,
     doente: tiposDeSimbolos.DOENTE,
+    descendente: tiposDeSimbolos.DESCENDENTE,
     ele: tiposDeSimbolos.ELE,
     essa: tiposDeSimbolos.ESSA,
     filho: tiposDeSimbolos.FILHO,

--- a/fontes/lexador/dialetos/palavras-reservadas/birl.ts
+++ b/fontes/lexador/dialetos/palavras-reservadas/birl.ts
@@ -36,6 +36,7 @@ export default {
     maluco: tiposDeSimbolos.MALUCO,
     monstrao: tiposDeSimbolos.MONSTRAO,
     monstro: tiposDeSimbolos.MONSTRO,
+    monstrinho: tiposDeSimbolos.MONSTRINHO, // Essa palavra reservada faz referencia a um short int que em C tem 2bytes ou 16 bits, mas não tratamos ela assim, aqui ela é ignorada e a tratamos como um inteiros de 4 bytes ou 32 bits.
     nao: tiposDeSimbolos.NAO,
     negativa: tiposDeSimbolos.NEGATIVA,
     o: tiposDeSimbolos.O,

--- a/fontes/tipos-de-simbolos/birl.ts
+++ b/fontes/tipos-de-simbolos/birl.ts
@@ -6,6 +6,7 @@ export default {
     BAMBAM: 'BAMBAM',
     BIRL: 'BIRL',
     BORA: 'BORA',
+    BICEPS: 'BICEPS',
     CE: 'CE',
     CUMPADE: 'CUMPADE',
     DA: 'DA',

--- a/fontes/tipos-de-simbolos/birl.ts
+++ b/fontes/tipos-de-simbolos/birl.ts
@@ -25,6 +25,7 @@ export default {
     MALUCO: 'MALUCO',
     MONSTRAO: 'MONSTRAO',
     MONSTRO: 'MONSTRO',
+    MONSTRINHO: 'MONSTRINHO',
     TRAPEZIO: 'TRAPEZIO',
     NAO: 'NAO',
     NEGATIVA: 'NEGATIVA',

--- a/fontes/tipos-de-simbolos/birl.ts
+++ b/fontes/tipos-de-simbolos/birl.ts
@@ -12,6 +12,7 @@ export default {
     DAR: 'DAR',
     DO: 'DO',
     DOENTE: 'DOENTE',
+    DESCENDENTE: 'DESCENDENTE',
     ELE: 'ELE',
     ESSA: 'ESSA',
     FRANGAO: 'FRANGAO',

--- a/testes/birl/avaliador-sintatico.test.ts
+++ b/testes/birl/avaliador-sintatico.test.ts
@@ -123,6 +123,21 @@ describe('Avaliador Sintático Birl', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
             });
+
+            it('Sucesso - Variavel - double', () => {
+                const retornoLexador = lexador.mapear([
+                    'HORA DO SHOW \n',
+                    '  TRAPEZIO DESCENDENTE TD = 0.37; \n',
+                    '  CE QUER VER ESSA PORRA? (M1); \n',
+                    '  BORA CUMPADE 0; \n',
+                    'BIRL \n',
+                ]);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+            });
         });
     });
 });

--- a/testes/birl/avaliador-sintatico.test.ts
+++ b/testes/birl/avaliador-sintatico.test.ts
@@ -138,6 +138,20 @@ describe('Avaliador Sintático Birl', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
             });
+
+            it('Sucesso - Variavel - unsigned char', () => {
+                const retornoLexador = lexador.mapear([
+                    'HORA DO SHOW \n',
+                    `  BICEPS FRANGO TD = 'test'; \n`,
+                    '  CE QUER VER ESSA PORRA? (M1); \n',
+                    '  BORA CUMPADE 0; \n',
+                    'BIRL \n',
+                ]);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador);
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+            });
         });
     });
 });

--- a/testes/birl/avaliador-sintatico.test.ts
+++ b/testes/birl/avaliador-sintatico.test.ts
@@ -92,5 +92,22 @@ describe('Avaliador Sintático Birl', () => {
             expect(retornoAvaliadorSintatico).toBeTruthy();
             expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
         });
+
+        describe('Sucesso - Variavel de tipagem não utilizada', () => {
+            it('Sucesso - Variavel - short int', () => {
+                const retornoLexador = lexador.mapear([
+                    'HORA DO SHOW \n',
+                    '  MONSTRINHO M1 = 1.03; \n',
+                    '  CE QUER VER ESSA PORRA? (M1); \n',
+                    '  BORA CUMPADE 0; \n',
+                    'BIRL \n',
+                ]);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+            });
+        });
     });
 });

--- a/testes/birl/avaliador-sintatico.test.ts
+++ b/testes/birl/avaliador-sintatico.test.ts
@@ -108,6 +108,21 @@ describe('Avaliador Sintático Birl', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
             });
+
+            it('Sucesso - Variavel - long int', () => {
+                const retornoLexador = lexador.mapear([
+                    'HORA DO SHOW \n',
+                    '  MONSTRAO M1 = 16666666; \n',
+                    '  CE QUER VER ESSA PORRA? (M1); \n',
+                    '  BORA CUMPADE 0; \n',
+                    'BIRL \n',
+                ]);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+            });
         });
     });
 });


### PR DESCRIPTION
Implementando novas tipagem de birl como *MONSTRAO*, *MONSTRINHO* e *TRAPEZIO DESCENDENTE*.

Embora esses tipos representem respectivamente *long int*, *short int* e *double* eles não são utilizados por baixo dos panos.

Exemplos as 3 variações de inteiro tem o mesmo tratamento e todos são um int de 8 bytes (64 bits).