### PR TITLE
Preparação para suporte de Portugol Studio no VSCode

### DIFF
--- a/fontes/interpretador/dialetos/portugol-studio/interpretador-portugol-studio-com-depuracao.ts
+++ b/fontes/interpretador/dialetos/portugol-studio/interpretador-portugol-studio-com-depuracao.ts
@@ -22,4 +22,27 @@ export class InterpretadorPortugolStudioComDepuracao extends InterpretadorComDep
             this.pilhaEscoposExecucao,
             expressao);
     }
+
+    /**
+     * No Portugol Studio, como o bloco de execução da função `inicio` é criado
+     * pelo avaliador sintático, precisamos ter uma forma aqui de avançar o
+     * primeiro bloco pós execução de comando, seja ele qual for.
+     */
+    private avancarPrimeiroEscopoAposInstrucao(): void {
+        const escopoUm = this.pilhaEscoposExecucao.naPosicao(1);
+        if (!escopoUm) return;
+        escopoUm.declaracaoAtual = escopoUm.declaracoes.length;
+    }
+
+    async instrucaoContinuarInterpretacao(escopo?: number): Promise<any> {
+        const retornoExecucao = await super.instrucaoContinuarInterpretacao(escopo);
+        this.avancarPrimeiroEscopoAposInstrucao();
+        return retornoExecucao;
+    }
+
+    async instrucaoPasso(escopo?: number): Promise<any> {
+        const retornoExecucaoPasso = await super.instrucaoPasso(escopo);
+        this.avancarPrimeiroEscopoAposInstrucao();
+        return retornoExecucaoPasso;
+    }
 }

--- a/fontes/interpretador/interpretador-com-depuracao.ts
+++ b/fontes/interpretador/interpretador-com-depuracao.ts
@@ -376,7 +376,7 @@ export class InterpretadorComDepuracao
         let i = this.pilhaEscoposExecucao.pilha.length - 1;
         while (i > 0) {
             let ultimoEscopo = this.pilhaEscoposExecucao.topoDaPilha();
-            if (ultimoEscopo.declaracaoAtual >= ultimoEscopo.declaracoes.length) {
+            if (ultimoEscopo.declaracaoAtual >= ultimoEscopo.declaracoes.length || ultimoEscopo.finalizado) {
                 this.pilhaEscoposExecucao.removerUltimo();
                 const escopoAnterior = this.pilhaEscoposExecucao.topoDaPilha();
                 escopoAnterior.ambiente.resolucoesChamadas = Object.assign(


### PR DESCRIPTION
Ajustando o interpretador de Portugol Studio para considerar a função `inicio()` como sempre executada após qualquer passo, seja ele continuar a execução ou passo incremental.