### PR TITLE
Avaliar interpretador depuracao

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -561,7 +561,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
             } else if (expressao instanceof AcessoIndiceVariavel) {
                 return new AtribuicaoSobrescrita(
                     this.hashArquivo,
-                    0,
+                    expressao.linha,
                     expressao.entidadeChamada,
                     expressao.indice,
                     valor

--- a/fontes/construtos/chamada.ts
+++ b/fontes/construtos/chamada.ts
@@ -1,6 +1,10 @@
 import { InterpretadorInterface } from '../interfaces';
 import { Construto } from './construto';
+import { uuidv4 } from '../geracao-identificadores';
 
+/**
+ * Chamada de funções, métodos, etc.
+ */
 export class Chamada implements Construto {
     id: string;
     linha: number;
@@ -11,32 +15,13 @@ export class Chamada implements Construto {
     parentese: any;
 
     constructor(hashArquivo: number, entidadeChamada: Construto, parentese: any, argumentos: any[]) {
-        this.id = this.uuidv4();
+        this.id = uuidv4();
         this.linha = entidadeChamada.linha;
         this.hashArquivo = hashArquivo;
 
         this.entidadeChamada = entidadeChamada;
         this.parentese = parentese;
         this.argumentos = argumentos;
-    }
-
-    private uuidv4(): string {
-        // Public Domain/MIT
-        let d = new Date().getTime(); // Timestamp
-        let d2 = (typeof performance !== 'undefined' && performance.now && performance.now() * 1000) || 0; // Time in microseconds since page-load or 0 if unsupported
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-            let r = Math.random() * 16; // random number between 0 and 16
-            if (d > 0) {
-                // Use timestamp until depleted
-                r = (d + r) % 16 | 0;
-                d = Math.floor(d / 16);
-            } else {
-                // Use microseconds since page-load if supported
-                r = (d2 + r) % 16 | 0;
-                d2 = Math.floor(d2 / 16);
-            }
-            return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
-        });
     }
 
     async aceitar(visitante: InterpretadorInterface): Promise<any> {

--- a/fontes/declaracoes/leia.ts
+++ b/fontes/declaracoes/leia.ts
@@ -1,4 +1,5 @@
 import { Construto } from '../construtos';
+import { uuidv4 } from '../geracao-identificadores';
 import { InterpretadorInterface } from '../interfaces';
 import { Declaracao } from './declaracao';
 
@@ -7,10 +8,12 @@ import { Declaracao } from './declaracao';
  * configurada no início da aplicação.
  */
 export class Leia extends Declaracao {
+    id: string;
     argumentos: Construto[];
 
     constructor(linha: number, hashArquivo: number, argumentos: Construto[]) {
         super(linha, hashArquivo);
+        this.id = uuidv4();
         this.argumentos = argumentos;
     }
 

--- a/fontes/declaracoes/para.ts
+++ b/fontes/declaracoes/para.ts
@@ -6,6 +6,7 @@ export class Para extends Declaracao {
     condicao: any;
     incrementar: any;
     corpo: any;
+    inicializada: boolean;
 
     constructor(hashArquivo: number, linha: number, inicializador: any, condicao: any, incrementar: any, corpo: any) {
         super(linha, hashArquivo);
@@ -13,6 +14,7 @@ export class Para extends Declaracao {
         this.condicao = condicao;
         this.incrementar = incrementar;
         this.corpo = corpo;
+        this.inicializada = false;
     }
 
     async aceitar(visitante: InterpretadorInterface): Promise<any> {

--- a/fontes/geracao-identificadores/index.ts
+++ b/fontes/geracao-identificadores/index.ts
@@ -1,0 +1,18 @@
+export function uuidv4(): string {
+    // Public Domain/MIT
+    let d = new Date().getTime(); // Timestamp
+    let d2 = (typeof performance !== 'undefined' && performance.now && performance.now() * 1000) || 0; // Time in microseconds since page-load or 0 if unsupported
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        let r = Math.random() * 16; // random number between 0 and 16
+        if (d > 0) {
+            // Use timestamp until depleted
+            r = (d + r) % 16 | 0;
+            d = Math.floor(d / 16);
+        } else {
+            // Use microseconds since page-load if supported
+            r = (d2 + r) % 16 | 0;
+            d2 = Math.floor(d2 / 16);
+        }
+        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+    });
+}

--- a/fontes/interfaces/interpretador-interface.ts
+++ b/fontes/interfaces/interpretador-interface.ts
@@ -1,5 +1,5 @@
 import { EspacoVariaveis } from '../espaco-variaveis';
-import { Atribuir, Literal, Super } from '../construtos';
+import { Atribuir, Construto, Literal, Super } from '../construtos';
 import {
     Bloco,
     Classe,
@@ -24,7 +24,6 @@ import { ContinuarQuebra, RetornoQuebra, SustarQuebra } from '../quebras';
 import { PilhaEscoposExecucaoInterface } from './pilha-escopos-execucao-interface';
 
 import { RetornoInterpretador } from './retornos/retorno-interpretador';
-import { SimboloInterface } from './simbolo-interface';
 import { EscrevaMesmaLinha } from '../declaracoes/escreva-mesma-linha';
 import { FormatacaoEscrita } from '../construtos/formatacao-escrita';
 
@@ -35,7 +34,7 @@ export interface InterpretadorInterface {
     interfaceEntradaSaida: any;
 
     visitarExpressaoLiteral(expressao: Literal): any;
-    avaliar(expressao: any): any;
+    avaliar(expressao: Construto | Declaracao): any;
     visitarExpressaoAgrupamento(expressao: any): any;
     visitarExpressaoUnaria(expressao: any): any;
     visitarExpressaoBinaria(expressao: any): any;

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -110,6 +110,17 @@ export class InterpretadorBase implements InterpretadorInterface {
         carregarBibliotecasGlobais(this, this.pilhaEscoposExecucao);
     }
 
+    async avaliar(expressao: Construto | Declaracao): Promise<any> {
+        // Descomente o código abaixo quando precisar detectar expressões undefined ou nulas.
+        // Por algum motivo o depurador do VSCode não funciona direito aqui
+        // com breakpoint condicional.
+        /* if (expressao === null || expressao === undefined) {
+            console.log('Aqui');
+        } */
+        
+        return await expressao.aceitar(this);
+    }
+
     /**
      * Execução da leitura de valores da entrada configurada no
      * início da aplicação.
@@ -175,16 +186,6 @@ export class InterpretadorBase implements InterpretadorInterface {
         }
 
         return expressao.valor;
-    }
-
-    async avaliar(expressao: Construto): Promise<any> {
-        // Descomente o código abaixo quando precisar detectar expressões undefined ou nulas.
-        // Por algum motivo o depurador do VSCode não funciona direito aqui
-        // com breakpoint condicional.
-        /* if (expressao === null || expressao === undefined) {
-            console.log('Aqui');
-        } */
-        return await expressao.aceitar(this);
     }
 
     async visitarExpressaoAgrupamento(expressao: Agrupamento): Promise<any> {


### PR DESCRIPTION
- Resolve #311 

- [Ajustes em construtos e declarações que precisam manter estado durante uma depuração](https://github.com/DesignLiquido/delegua/commit/73b53c170ea7605e1f9dd6384553fa573f8493c4) 

- [Atribuição por sobrescrita tem linha definida pelo começo do símbolo.](https://github.com/DesignLiquido/delegua/commit/1d67175411dd4e4ba7a10c249688fb7b5b8dd837)

- [Mudando completamente o algoritmo de preservação de chamadas durante depuração](https://github.com/DesignLiquido/delegua/commit/cb7ca6c8bfb880202081c9400c7915c9123b5ebf) 


Customizar cada chamada não é sustentável. O melhor é usar `avaliar()` como ponto de entrada de todas as resoluções, previamente resolvidas ou não.

Resolução de `para` foi totalmente repensada para manter blocos de escopo em qualquer posição. Portanto, inicializador e incremento passam a fazer parte trivial do bloco.