### PR TITLE
Várias correções em diferentes dialetos quanto a atribuição de vetores

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -225,84 +225,6 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
                 this.avancarEDevolverAnterior();
                 return new Literal(this.hashArquivo, Number(simboloAtual.linha), true);
         }
-        
-        /*if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SUPER)) {
-            const simboloChave = this.simbolos[this.atual - 1];
-            this.consumir(tiposDeSimbolos.PONTO, "Esperado '.' após 'super'.");
-            const metodo = this.consumir(tiposDeSimbolos.IDENTIFICADOR, 'Esperado nome do método da Superclasse.');
-            return new Super(this.hashArquivo, simboloChave, metodo);
-        }*/
-
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_ESQUERDO)) {
-            const valores = [];
-
-            if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_DIREITO)) {
-                return new Vetor(this.hashArquivo, Number(simboloAtual.linha), []);
-            }
-
-            while (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_DIREITO)) {
-                const valor = this.atribuir();
-                valores.push(valor);
-                if (this.simbolos[this.atual].tipo !== tiposDeSimbolos.COLCHETE_DIREITO) {
-                    this.consumir(tiposDeSimbolos.VIRGULA, 'Esperado vírgula antes da próxima expressão.');
-                }
-            }
-
-            return new Vetor(this.hashArquivo, Number(simboloAtual.linha), valores);
-        } */
-
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_ESQUERDA)) {
-            const chaves = [];
-            const valores = [];
-
-            if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_DIREITA)) {
-                return new Dicionario(this.hashArquivo, Number(simboloAtual.linha), [], []);
-            }
-
-            while (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_DIREITA)) {
-                const chave = this.atribuir();
-                this.consumir(tiposDeSimbolos.DOIS_PONTOS, "Esperado ':' entre chave e valor.");
-                const valor = this.atribuir();
-
-                chaves.push(chave);
-                valores.push(valor);
-
-                if (this.simbolos[this.atual].tipo !== tiposDeSimbolos.CHAVE_DIREITA) {
-                    this.consumir(tiposDeSimbolos.VIRGULA, 'Esperado vírgula antes da próxima expressão.');
-                }
-            }
-
-            return new Dicionario(this.hashArquivo, Number(simboloAtual.linha), chaves, valores);
-        } */
-
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.FUNÇÃO, tiposDeSimbolos.FUNCAO))
-            return this.corpoDaFuncao(this.simbolos[this.atual - 1].lexema);
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.FALSO))
-            return new Literal(this.hashArquivo, Number(simboloAtual.linha), false);
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VERDADEIRO))
-            return new Literal(this.hashArquivo, Number(simboloAtual.linha), true);
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.NULO))
-            return new Literal(this.hashArquivo, Number(simboloAtual.linha), null);
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ISTO))
-            return new Isto(this.hashArquivo, Number(simboloAtual.linha), this.simbolos[this.atual - 1]); */
-
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.NUMERO, tiposDeSimbolos.TEXTO)) {
-            const simboloAnterior: SimboloInterface = this.simbolos[this.atual - 1];
-            return new Literal(this.hashArquivo, Number(simboloAnterior.linha), simboloAnterior.literal);
-        }
-
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IDENTIFICADOR)) {
-            return new Variavel(this.hashArquivo, this.simbolos[this.atual - 1]);
-        }
-
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARENTESE_ESQUERDO)) {
-            const expressao = this.expressao();
-            this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após a expressão.");
-
-            return new Agrupamento(this.hashArquivo, Number(simboloAtual.linha), expressao);
-        }
-
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IMPORTAR)) return this.declaracaoImportar(); */
 
         throw this.erro(this.simbolos[this.atual], 'Esperado expressão.');
     }
@@ -549,7 +471,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
             return new Atribuir(this.hashArquivo, (expressao.esquerda as Variavel).simbolo, expressao);
         } else if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
             const igual = this.simbolos[this.atual - 1];
-            const valor = this.atribuir();
+            const valor = this.expressao();
 
             if (expressao instanceof Variavel) {
                 const simbolo = expressao.simbolo;
@@ -932,21 +854,6 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
                 return this.declaracaoTente();
             
         }
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.FAZER)) return this.declaracaoFazer();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.TENTE)) return this.declaracaoTente();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ESCOLHA)) return this.declaracaoEscolha();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.RETORNA)) return this.declaracaoRetorna();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CONTINUA)) return this.declaracaoContinua();
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PAUSA, tiposDeSimbolos.SUSTAR))
-            return this.declaracaoSustar(); */
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARA)) return this.declaracaoPara();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ENQUANTO)) return this.declaracaoEnquanto();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SE)) return this.declaracaoSe();
-        // if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ESCREVA)) return this.declaracaoEscreva();
-        /* if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_ESQUERDA)) {
-            const simboloInicioBloco: SimboloInterface = this.simbolos[this.atual - 1];
-            return new Bloco(simboloInicioBloco.hashArquivo, Number(simboloInicioBloco.linha), this.blocoEscopo());
-        } */
 
         const simboloAtual = this.simbolos[this.atual];
         if (simboloAtual.tipo === tiposDeSimbolos.IDENTIFICADOR) {
@@ -1086,6 +993,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface {
             return this.resolverDeclaracao();
         } catch (erro: any) {
             this.sincronizar();
+            this.erros.push(erro);
             return null;
         }
     }

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -48,7 +48,7 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
             const dimensao = dimensoes[0] + 1;
             const resto = dimensoes.slice(1);
             const novoArray = Array(dimensao);
-            for (let i = 0; i < dimensao; i++) {
+            for (let i = 0; i <= dimensao; i++) {
                 novoArray[i] = this.criarVetorNDimensional(resto);
             }
             return novoArray;
@@ -723,7 +723,7 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
             new Binario(
                 this.hashArquivo,
                 new Variavel(this.hashArquivo, variavelIteracao),
-                new Simbolo(tiposDeSimbolos.MENOR, '', '', Number(simboloPara.linha), this.hashArquivo),
+                new Simbolo(tiposDeSimbolos.MENOR_IGUAL, '', '', Number(simboloPara.linha), this.hashArquivo),
                 new Literal(this.hashArquivo, Number(simboloPara.linha), numeroFim.literal)
             ),
             new Atribuir(

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -909,15 +909,15 @@ export class InterpretadorBase implements InterpretadorInterface {
             objeto instanceof DeleguaModulo
         ) {
             objeto[indice] = valor;
-        } 
-
-        return Promise.reject(
-            new ErroEmTempoDeExecucao(
-                expressao.objeto.nome,
-                'Somente listas, dicionários, classes e objetos podem ser mudados por sobrescrita.',
-                expressao.linha
-            )
-        );
+        } else {
+            return Promise.reject(
+                new ErroEmTempoDeExecucao(
+                    expressao.objeto.nome,
+                    'Somente listas, dicionários, classes e objetos podem ser mudados por sobrescrita.',
+                    expressao.linha
+                )
+            );
+        }        
     }
 
     async visitarExpressaoAcessoIndiceVariavel(expressao: AcessoIndiceVariavel | any): Promise<any> {

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -114,9 +114,9 @@ export class InterpretadorBase implements InterpretadorInterface {
         // Descomente o código abaixo quando precisar detectar expressões undefined ou nulas.
         // Por algum motivo o depurador do VSCode não funciona direito aqui
         // com breakpoint condicional.
-        if (expressao === null || expressao === undefined) {
+        /* if (expressao === null || expressao === undefined) {
             console.log('Aqui');
-        }
+        } */
         
         return await expressao.aceitar(this);
     }

--- a/fontes/interpretador/interpretador-com-depuracao.ts
+++ b/fontes/interpretador/interpretador-com-depuracao.ts
@@ -159,7 +159,7 @@ export class InterpretadorComDepuracao
         let formatoTexto: string = '';
 
         for (const argumento of argumentos) {
-            let resultadoAvaliacao: any;
+            /* let resultadoAvaliacao: any;
             if (argumento instanceof Chamada) {
                 const escopoAtual = this.pilhaEscoposExecucao.topoDaPilha();
                 const idChamadaComArgumentos = await this.gerarIdResolucaoChamada(argumento);
@@ -170,11 +170,11 @@ export class InterpretadorComDepuracao
                     resultadoAvaliacao = await this.avaliar(argumento);
                 }
             } else {
-                resultadoAvaliacao = await this.avaliar(argumento);
-            }
+                
+            } */
 
+            const resultadoAvaliacao = await this.avaliar(argumento);
             let valor = resultadoAvaliacao?.hasOwnProperty('valor') ? resultadoAvaliacao.valor : resultadoAvaliacao;
-
             formatoTexto += `${this.paraTexto(valor)} `;
         }
 

--- a/testes/tradutores/tradutor-visualg.test.ts
+++ b/testes/tradutores/tradutor-visualg.test.ts
@@ -57,7 +57,7 @@ describe('Tradutor Reverso JavaScript -> Delégua', () => {
             const resultado = tradutor.traduzir(codigo);
             expect(resultado).toBeTruthy();
             expect(resultado).toMatch(/var i = 0/i);
-            expect(resultado).toMatch(/para \(i = 1 ;i < 10; i = i \+ 1\)/i);
+            expect(resultado).toMatch(/para \(i = 1 ;i <= 10; i = i \+ 1\)/i);
         })
 
         it('cálculo imc com se/senão', () => {


### PR DESCRIPTION
`leia()` do VisuAlg nunca chama `visitarExpressaoAtribuicaoSobrescrita` porque a variável que recebe o valor é passada por argumento;
- Ajustes no avaliador sintático quanto ao número de iterações de uma instrução `para` no VisuAlg;
- Remoção temporária de lógica de resolução de chamada em `avaliarArgumentosEscreva` (avaliar remover completamente mais futuramente);
- Demais remoções de lógicas que foram reescritas no Avaliador Sintático de Delégua.