### PR TITLE
Tipo retorno funcoes

### DIFF
--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -188,7 +188,8 @@ export class InterpretadorBase implements InterpretadorInterface {
             tipoDe instanceof TipoDe ||
             tipoDe instanceof Unario ||
             tipoDe instanceof Variavel ||
-            tipoDe instanceof Agrupamento
+            tipoDe instanceof Agrupamento ||
+            tipoDe instanceof Chamada
         ) {
             tipoDe = await this.avaliar(tipoDe);
             return tipoDe.tipo || inferirTipoVariavel(tipoDe);


### PR DESCRIPTION
Está pull request vem dar resposta a issus #604 

O problema consistia no facto não ter se verificado se o que vem após do `tipo de ` era uma chama
Aqui está a resolução:

```typescript
if (
    tipoDe instanceof Binario ||
    tipoDe instanceof TipoDe ||
    tipoDe instanceof Unario ||
    tipoDe instanceof Variavel ||
    tipoDe instanceof Agrupamento ||
    tipoDe instanceof Chamada
) {
    tipoDe = await this.avaliar(tipoDe);
    return tipoDe.tipo || inferirTipoVariavel(tipoDe);
}
``` 