### PR TITLE
Modificando o avaliador sintático do VisuAlg para suportar operações matemáticas na condição da declaração `para`

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -688,38 +688,14 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
 
         this.consumir(tiposDeSimbolos.DE, "Esperado palavra reservada 'de' após variáve de controle de 'para'.");
 
-        let literalOuVariavelInicio;
-        switch (this.simbolos[this.atual].tipo) {
-            case tiposDeSimbolos.IDENTIFICADOR:
-                let identificadorInicio = this.avancarEDevolverAnterior();
-                literalOuVariavelInicio = new Variavel(this.hashArquivo, identificadorInicio);
-                break;
-            case tiposDeSimbolos.NUMERO: 
-                let numeroInicio = this.avancarEDevolverAnterior();
-                literalOuVariavelInicio = new Literal(this.hashArquivo, Number(simboloPara.linha), numeroInicio.literal);
-                break;
-            default:
-                throw this.erro(this.simbolos[this.atual], "Esperado literal ou variável após 'de' em declaração 'para'.");
-        }
+        const literalOuVariavelInicio = this.adicaoOuSubtracao();
 
         this.consumir(
             tiposDeSimbolos.ATE,
             "Esperado palavra reservada 'ate' após valor inicial do laço de repetição 'para'."
         );
 
-        let literalOuVariavelFim;
-        switch (this.simbolos[this.atual].tipo) {
-            case tiposDeSimbolos.IDENTIFICADOR:
-                let identificadorFim = this.avancarEDevolverAnterior();
-                literalOuVariavelFim = new Variavel(this.hashArquivo, identificadorFim);
-                break;
-            case tiposDeSimbolos.NUMERO: 
-                let numeroFim = this.avancarEDevolverAnterior();
-                literalOuVariavelFim = new Literal(this.hashArquivo, Number(simboloPara.linha), numeroFim.literal);
-                break;
-            default:
-                throw this.erro(this.simbolos[this.atual], "Esperado literal ou variável após 'ate' em declaração 'para'.");
-        }
+        const literalOuVariavelFim = this.adicaoOuSubtracao();
 
         this.consumir(
             tiposDeSimbolos.FACA,


### PR DESCRIPTION
Código de testes:

```
algoritmo "Ex-038"

var
    li : vetor[0..9] de inteiro
    i, j, k, cont : inteiro
    resposta: caractere

inicio

    i <- 0
    k <- 0

    enquanto resposta <> "N" faca
        escreval("---------------------------")
        escreval("Digite a", i + 1, "a nota: ")
        leia(li[i])

        j <- 0
        // cont <- i - 1 // cont criada para substituir o i - 1

        // para j de 0 ate cont faca // cont funciona
        para j de 0 ate i - 1 faca // i - 1 não é aceito
            se li[i] = li[j] entao
                escreval("Valores repetidos não serão computados.")
                li[i] = ""
                i <- i - 1
                interrompa
            fimse
        fimpara

        escreval ("Você deseja inserir mais um número? (S/N)")
        leia(resposta)

        i <- i + 1
    fimenquanto

    para k de 0 ate i faca
        escreva(li[k], " ")
    fimPara

fimAlgoritmo
```