### PR TITLE
Traduzir funcoes em python

### DIFF
--- a/fontes/tradutores/tradutor-python.ts
+++ b/fontes/tradutores/tradutor-python.ts
@@ -79,6 +79,38 @@ export class TradutorPython implements TradutorInterface<Declaracao> {
         }
     }
 
+    traduzirFuncoesNativas(metodo: string): string {
+        switch (metodo.toLowerCase()) {
+            case 'adicionar':
+            case 'empilhar':
+                return 'append';
+            case 'fatiar':
+                return 'slice';
+            case 'inclui':
+                return 'in';
+            case 'inverter':
+                return 'reverse';
+            case 'juntar':
+                return 'join';
+            case 'ordenar':
+                return 'sort';
+            case 'removerprimeiro':
+                return 'pop(0)';
+            case 'removerultimo':
+                return 'pop';
+            case 'tamanho':
+                return 'len';
+            case 'maiusculo':
+                return 'upper';
+            case 'minusculo':
+                return 'lower';
+            case 'substituir':
+                return 'replace';
+            default:
+                return metodo;
+        }
+    }
+
     logicaComumBlocoEscopo(declaracoes: Declaracao[]): string {
         let resultado = '';
         this.indentacao += 4;

--- a/fontes/tradutores/tradutor-python.ts
+++ b/fontes/tradutores/tradutor-python.ts
@@ -336,7 +336,6 @@ export class TradutorPython implements TradutorInterface<Declaracao> {
 
         resultado += this.logicaComumBlocoEscopo(metodoClasse.funcao.corpo);
         resultado += ' '.repeat(this.indentacao) + '\n';
-
         this.indentacao -= 4;
         return resultado;
     }
@@ -363,27 +362,28 @@ export class TradutorPython implements TradutorInterface<Declaracao> {
         const retorno = `${this.dicionarioConstrutos[chamada.entidadeChamada.constructor.name](
             chamada.entidadeChamada
         )}`;
+
         resultado += retorno;
 
-        if(resultado.includes(".") && !resultado.includes("(")){
+        if(!resultado.includes("in ") && !resultado.includes("len") && !resultado.includes("pop(")){
             resultado += '(';
         }
 
         if(!resultado.includes("len(")){
             for (let parametro of chamada.argumentos) {
-                const parametroPego = this.dicionarioConstrutos[parametro.constructor.name](parametro)
-                if(!retorno.includes(".")){
-                    const novoResultado = `${parametroPego} ${resultado}`;
-                    resultado = novoResultado
+                const parametroTratado = this.dicionarioConstrutos[parametro.constructor.name](parametro)
+                if(resultado.includes("in ") || resultado.includes("len")){
+                    resultado = `${parametroTratado} ${resultado}`
                 }else{
-                    resultado += parametroPego + ', ';
+                    resultado += parametroTratado + ', ';
                 }
             }
 
-            if (chamada.argumentos.length > 0 && resultado.includes(".")) {
+            if (chamada.argumentos.length > 0 && (!resultado.includes("in ") && !resultado.includes("len"))) {
                 resultado = resultado.slice(0, -2);
             }
-            if(resultado.includes(".") && !resultado.includes(")")){
+
+            if(!resultado.includes(")") && !resultado.includes("in ")){
                 resultado += ')';
             }
         }

--- a/testes/tradutores/tradutor-python.test.ts
+++ b/testes/tradutores/tradutor-python.test.ts
@@ -16,7 +16,7 @@ describe('Tradutor Delégua -> Python', () => {
 
         it('Olá mundo', () => {
             const retornoLexador = lexador.mapear(
-                ['escreva("Olá mundo")'], 
+                ['escreva("Olá mundo")'],
                 -1
             );
 
@@ -28,9 +28,45 @@ describe('Tradutor Delégua -> Python', () => {
             expect(resultado).toMatch(/print\('Olá mundo'\)/i);
         });
 
+        it('funções nativas', () => {
+            const retornoLexador = lexador.mapear(
+                [
+                    'var vetor = [1, 2];',
+                    'vetor.adicionar(3);',
+                    'vetor.empilhar(4);',
+                    'vetor.removerUltimo();',
+                    'vetor.inverter();',
+                    'vetor.inclui(2)',
+                    'vetor.ordenar()',
+                    'vetor.removerPrimeiro();',
+
+                    'var nome = \'delégua > égua\';',
+                    'nome = nome.maiusculo();',
+                    'nome = nome.minusculo();',
+                ],
+                -1
+            );
+            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+            const resultado = tradutor.traduzir(retornoAvaliadorSintatico.declaracoes);
+            expect(resultado).toBeTruthy();
+            expect(resultado).toMatch(/vetor = \[1, 2\]/i);
+            expect(resultado).toMatch(/vetor.append\(3\)/i);
+            expect(resultado).toMatch(/vetor.append\(4\)/i);
+            expect(resultado).toMatch(/vetor.pop\(\)/i);
+            expect(resultado).toMatch(/vetor.reverse()/i)
+            expect(resultado).toMatch(/2 in vetor/i)
+            expect(resultado).toMatch(/vetor.sort()/i)
+            expect(resultado).toMatch(/vetor.pop\(0\)/i);
+
+
+            expect(resultado).toMatch(/nome.upper\(\)/i);
+            expect(resultado).toMatch(/nome.lower\(\)/i);
+        });
+
         it('Agrupamento', () => {
             const retornoLexador = lexador.mapear(
-                ['escreva((2 * 3) + (4 ^ 2))'], 
+                ['escreva((2 * 3) + (4 ^ 2))'],
                 -1
             );
 
@@ -52,7 +88,7 @@ describe('Tradutor Delégua -> Python', () => {
                     'const NOME2 = \'delegua\';',
                     'const nomeCompleto3 = \'delegua completo3\';',
                     'const NomeCompleto4 = \'delegua completo4\';',
-                ], 
+                ],
                 -1
             );
 
@@ -79,7 +115,7 @@ describe('Tradutor Delégua -> Python', () => {
                     'var f = nulo',
                     'const g = \'olá\'',
                     '2 * 2'
-                ], 
+                ],
                 -1
             );
 
@@ -494,7 +530,7 @@ describe('Tradutor Delégua -> Python', () => {
                 ],
                 -1
             );
-            
+
             const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
             const resultado = tradutor.traduzir(retornoAvaliadorSintatico.declaracoes);

--- a/testes/tradutores/tradutor-python.test.ts
+++ b/testes/tradutores/tradutor-python.test.ts
@@ -328,6 +328,7 @@ describe('Tradutor Delégua -> Python', () => {
             const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
             const resultado = tradutor.traduzir(retornoAvaliadorSintatico.declaracoes);
+            console.log(resultado)
             expect(resultado).toBeTruthy();
             expect(resultado).toMatch(/def minhaFuncao\(textoQualquer\):/i);
             expect(resultado).toMatch(/return textoQualquer/i);
@@ -455,6 +456,7 @@ describe('Tradutor Delégua -> Python', () => {
             const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
             const resultado = tradutor.traduzir(retornoAvaliadorSintatico.declaracoes);
+            console.log(resultado)
             expect(resultado).toBeTruthy();
             expect(resultado).toMatch(/class Teste:/i);
             expect(resultado).toMatch(/def __init__\(self, abc\):/i);


### PR DESCRIPTION
Nesta PR traduzo as funções Delégua para Python, também alterei a forma de mostrar a tradução para métodos específicos de python:

```typescript

    traduzirConstrutoChamada(chamada: Chamada): string {
        let resultado = '';

        const retorno = `${this.dicionarioConstrutos[chamada.entidadeChamada.constructor.name](
            chamada.entidadeChamada
        )}`;
        resultado += retorno;

        if(resultado.includes(".") && !resultado.includes("(")){
            resultado += '(';
        }

        if(!resultado.includes("len(")){
            for (let parametro of chamada.argumentos) {
                const parametroPego = this.dicionarioConstrutos[parametro.constructor.name](parametro)
                if(!retorno.includes(".")){
                    const novoResultado = `${parametroPego} ${resultado}`;
                    resultado = novoResultado
                }else{
                    resultado += parametroPego + ', ';
                }
            }

            if (chamada.argumentos.length > 0 && resultado.includes(".")) {
                resultado = resultado.slice(0, -2);
            }
            if(resultado.includes(".") && !resultado.includes(")")){
                resultado += ')';
            }
        }

        return resultado;
    }
``` 