### PR TITLE
Usando resolução de expressão ao invés de literal para avaliador sintático do Portugol Studio.

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-portugol-studio.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-portugol-studio.ts
@@ -402,14 +402,12 @@ export class AvaliadorSintaticoPortugolStudio extends AvaliadorSintaticoBase {
             );
 
             // Inicializações de variáveis podem ter valores definidos.
-            let valorInicializacao = 0;
+            let valorInicializacao: Construto = new Literal(this.hashArquivo, Number(simboloInteiro.linha), 0);
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
-                const literalInicializacao = this.consumir(tiposDeSimbolos.INTEIRO,
-                    'Esperado literal inteiro após símbolo de igual em declaração de variável.');
-                valorInicializacao = Number(literalInicializacao.literal);
+                valorInicializacao = this.expressao();
             }
 
-            inicializacoes.push(new Var(identificador, new Literal(this.hashArquivo, Number(simboloInteiro.linha), valorInicializacao)));
+            inicializacoes.push(new Var(identificador, valorInicializacao));
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
         return inicializacoes;

--- a/testes/portugol-studio/avaliador-sintatico.test.ts
+++ b/testes/portugol-studio/avaliador-sintatico.test.ts
@@ -227,6 +227,23 @@ describe('Avaliador sintático (Portugol Studio)', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes.length).toBeGreaterThan(0);
             });
+
+            it('Atribuição de Variáveis', () => {
+                const resultado = lexador.mapear([
+                    'programa {',
+                    '    funcao inicio() {',
+                    '        inteiro a = 2',
+                    '        inteiro b = a',
+                    '        escreva("variáveis a:",a," b:",b)',
+                    '    }',
+                    '}'
+                ], -1);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(resultado, -1);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes.length).toBeGreaterThan(0);
+            });
         });
 
         describe('Casos de Falha', () => {


### PR DESCRIPTION
Resolve #429 