### PR TITLE
Ajustando análise semântica para também considerar funções como argumentos válidos de `escreva`.

### DIFF
--- a/fontes/analisador-semantico/analisador-semantico.ts
+++ b/fontes/analisador-semantico/analisador-semantico.ts
@@ -527,11 +527,16 @@ export class AnalisadorSemantico extends AnalisadorSemanticoBase {
         const variaveis = declaracao.argumentos.filter((arg) => arg instanceof Variavel);
 
         for (let variavel of variaveis as Variavel[]) {
-            if (!this.variaveis[variavel.simbolo.lexema]) {
-                this.erro(variavel.simbolo, `Variável '${variavel.simbolo.lexema}' não existe.`);
+            // TODO: Funções também são consideradas "variáveis" até aqui, mas isso deve mudar futuramente.
+            const possivelVariavel = this.variaveis[variavel.simbolo.lexema];
+            const possivelFuncao = this.funcoes[variavel.simbolo.lexema];
+
+            if (!possivelVariavel && !possivelFuncao) {
+                this.erro(variavel.simbolo, `Variável ou função '${variavel.simbolo.lexema}' não existe.`);
+                continue;
             }
 
-            if (this.variaveis[variavel.simbolo.lexema]?.valor === undefined) {
+            if (possivelVariavel && possivelVariavel.valor === undefined) {
                 this.aviso(variavel.simbolo, `Variável '${variavel.simbolo.lexema}' não foi inicializada.`);
             }
         }

--- a/testes/analisador-semantico.test.ts
+++ b/testes/analisador-semantico.test.ts
@@ -91,6 +91,18 @@ describe('Analisador semântico', () => {
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
+
+            it('Função sem corpo', () => {
+                const retornoLexador = lexador.mapear([
+                    "funcao minhaFuncao() {}",
+                    "escreva(minhaFuncao)"
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);  
+            })
         });
 
         describe('Cenários de falha', () => {


### PR DESCRIPTION
- Resolve #757 