### PR TITLE
retorno de itens removido

### DIFF
--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -17,12 +17,20 @@ export default {
         interpretador: VisitanteComumInterface,
         vetor: Array<any>,
         inicio: number,
-        excluirQuantidade: number,
+        excluirQuantidade?: number,
         ...items: any[]
     ): Promise<any> => {
-        const elementos = !items.length
+        let elementos = [];
+
+        if(excluirQuantidade || excluirQuantidade === 0){
+            elementos = !items.length
             ? vetor.splice(inicio, excluirQuantidade)
             : vetor.splice(inicio, excluirQuantidade, ...items);
+        } else {
+            elementos = !items.length
+            ? vetor.splice(inicio)
+            : vetor.splice(inicio, ...items);
+        }
         return Promise.resolve(elementos);
     },
     fatiar: (interpretador: VisitanteComumInterface, vetor: Array<any>, inicio: number, fim: number): Promise<any> =>

--- a/testes/primitivas/primitivas-vetor.test.ts
+++ b/testes/primitivas/primitivas-vetor.test.ts
@@ -129,6 +129,14 @@ describe('Primitivas de vetor', () => {
             expect(vetor).toStrictEqual([1, 'texto1', 'texto2', 5]);
             expect(resultado).toStrictEqual([2, 3, 4]);
         });
+
+        it('Apenas um parâmetro', async () => {
+            let vetor = ['Oscilador', 'Circuito', 'Modulador', 'Refrigerador']
+            const resultado = await primitivasVetor.encaixar(interpretador, vetor, 1);
+            
+            expect(vetor).toStrictEqual(['Oscilador']);
+            expect(resultado).toStrictEqual([ 'Circuito', 'Modulador', 'Refrigerador' ]);
+        });
     });
 
     describe('somar()', () => {


### PR DESCRIPTION
Saudações esta PR é devido ao problema #645 que se eu passar apenas um parâmetro no método encaixar() nenhum elemento é removido. mas não é que nenhum elemento é removido é todos elementos são removidos e se remover o escreva(elementos) ele só mostra `]` que também é um erro no minimo deveria mostrar **um vector vazio** 

```
var elementos = ['Oscilador', 'Circuito', 'Modulador', 'Refrigerador']

var elementosRemovidos = elementos.encaixar(1)

escreva(elementosRemovidos)
escreva(elementos)
```

Oque eu não percebi foi que    `expect(vetor).toStrictEqual([1, 2, 10, 3]);` no codigo a baixo porque que ele esperava `[1, 2, 10, 3]` acho que o que deveria ser esperado é um vector vazio porque os parametros de inicio e fim no encaixar mostra o valor de inicio maior que o fim então oque deve acontecer nestes casos é apresnetar um vector vazio (o mesmo acontece no Js com metodo slice) por isso que o ``var elementosRemovidos = elementos.encaixar(1)`` Só esta apresentando ``]``
```typescript
it('Inserindo novo elemento', async () => {
            let vetor = [1, 2, 3]
            await primitivasVetor.encaixar(interpretador, vetor, 2, 0, 10);
            expect(vetor).toStrictEqual([1, 2, 10, 3]);
        });
``` 