### PR TITLE
Inferindo o tipo da variável ou literal quando tipo não é explícito na hora de chamar um método de primitiva.

### DIFF
--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -3,7 +3,7 @@ export default {
     apararFim: (texto: string) => texto.trimEnd(),
     apararInicio: (texto: string) => texto.trimStart(),
     concatenar: (...texto: string[]) => "".concat(...texto),
-    dividir: (texto: string, divisor: any, limite: number) => [...texto.split(divisor, limite)],
+    dividir: (texto: string, divisor: any, limite: number) => texto.split(divisor || ' ', limite),
     fatiar: (texto: string, inicio: number, fim: number) => texto.slice(inicio, fim),
     inclui: (texto: string, elemento: any) => texto.includes(elemento),
     maiusculo: (texto: string) => texto.toUpperCase(),

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -1234,7 +1234,12 @@ export class InterpretadorBase implements InterpretadorInterface {
             return objeto.componentes[expressao.simbolo.lexema] || null;
         }
 
-        switch (variavelObjeto.tipo) {
+        let tipoObjeto = variavelObjeto.tipo;
+        if (tipoObjeto === null || tipoObjeto === undefined) {
+            tipoObjeto = inferirTipoVariavel(variavelObjeto as any);
+        }
+
+        switch (tipoObjeto) {
             case 'texto':
                 const metodoDePrimitivaTexto: Function = primitivasTexto[expressao.simbolo.lexema];
                 if (metodoDePrimitivaTexto) {
@@ -1252,7 +1257,7 @@ export class InterpretadorBase implements InterpretadorInterface {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 expressao.nome,
-                'Você só pode acessar métodos do objeto e dicionários.',
+                `Método para objeto ou primitiva não encontrado: ${expressao.simbolo.lexema}.`,
                 expressao.linha
             )
         );


### PR DESCRIPTION
Resolve #377 