### PR TITLE
Casos avançados de tipagem no VisuAlg

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-visualg.ts
@@ -37,6 +37,12 @@ import tiposDeSimbolos from '../../tipos-de-simbolos/visualg';
 
 export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
     blocoPrincipalIniciado: boolean;
+    dicionarioTiposPrimitivos = {
+        'caractere': 'texto',
+        'inteiro': 'número',
+        'logico': 'lógico',
+        'real': 'número'
+    }
 
     constructor() {
         super();
@@ -192,17 +198,17 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
                                     tiposDeSimbolos.DE,
                                     'Esperado palavra reservada "de" após declaração de dimensões de vetor.'
                                 );
+
+                                const simboloTipo = this.simbolos[this.atual];
                                 if (
-                                    !this.verificarSeSimboloAtualEIgualA(
-                                        tiposDeSimbolos.CARACTERE,
+                                    ![tiposDeSimbolos.CARACTERE,
                                         tiposDeSimbolos.INTEIRO,
                                         tiposDeSimbolos.LOGICO,
                                         tiposDeSimbolos.REAL,
-                                        tiposDeSimbolos.VETOR
-                                    )
+                                        tiposDeSimbolos.VETOR].includes(simboloTipo.tipo)
                                 ) {
                                     throw this.erro(
-                                        this.simbolos[this.atual],
+                                        simboloTipo,
                                         'Tipo de variável não conhecido para inicialização de vetor.'
                                     );
                                 }
@@ -213,9 +219,11 @@ export class AvaliadorSintaticoVisuAlg extends AvaliadorSintaticoBase {
                                             this.hashArquivo,
                                             Number(dadosVariaveis.simbolo.linha),
                                             this.criarVetorNDimensional(dimensoes)
-                                        )
+                                        ),
+                                        this.dicionarioTiposPrimitivos[simboloTipo.lexema.toLowerCase()]
                                     )
                                 );
+                                this.atual++;
                                 break;
                         }
                     }

--- a/fontes/declaracoes/var.ts
+++ b/fontes/declaracoes/var.ts
@@ -2,14 +2,23 @@ import { Construto } from '../construtos';
 import { InterpretadorInterface, SimboloInterface } from '../interfaces';
 import { Declaracao } from './declaracao';
 
+/**
+ * Uma declaração de variável.
+ */
 export class Var extends Declaracao {
     simbolo: SimboloInterface;
     inicializador: Construto;
+    tipo: 'texto' | 'numero' | 'longo' | 'lógico' | 'nulo' | 'vetor' | 'módulo' | 'dicionário' | 'função' | 'símbolo' | undefined
 
-    constructor(simbolo: SimboloInterface, inicializador: Construto) {
+    constructor(
+        simbolo: SimboloInterface, 
+        inicializador: Construto,
+        tipo: 'texto' | 'numero' | 'longo' | 'lógico' | 'nulo' | 'vetor' | 'módulo' | 'dicionário' | 'função' | 'símbolo' | undefined = undefined
+    ) {
         super(Number(simbolo.linha), simbolo.hashArquivo);
         this.simbolo = simbolo;
         this.inicializador = inicializador;
+        this.tipo = tipo;
     }
 
     async aceitar(visitante: InterpretadorInterface): Promise<any> {

--- a/fontes/interfaces/pilha-escopos-execucao-interface.ts
+++ b/fontes/interfaces/pilha-escopos-execucao-interface.ts
@@ -7,7 +7,7 @@ import { VariavelInterface } from './variavel-interface';
 export interface PilhaEscoposExecucaoInterface extends PilhaInterface<EscopoExecucao> {
     atribuirVariavel(simbolo: SimboloInterface, valor: any): void;
     atribuirVariavelEm(distancia: number, simbolo: SimboloInterface, valor: any): void;
-    definirVariavel(nomeVariavel: string, valor: any): void;
+    definirVariavel(nomeVariavel: string, valor: any, subtipo?: string): void;
     elementos(): number;
     naPosicao(posicao: number): EscopoExecucao;
     obterEscopoPorTipo(idChamada: string): EscopoExecucao | undefined;

--- a/fontes/interfaces/variavel-interface.ts
+++ b/fontes/interfaces/variavel-interface.ts
@@ -12,4 +12,5 @@ export interface VariavelInterface {
         | 'símbolo'
         | 'objeto'
         | 'módulo';
+    subtipo?: 'texto' | 'número' | 'longo' | 'lógico'
 }

--- a/fontes/interpretador/dialetos/visualg/interpretador-visualg-com-depuracao.ts
+++ b/fontes/interpretador/dialetos/visualg/interpretador-visualg-com-depuracao.ts
@@ -111,6 +111,10 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
 
             let alvo = promises[0];
             let indice = promises[1];
+            const subtipo = alvo.hasOwnProperty('subtipo') ? 
+                alvo.subtipo :
+                undefined;
+
             if (alvo.hasOwnProperty('valor')) {
                 alvo = alvo.valor;
             }
@@ -119,7 +123,23 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
                 indice = indice.valor;
             }
 
-            alvo[indice] = valor;
+            let valorResolvido;
+            switch (subtipo) {
+                case 'texto':
+                    valorResolvido = String(valor);
+                    break;
+                case 'número':
+                    valorResolvido = Number(valor);
+                    break;
+                case 'lógico':
+                    valorResolvido = Boolean(valor);
+                    break;
+                default:
+                    valorResolvido = valor;
+                    break;
+            }
+
+            alvo[indice] = valorResolvido;
         }
     }
 

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -850,8 +850,13 @@ export class InterpretadorBase implements InterpretadorInterface {
      */
     async visitarDeclaracaoVar(declaracao: Var): Promise<any> {
         const valorFinal = await this.avaliacaoDeclaracaoVar(declaracao);
+        
+        let subtipo;
+        if (declaracao.tipo !== undefined) {
+            subtipo = declaracao.tipo;
+        }
 
-        this.pilhaEscoposExecucao.definirVariavel(declaracao.simbolo.lexema, valorFinal);
+        this.pilhaEscoposExecucao.definirVariavel(declaracao.simbolo.lexema, valorFinal, subtipo);
 
         return null;
     }

--- a/fontes/interpretador/pilha-escopos-execucao.ts
+++ b/fontes/interpretador/pilha-escopos-execucao.ts
@@ -52,16 +52,23 @@ export class PilhaEscoposExecucao implements PilhaEscoposExecucaoInterface {
         }
     }
 
-    definirVariavel(nomeVariavel: string, valor: any) {
+    definirVariavel(nomeVariavel: string, valor: any, subtipo?: string) {
         const variavel = this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel];
         const tipo = variavel && variavel.hasOwnProperty('tipo') ? 
             variavel.tipo : 
             inferirTipoVariavel(valor);
 
-        this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel] = {
+        let elementoAlvo = {
             valor,
-            tipo: tipo
+            tipo: tipo,
+            subtipo: undefined
         };
+
+        if (subtipo !== undefined) {
+            (elementoAlvo.subtipo as any) = subtipo;
+        }
+
+        this.pilha[this.pilha.length - 1].ambiente.valores[nomeVariavel] = elementoAlvo;
     }
 
     atribuirVariavelEm(distancia: number, simbolo: any, valor: any): void {


### PR DESCRIPTION
- Anotando um subtipo de variável em casos que o vetor é tipado (exemplo: VisuAlg);
- Convertendo um valor ao atribuir valor em vetor (VisuAlg).