### PR TITLE
Resolvendo bug de primitiva `filtrarPor()`.

### DIFF
--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -405,8 +405,10 @@ export default function (interpretador: InterpretadorInterface, pilhaEscoposExec
 
             const resultados = [];
             for (let indice = 0; indice < valorVetor.length; ++indice) {
-                (await valorFuncaoFiltragem.chamar(interpretador, [valorVetor[indice]])) &&
-                    resultados.push(await valorFuncaoFiltragem.chamar(interpretador, [valorVetor[indice]]));
+                const deveRetornarValor = await valorFuncaoFiltragem.chamar(interpretador, [valorVetor[indice]]);
+                if (deveRetornarValor) {
+                    resultados.push(valorVetor[indice]);
+                }
             }
 
             return resultados;

--- a/fontes/estruturas/delegua-funcao.ts
+++ b/fontes/estruturas/delegua-funcao.ts
@@ -63,6 +63,7 @@ export class DeleguaFuncao extends Chamavel {
             };
         }
 
+        (interpretador as any).proximoEscopo = 'funcao';
         const retornoBloco: any = await interpretador.executarBloco(this.declaracao.corpo, ambiente);
         if (retornoBloco instanceof RetornoQuebra) {
             return retornoBloco.valor;


### PR DESCRIPTION
- Correção de bug na biblioteca global;
- Marcando escopo como "função" para depuração funcionar corretamente na chamada de uma função da biblioteca global.