### PR TITLE
[Potigol] Expansão de propriedades em escopo de chamada de método

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -724,7 +724,7 @@
             "runtimeArgs": [
                 "--inspect-brk",
                 "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                "potigol/interpretador",
+                "potigol/interpretador.test",
                 "--runInBand"
             ],
             "skipFiles": [

--- a/fontes/estruturas/delegua-classe.ts
+++ b/fontes/estruturas/delegua-classe.ts
@@ -4,11 +4,15 @@ import { Chamavel } from './chamavel';
 import { DeleguaFuncao } from './delegua-funcao';
 import { ObjetoDeleguaClasse } from './objeto-delegua-classe';
 
+/**
+ * Estrutura de declaração de classe. 
+ */
 export class DeleguaClasse extends Chamavel {
     nome: string;
     superClasse: DeleguaClasse;
     metodos: { [nome: string]: DeleguaFuncao };
-    propriedades: PropriedadeClasse[]
+    propriedades: PropriedadeClasse[];
+    dialetoRequerExpansaoPropriedadesEspacoVariaveis: boolean;
 
     constructor(nome?: string, superClasse?: any, metodos?: any, propriedades?: PropriedadeClasse[]) {
         super();
@@ -43,7 +47,22 @@ export class DeleguaClasse extends Chamavel {
     }
 
     paraTexto(): string {
-        return `<classe ${this.nome}>`;
+        let texto = `<classe ${this.nome}`;
+        for (let propriedade of this.propriedades) {
+            texto += ` ${propriedade.nome}`;
+            if (propriedade.tipo) {
+                texto += `:${propriedade.tipo}`;
+            }
+
+            texto += ' ';
+        }
+
+        texto += '>';
+        return texto;
+    }
+
+    toString(): string {
+        return this.paraTexto();
     }
 
     aridade(): number {

--- a/fontes/estruturas/delegua-funcao.ts
+++ b/fontes/estruturas/delegua-funcao.ts
@@ -7,6 +7,7 @@ import { ObjetoDeleguaClasse } from './objeto-delegua-classe';
 import { FuncaoConstruto } from '../construtos';
 import { ArgumentoInterface } from '../interpretador/argumento-interface';
 import { PilhaEscoposExecucaoInterface } from '../interfaces/pilha-escopos-execucao-interface';
+import { inferirTipoVariavel } from '../interpretador/inferenciador';
 
 /**
  * Qualquer função declarada em código é uma DeleguaFuncao.
@@ -63,6 +64,16 @@ export class DeleguaFuncao extends Chamavel {
                 tipo: 'objeto',
                 imutavel: false
             };
+
+            if (this.instancia.classe.dialetoRequerExpansaoPropriedadesEspacoVariaveis) {
+                for (let [nomeCampo, valorCampo] of Object.entries(this.instancia.campos)) {
+                    ambiente.valores[nomeCampo] = {
+                        valor: valorCampo,
+                        tipo: inferirTipoVariavel(valorCampo as any),
+                        imutavel: false
+                    };
+                }
+            }
         }
 
         // TODO: Repensar essa dinâmica para análise semântica.

--- a/fontes/interpretador/dialetos/potigol/interpretador-potigol.ts
+++ b/fontes/interpretador/dialetos/potigol/interpretador-potigol.ts
@@ -9,7 +9,11 @@ import { registrarBibliotecaGlobalPotigol } from "../../../bibliotecas/dialetos/
 import primitivasNumero from "../../../bibliotecas/dialetos/potigol/primitivas-numero";
 import primitivasTexto from "../../../bibliotecas/dialetos/potigol/primitivas-texto";
 import primitivasVetor from "../../../bibliotecas/dialetos/potigol/primitivas-vetor";
+import { AcessoMetodo } from "../../../construtos";
 
+/**
+ * Uma implementação do interpretador de Potigol.
+ */
 export class InterpretadorPotigol extends InterpretadorBase {
     constructor(
         diretorioBase: string,
@@ -18,6 +22,7 @@ export class InterpretadorPotigol extends InterpretadorBase {
         funcaoDeRetornoMesmaLinha: Function = null
     ) {
         super(diretorioBase, performance, funcaoDeRetorno, funcaoDeRetornoMesmaLinha);
+        this.expandirPropriedadesDeObjetosEmEspacoVariaveis = true;
 
         registrarBibliotecaGlobalPotigol(this, this.pilhaEscoposExecucao);
     }
@@ -27,7 +32,7 @@ export class InterpretadorPotigol extends InterpretadorBase {
      * @param expressao A expressão de acesso.
      * @returns O resultado da execução.
      */
-    async visitarExpressaoAcessoMetodo(expressao: any): Promise<any> {
+    async visitarExpressaoAcessoMetodo(expressao: AcessoMetodo): Promise<any> {
         const variavelObjeto: VariavelInterface = await this.avaliar(expressao.objeto);
         const objeto = variavelObjeto.hasOwnProperty('valor') ? variavelObjeto.valor : variavelObjeto;
 
@@ -86,7 +91,7 @@ export class InterpretadorPotigol extends InterpretadorBase {
 
         return Promise.reject(
             new ErroEmTempoDeExecucao(
-                expressao.nome,
+                expressao.simbolo,
                 `Método para objeto ou primitiva não encontrado: ${expressao.simbolo.lexema}.`,
                 expressao.linha
             )

--- a/testes/potigol/interpretador.test.ts
+++ b/testes/potigol/interpretador.test.ts
@@ -25,7 +25,7 @@ describe('Interpretador', () => {
             expect(retornoInterpretador.erros).toHaveLength(0);
         });
 
-        describe.skip('Tipos e objetos', () => {
+        describe('Tipos e objetos', () => {
             it('Trivial', async () => {
                 const retornoLexador = lexador.mapear([
                     'tipo Quadrado',


### PR DESCRIPTION
Implementando expansão de propriedades de classe no escopo para o dialeto Potigol.

Ou seja, em Potigol não é necessário utilizar a palavra `isto` dentro de um método para acessar uma propriedade de um objeto.