### PR TITLE
Adição do tipo "módulo". Módulos passam a ser resolvidos na avaliação sintática

### DIFF
--- a/.github/workflows/principal.yml
+++ b/.github/workflows/principal.yml
@@ -18,14 +18,13 @@ jobs:
       with:
         node-version: '20'
     # Maneira tradicional de build, sem cobertura.
+    # Usado quando o `jest-coverage-report-action` dá problema.
     # - name: NPM - Dependências
     #   run: |
     #     sudo npm install
     # - name: Testes unitários
     #   run: |
     #     sudo npm run testes-unitarios
-    # Cobertura de código: Trava o GitHub Actions inteiro por algum motivo.
-    # Reabilitar quando conseguirmos descobrir a causa.
     - uses: ArtiomTr/jest-coverage-report-action@v2
       id: coverage
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DesignLiquido/delegua' }}

--- a/fontes/avaliador-sintatico/README.md
+++ b/fontes/avaliador-sintatico/README.md
@@ -1,6 +1,6 @@
 # Avaliador Sintático
 
-O avaliador sintático (_Parser_) é responsável por transformar os símbolos do Lexador em estruturas de alto nível. Essas estruturas de alto nível são as partes que contêm lógica de programação de fato. É a funcionalidade mais importante de Delégua, já que seu resultado é utilizado para:
+O avaliador sintático (_Parser_) é responsável por transformar os símbolos do Lexador em estruturas de alto nível. Essas estruturas de alto nível são as partes chamadas resolvidas do código, e que podem conter lógica de programação de fato, ou que contêm informações importantes a serem consideradas em etapas posteriores. É a funcionalidade mais importante de Delégua, já que seu resultado é utilizado para:
 
 - Interpretar o código e executá-lo;
 - Formatar o código;
@@ -10,7 +10,7 @@ O avaliador sintático (_Parser_) é responsável por transformar os símbolos d
 Há dois grupos de estruturas de alto nível: Construtos e Declarações. 
 
 - Um Construto não executa por si só;
-- Uma combinação de Construtos forma uma Expressão;
+- Uma combinação de Construtos precisa estar contida em uma Expressão para ser válida;
 - Uma Expressão é um tipo de Declaração;
 - Uma Declaração é um elemento que
     - Pode ser executado pelo Interpretador;

--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -9,6 +9,7 @@ import {
     Expressao,
     Fazer,
     FuncaoDeclaracao,
+    Importar,
     Leia,
     Para,
     ParaCada,
@@ -326,7 +327,7 @@ export abstract class AvaliadorSintaticoBase implements AvaliadorSintaticoInterf
         throw new Error('Método não implementado.');
     }
 
-    protected declaracaoImportar(): Construto {
+    protected declaracaoImportar(): Importar {
         throw new Error('Método não implementado.');
     }
 

--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -9,7 +9,6 @@ import {
     Expressao,
     Fazer,
     FuncaoDeclaracao,
-    Importar,
     Leia,
     Para,
     ParaCada,
@@ -327,7 +326,7 @@ export abstract class AvaliadorSintaticoBase implements AvaliadorSintaticoInterf
         throw new Error('Método não implementado.');
     }
 
-    protected declaracaoImportar(): Importar {
+    protected declaracaoImportar(): Construto {
         throw new Error('Método não implementado.');
     }
 
@@ -353,7 +352,8 @@ export abstract class AvaliadorSintaticoBase implements AvaliadorSintaticoInterf
 
     /**
      * Este é o ponto de entrada de toda a avaliação sintática. É o
-     * único método mencionado na interface do avaliador sintático.
+     * único método mencionado na interface do avaliador sintático, e cada
+     * avaliador sintático deve implementar o seu método.
      * @param retornoLexador O retorno do Lexador.
      * @param hashArquivo O hash do arquivo, gerado pela função `cyrb53`.
      */

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -45,6 +45,7 @@ import {
     Falhar,
     Fazer,
     FuncaoDeclaracao,
+    Importar,
     Leia,
     Para,
     ParaCada,
@@ -874,52 +875,6 @@ export class AvaliadorSintatico
         return declaracoes;
     }
 
-    override declaracaoEnquanto(): Enquanto {
-        try {
-            this.blocos += 1;
-
-            const condicao = this.expressao();
-            const corpo = this.resolverDeclaracao();
-
-            return new Enquanto(condicao, corpo);
-        } finally {
-            this.blocos -= 1;
-        }
-    }
-
-    override declaracaoEscreva(): Escreva {
-        const simboloAtual = this.simbolos[this.atual];
-
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos valores em escreva.");
-
-        const argumentos: Construto[] = [];
-
-        if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.PARENTESE_DIREITO)) {
-            do {
-                argumentos.push(this.expressao());
-            } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
-        }
-
-        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os valores em escreva.");
-
-        // Ponto-e-vírgula é opcional aqui.
-        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
-
-        return new Escreva(Number(simboloAtual.linha), simboloAtual.hashArquivo, argumentos);
-    }
-
-    protected declaracaoExpressao(): Expressao {
-        // Se há decoradores a serem adicionados aqui, obtemo-los agora,
-        // para evitar que outros passos recursivos peguem-los antes.
-        const decoradores = Array.from(this.pilhaDecoradores);
-        this.pilhaDecoradores = [];
-
-        const expressao = this.expressao();
-        // Ponto-e-vírgula é opcional aqui.
-        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
-        return new Expressao(expressao, decoradores);
-    }
-
     protected declaracaoComentarioMultilinha(): Comentario {
         let simboloComentario: SimboloInterface;
         const conteudos: string[] = [];
@@ -944,6 +899,19 @@ export class AvaliadorSintatico
         // Ponto-e-vírgula é opcional aqui.
         this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
         return new Continua(this.simbolos[this.atual - 1]);
+    }
+
+    override declaracaoEnquanto(): Enquanto {
+        try {
+            this.blocos += 1;
+
+            const condicao = this.expressao();
+            const corpo = this.resolverDeclaracao();
+
+            return new Enquanto(condicao, corpo);
+        } finally {
+            this.blocos -= 1;
+        }
     }
 
     override declaracaoEscolha(): Escolha {
@@ -1017,6 +985,39 @@ export class AvaliadorSintatico
         }
     }
 
+    override declaracaoEscreva(): Escreva {
+        const simboloAtual = this.simbolos[this.atual];
+
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos valores em escreva.");
+
+        const argumentos: Construto[] = [];
+
+        if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.PARENTESE_DIREITO)) {
+            do {
+                argumentos.push(this.expressao());
+            } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
+        }
+
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os valores em escreva.");
+
+        // Ponto-e-vírgula é opcional aqui.
+        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
+
+        return new Escreva(Number(simboloAtual.linha), simboloAtual.hashArquivo, argumentos);
+    }
+
+    protected declaracaoExpressao(): Expressao {
+        // Se há decoradores a serem adicionados aqui, obtemo-los agora,
+        // para evitar que outros passos recursivos peguem-los antes.
+        const decoradores = Array.from(this.pilhaDecoradores);
+        this.pilhaDecoradores = [];
+
+        const expressao = this.expressao();
+        // Ponto-e-vírgula é opcional aqui.
+        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
+        return new Expressao(expressao, decoradores);
+    }
+
     protected declaracaoFalhar(): Falhar {
         const simboloFalha: SimboloInterface = this.simbolos[this.atual - 1];
         return new Falhar(simboloFalha, this.declaracaoExpressao().expressao);
@@ -1034,6 +1035,19 @@ export class AvaliadorSintatico
         } finally {
             this.blocos -= 1;
         }
+    }
+
+    /**
+     * O símbolo é emitido aqui para fins de formatação, mas este método é
+     * sobrescrito em `delegua-node`. 
+     * @returns {Importar} Uma declaração `Importar`.
+     */
+    override declaracaoImportar(): Importar {
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
+        const caminho = this.expressao();
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
+
+        return new Importar(caminho as Literal);
     }
 
     /**

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -45,7 +45,6 @@ import {
     Falhar,
     Fazer,
     FuncaoDeclaracao,
-    Importar,
     Leia,
     Para,
     ParaCada,
@@ -332,32 +331,6 @@ export class AvaliadorSintatico
                     simboloSuper,
                     this.superclasseAtual
                 );
-                /* Se o próximo símbolo for uma abertura de parênteses, significa que
-                // é uma chamada ao construtor da classe ancestral (superclasse).
-                // Se o próximo símbolo for um ponto, significa que é uma chamada
-                // a um método da superclasse.
-                switch (this.simbolos[this.atual].tipo) {
-                    case tiposDeSimbolos.PARENTESE_ESQUERDO:
-                        return new Super(
-                            this.hashArquivo,
-                            simboloSuper,
-                            new Simbolo(
-                                tiposDeSimbolos.IDENTIFICADOR,
-                                'construtor',
-                                null,
-                                simboloSuper.linha,
-                                this.hashArquivo
-                            )
-                        );
-                    default:
-                        this.consumir(tiposDeSimbolos.PONTO, "Esperado '.' após 'super'.");
-                        const metodoSuperclasse = this.consumir(
-                            tiposDeSimbolos.IDENTIFICADOR,
-                            'Esperado nome do método da Superclasse.'
-                        );
-                        // TODO: Validar se o método existe no ancestral.
-                        return new Super(this.hashArquivo, simboloSuper, metodoSuperclasse);
-                } */
 
             case tiposDeSimbolos.VERDADEIRO:
                 this.avancarEDevolverAnterior();
@@ -573,6 +546,24 @@ export class AvaliadorSintatico
                     construtoTipado.simbolo.lexema,
                     primitivaNumeroSelecionada.tipoRetorno
                 );
+
+            case tipoDeDadosDelegua.MODULO:
+            case tipoDeDadosDelegua.MÓDULO:
+                if (construtoTipado.simbolo.lexema in this.tiposDefinidosEmCodigo) {
+                    // Construtor de classe.
+                    return new Variavel(
+                        construtoTipado.hashArquivo, 
+                        construtoTipado.simbolo, 
+                        construtoTipado.objeto.tipo
+                    );
+                }
+
+                return new AcessoMetodo(
+                    construtoTipado.hashArquivo, 
+                    construtoTipado.objeto,
+                    construtoTipado.simbolo.lexema,
+                );
+
             case tipoDeDadosDelegua.TEXTO:
                 if (!(construtoTipado.simbolo.lexema in primitivasTexto)) {
                     throw this.erro(construtoTipado.simbolo, `${construtoTipado.simbolo.lexema} não é uma primitiva de texto.`);
@@ -1043,13 +1034,6 @@ export class AvaliadorSintatico
         } finally {
             this.blocos -= 1;
         }
-    }
-
-    override declaracaoImportar(): Importar {
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
-        const caminho = this.expressao();
-        const simboloFechamento = this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
-        return new Importar(caminho as Literal, simboloFechamento);
     }
 
     /**
@@ -1947,6 +1931,8 @@ export class AvaliadorSintatico
         this.pilhaEscopos.empilhar(new InformacaoEscopo());
 
         // Funções nativas de Delégua
+        this.pilhaEscopos.definirTipoVariavel('aleatorio', 'inteiro');
+        this.pilhaEscopos.definirTipoVariavel('aleatorioEntre', 'inteiro');
         this.pilhaEscopos.definirTipoVariavel('filtrarPor', 'qualquer[]');
         this.pilhaEscopos.definirTipoVariavel('inteiro', 'inteiro');
         this.pilhaEscopos.definirTipoVariavel('mapear', 'qualquer[]');

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
@@ -667,12 +667,10 @@ export class AvaliadorSintaticoEguaClassico implements AvaliadorSintaticoInterfa
 
     declaracaoImportar(): Importar {
         this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
-
         const caminho = this.expressao();
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
 
-        const simboloFechamento = this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
-
-        return new Importar(caminho as Literal, simboloFechamento);
+        return new Importar(caminho as Literal);
     }
 
     declaracaoTente(): Tente {

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -760,12 +760,10 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<S
 
     declaracaoImportar(): Importar {
         this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
-
         const caminho = this.expressao();
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
 
-        const simboloFechamento = this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
-
-        return new Importar(caminho as Literal, simboloFechamento);
+        return new Importar(caminho as Literal);
     }
 
     declaracaoTente(): Tente {

--- a/fontes/declaracoes/importar.ts
+++ b/fontes/declaracoes/importar.ts
@@ -9,12 +9,10 @@ import { Declaracao } from './declaracao';
  */
 export class Importar extends Declaracao {
     caminho: Literal;
-    simboloFechamento: any;
 
-    constructor(caminho: Literal, simboloFechamento: any) {
+    constructor(caminho: Literal) {
         super(caminho.linha, caminho.hashArquivo);
         this.caminho = caminho;
-        this.simboloFechamento = simboloFechamento;
     }
 
     async aceitar(visitante: VisitanteComumInterface): Promise<any> {

--- a/fontes/declaracoes/importar.ts
+++ b/fontes/declaracoes/importar.ts
@@ -2,6 +2,11 @@ import { Literal } from '../construtos';
 import { VisitanteComumInterface } from '../interfaces';
 import { Declaracao } from './declaracao';
 
+/**
+ * Declaração usada para importação resolvida em tempo de execução. 
+ * Para Delégua, a partir da versão 0.40.0, importações de módulos resolvem
+ * no avaliador sintático, já que alguma resolução de tipo é necessária.
+ */
 export class Importar extends Declaracao {
     caminho: Literal;
     simboloFechamento: any;

--- a/fontes/interpretador/dialetos/egua-classico/interpretador-egua-classico.ts
+++ b/fontes/interpretador/dialetos/egua-classico/interpretador-egua-classico.ts
@@ -601,7 +601,11 @@ export class InterpretadorEguaClassico implements InterpretadorInterface {
     // TODO: Implementar em `delegua-node`.
     async visitarDeclaracaoImportar(declaracao: Importar) {
         throw new ErroEmTempoDeExecucao(
-            declaracao.simboloFechamento,
+            {
+                lexema: declaracao.caminho.valor,
+                linha: declaracao.linha,
+                hashArquivo: declaracao.caminho.hashArquivo
+            } as SimboloInterface,
             'Importação não suportada em núcleo da linguagem puro. Favor executar a aplicação usando o pacote NPM `delegua-node`.',
             declaracao.linha
         );

--- a/fontes/tipos-de-dados/delegua.ts
+++ b/fontes/tipos-de-dados/delegua.ts
@@ -4,6 +4,8 @@ export default {
     INTEIRO: 'inteiro',
     LOGICO: 'logico',
     LÓGICO: 'lógico',
+    MODULO: 'modulo',
+    MÓDULO: 'módulo',
     NUMERO: 'numero',
     NÚMERO: 'número',
     NULO: 'nulo',

--- a/testes/avaliador-sintatico/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/avaliador-sintatico.test.ts
@@ -585,7 +585,6 @@ describe('Avaliador sintático', () => {
             
                     const resultadoAvaliacaoSintatica = avaliadorSintatico.analisar(resultadoLexador, -1);
                     
-                    // console.log(resultado);
                     expect(resultadoAvaliacaoSintatica).toBeTruthy();
                     expect(resultadoAvaliacaoSintatica.declaracoes).toHaveLength(2);
                     expect(resultadoAvaliacaoSintatica.erros).toHaveLength(0);

--- a/testes/formatadores/formatador-delegua.test.ts
+++ b/testes/formatadores/formatador-delegua.test.ts
@@ -32,7 +32,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(7);
     })
 
@@ -45,7 +44,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(13);
     });
 
@@ -59,7 +57,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(11);
     });
 
@@ -72,7 +69,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(2);
     });
 
@@ -85,7 +81,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(10);
     });
 
@@ -99,7 +94,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(8);
     });
 
@@ -115,7 +109,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(4);
     });
 
@@ -139,7 +132,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(10);
     });
 
@@ -153,7 +145,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(5);
     });
 
@@ -167,7 +158,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(6);
     });
 
@@ -191,7 +181,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(10);
     });
 
@@ -207,7 +196,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        // console.log(resultado);
         expect(linhasResultado).toHaveLength(4);
     });
 
@@ -223,7 +211,6 @@ describe('Formatadores > Delégua', () => {
         const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
         const linhasResultado = resultado.split(sistemaOperacional.EOL);
         
-        console.log(resultado);
         expect(linhasResultado).toHaveLength(3);
     });
 


### PR DESCRIPTION
Pela implementação de tipagem e inferência, resolver módulos na interpretação virou um grande problema, principalmente em `delegua-node`. 

Aqui temos a lógica para resolução de componentes de módulo. 