### PR TITLE
Correções de laço de repetição em modo de depuração

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -425,7 +425,7 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
             new Bloco(
                 simboloAtual.hashArquivo, 
                 Number(simboloAtual.linha), 
-                declaracoes
+                declaracoes.filter(d => d)
             )
         );
     }
@@ -645,7 +645,7 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
             'Esperado quebra de linha após fechamento de parênteses pós instrução `leia`.'
         );
 
-        return new Leia(simboloAtual.hashArquivo, Number(simboloAtual.linha), argumentos);
+        return new Leia(Number(simboloAtual.linha), simboloAtual.hashArquivo, argumentos);
     }
 
     declaracaoPara(): Para {

--- a/fontes/interfaces/escopo-execucao.ts
+++ b/fontes/interfaces/escopo-execucao.ts
@@ -10,4 +10,5 @@ export interface EscopoExecucao {
     finalizado: boolean;
     tipo: TipoEscopoExecucao;
     idChamada?: string;
+    emLacoRepeticao: boolean;
 }

--- a/fontes/interpretador/dialetos/egua-classico/interpretador-egua-classico.ts
+++ b/fontes/interpretador/dialetos/egua-classico/interpretador-egua-classico.ts
@@ -77,6 +77,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
             ambiente: new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
 
@@ -582,6 +583,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
             ambiente: ambiente || new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
         const retornoUltimoEscopo: any = await this.executarUltimoEscopo();
@@ -928,6 +930,7 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
             ambiente: new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
         await this.executarUltimoEscopo();

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -104,6 +104,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             ambiente: new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
 
@@ -812,6 +813,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             ambiente: ambiente || new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
         const retornoUltimoEscopo: any = await this.executarUltimoEscopo();
@@ -1253,6 +1255,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             ambiente: new EspacoVariaveis(),
             finalizado: false,
             tipo: 'outro',
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
 

--- a/fontes/interpretador/interpretador-com-depuracao.ts
+++ b/fontes/interpretador/interpretador-com-depuracao.ts
@@ -142,11 +142,15 @@ export class InterpretadorComDepuracao
     }
 
     async visitarDeclaracaoEnquanto(declaracao: Enquanto): Promise<any> {
+        const escopoAtual = this.pilhaEscoposExecucao.topoDaPilha();
         switch (this.comando) {
             case "proximo":
                 if (this.eVerdadeiro(await this.avaliar(declaracao.condicao))) {
+                    escopoAtual.emLacoRepeticao = true;
                     return this.executarBloco((declaracao.corpo as Bloco).declaracoes);
                 }
+
+                escopoAtual.emLacoRepeticao = false;
                 return null;
             default:
                 return super.visitarDeclaracaoEnquanto(declaracao);
@@ -420,7 +424,7 @@ export class InterpretadorComDepuracao
             this.passos--;
             retornoExecucao = await this.executar(ultimoEscopo.declaracoes[ultimoEscopo.declaracaoAtual]);
 
-            if (!this.pontoDeParadaAtivo) {
+            if (!this.pontoDeParadaAtivo && !ultimoEscopo.emLacoRepeticao) {
                 ultimoEscopo.declaracaoAtual++;
             }
 
@@ -598,6 +602,7 @@ export class InterpretadorComDepuracao
             ambiente: ambiente || new EspacoVariaveis(),
             finalizado: false,
             tipo: tipoEscopo,
+            emLacoRepeticao: false
         };
         this.pilhaEscoposExecucao.empilhar(escopoExecucao);
         this.escopoAtual++;


### PR DESCRIPTION
- Registrando no escopo quando há um laço de repetição executando para evitar avanços no contador de instrução atual, em modo de depuração;
- Alteração de lógica de `enquanto` tanto para modo passo quanto para modo continuar.