### PR TITLE
Mudando lógica de definição de argumentos com abrangência múltipla: `minhaFuncao(*multiplosArgumentos)`.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -1219,8 +1219,6 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface<SimboloIn
                 parametro.valorPadrao = this.primario();
             }
 
-            if (parametro.abrangencia === 'multiplo') break;
-
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
                 let tipoDadoParametro = this.verificarDefinicaoTipoAtual();
                 parametro.tipoDado = {
@@ -1232,6 +1230,7 @@ export class AvaliadorSintatico implements AvaliadorSintaticoInterface<SimboloIn
             }
 
             parametros.push(parametro as ParametroInterface);
+            if (parametro.abrangencia === 'multiplo') break;
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
         return parametros;
     }

--- a/fontes/estruturas/delegua-funcao.ts
+++ b/fontes/estruturas/delegua-funcao.ts
@@ -48,12 +48,24 @@ export class DeleguaFuncao extends Chamavel {
             const parametro = parametros[i];
 
             const nome = parametro['nome'].lexema;
-            let argumento = argumentos[i];
-            if (argumentos[i] === null) {
-                argumento = parametro['padrao'] ? parametro['padrao'].valor : null;
-            }
+            if (parametro.abrangencia === 'multiplo') {
+                const argumentosResolvidos = [];
+                for (let indiceArgumentoAtual = i; indiceArgumentoAtual < argumentos.length; indiceArgumentoAtual++) {
+                    const argumentoAtual = argumentos[indiceArgumentoAtual];
+                    argumentosResolvidos.push(argumentoAtual && argumentoAtual.hasOwnProperty('valor') ? argumentoAtual.valor : argumentoAtual);
+                }
 
-            ambiente.valores[nome] = argumento && argumento.hasOwnProperty('valor') ? argumento.valor : argumento;
+                // TODO: Verificar se `imutavel` é `true` aqui mesmo.
+                ambiente.valores[nome] = { tipo: 'vetor', valor: argumentosResolvidos, imutavel: true };
+            } else {
+                let argumento = argumentos[i];
+                if (argumentos[i] === null) {
+                    argumento = parametro['padrao'] ? parametro['padrao'].valor : null;
+                }
+    
+                ambiente.valores[nome] = argumento && argumento.hasOwnProperty('valor') ? argumento.valor : argumento;
+            }
+            
         }
 
         if (this.instancia !== undefined) {

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -637,6 +637,9 @@ export class InterpretadorBase implements InterpretadorInterface {
                     argumentos.push(null);
                 }
             } else {
+                // TODO: Aparentemente isso aqui nunca funcionou. 
+                // Avaliar de simplesmente apagar este código, e usar o que foi 
+                // implementado em `DeleguaFuncao.chamar`.
                 if (
                     parametros &&
                     parametros.length > 0 &&


### PR DESCRIPTION
Achamos um bug enquanto implementávamos coisas em Liquido.