### PR TITLE
Um argumento de função pode ser nulo ou indefinido. Devemos testar isso antes de chamar `hasOwnProperty`.

### DIFF
--- a/fontes/estruturas/delegua-funcao.ts
+++ b/fontes/estruturas/delegua-funcao.ts
@@ -53,7 +53,7 @@ export class DeleguaFuncao extends Chamavel {
                 argumento = parametro['padrao'] ? parametro['padrao'].valor : null;
             }
 
-            ambiente.valores[nome] = argumento.hasOwnProperty('valor') ? argumento.valor : argumento;
+            ambiente.valores[nome] = argumento && argumento.hasOwnProperty('valor') ? argumento.valor : argumento;
         }
 
         if (this.instancia !== undefined) {


### PR DESCRIPTION
Condição verificada em [`liquido`](https://github.com/DesignLiquido/liquido).