### PR TITLE
Corrigindo bug reportado pelo Delpupo no Discord.

### DIFF
--- a/fontes/interpretador/dialetos/visualg/interpretador-visualg-com-depuracao.ts
+++ b/fontes/interpretador/dialetos/visualg/interpretador-visualg-com-depuracao.ts
@@ -143,7 +143,6 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
     }
 
     async visitarDeclaracaoPara(declaracao: Para): Promise<any> {
-        // const cloneDeclaracao = JSON.parse(JSON.stringify(declaracao)) as Para;
         const cloneDeclaracao = _.cloneDeep(declaracao) as Para;
         const corpoExecucao = cloneDeclaracao.corpo as Bloco;
         if (cloneDeclaracao.inicializador !== null) {
@@ -155,7 +154,6 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
             }
         }
 
-        // cloneDeclaracao.inicializada = true;
         const escopoAtual = this.pilhaEscoposExecucao.topoDaPilha();
         switch (this.comando) {
             case 'proximo':
@@ -170,7 +168,6 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
                 }
 
                 escopoAtual.emLacoRepeticao = false;
-                // declaracao.inicializada = false;
                 return null;
             default:
                 let retornoExecucao: any;
@@ -195,8 +192,7 @@ export class InterpretadorVisuAlgComDepuracao extends InterpretadorComDepuracao 
                         return Promise.reject(erro);
                     }
                 }
-                // escopoAtual.emLacoRepeticao = false;
-                // declaracao.inicializada = false;
+
                 return retornoExecucao;
         }
     }

--- a/fontes/interpretador/dialetos/visualg/interpretador-visualg.ts
+++ b/fontes/interpretador/dialetos/visualg/interpretador-visualg.ts
@@ -146,8 +146,8 @@ export class InterpretadorVisuAlg extends InterpretadorBase {
 
     async visitarDeclaracaoPara(declaracao: Para): Promise<any> {
         if (declaracao.inicializador !== null) {
-            await comum.resolverIncrementoPara(this, declaracao);
             await this.avaliar(declaracao.inicializador);
+            await comum.resolverIncrementoPara(this, declaracao);
         }
 
         let retornoExecucao: any;


### PR DESCRIPTION
As implementações do interpretador e do interpretador com depuração do VisuAlg são levemente diferentes, o que causava uma situação em que códigos VisuAlg funcionavam corretamente na extensão (com depuração), mas não funcionavam por linha de comando (sem depuração).