### PR TITLE
`leia()` passa a ser resolvida dentro de `primario` na avaliação sintática, e não mais como uma expressão especial.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -372,6 +372,9 @@ export class AvaliadorSintatico
                 this.avancarEDevolverAnterior();
                 return new Isto(this.hashArquivo, Number(simboloAtual.linha), simboloAtual);
 
+            case tiposDeSimbolos.LEIA:
+                return this.expressaoLeia();
+
             case tiposDeSimbolos.NULO:
                 this.avancarEDevolverAnterior();
                 return new Literal(this.hashArquivo, Number(simboloAtual.linha), null, 'nulo');
@@ -1046,7 +1049,7 @@ export class AvaliadorSintatico
      * @returns Um objeto da classe `Leia`.
      */
     override expressaoLeia(): Leia {
-        const simboloLeia = this.simbolos[this.atual];
+        const simboloLeia = this.avancarEDevolverAnterior();
 
         this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' antes dos argumentos em instrução `leia`.");
 
@@ -1063,8 +1066,8 @@ export class AvaliadorSintatico
         return new Leia(simboloLeia, argumentos);
     }
 
+    // TODO: Depreciar.
     override expressao(): Construto {
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.LEIA)) return this.expressaoLeia();
         return this.atribuir();
     }
 
@@ -1679,6 +1682,19 @@ export class AvaliadorSintatico
                     case 'AcessoMetodo':
                         const entidadeChamadaAcessoMetodo = entidadeChamadaChamada as AcessoMetodo;
                         return entidadeChamadaAcessoMetodo.tipoRetornoMetodo;
+                    case 'AcessoMetodoOuPropriedade':
+                        // Este caso ocorre quando a variável/constante é do tipo 'qualquer', 
+                        // e a chamada normalmente é feita para uma primitiva. 
+                        // A inferência, portanto, ocorre pelo uso da primitiva.
+                        const entidadeChamadaAcessoMetodoOuPropriedade = entidadeChamadaChamada as AcessoMetodoOuPropriedade;
+                        if (this.primitivasConhecidas.hasOwnProperty(entidadeChamadaAcessoMetodoOuPropriedade.simbolo.lexema)) {
+                            return this.primitivasConhecidas[entidadeChamadaAcessoMetodoOuPropriedade.simbolo.lexema].tipo;
+                        }
+
+                        throw new ErroAvaliadorSintatico(
+                            entidadeChamadaAcessoMetodoOuPropriedade.simbolo, 
+                            `Primitiva '${entidadeChamadaAcessoMetodoOuPropriedade.simbolo.lexema}' não existe.`
+                        );
                     case 'AcessoPropriedade':
                         const entidadeChamadaAcessoPropriedade = entidadeChamadaChamada as AcessoPropriedade;
                         return entidadeChamadaAcessoPropriedade.tipoRetornoPropriedade;
@@ -1709,6 +1725,9 @@ export class AvaliadorSintatico
             case 'Noneto':
             case 'Deceto':
                 return tipoDeDadosDelegua.TUPLA;
+            case "ImportarBiblioteca":
+            case "ModuloDeclaracoes":
+                return "módulo";
             default:
                 return inicializador.tipo;
         }

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -1718,6 +1718,34 @@ describe('Interpretador', () => {
             });
 
             describe('Entrada e saída', () => {
+                it('escreva e leia na mesma linha', async () => {
+                    let _saida: string = '';
+                    // Aqui vamos simular a resposta para uma variável de `leia()`.
+                    const respostas = ['5'];
+                    interpretador.interfaceEntradaSaida = {
+                        question: (mensagem: string, callback: Function) => {
+                            callback(respostas.shift());
+                        },
+                    };
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'escreva("Você digitou " + leia("Digite alguma coisa: "))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe("Você digitou 5");
+                });
+
                 it('Enquanto (verdadeiro) e Sustar', async () => {
                     const saidasMensagens = ['opção invalida', 'opção invalida', 'resultado 4'];
                     // Aqui vamos simular a resposta para cinco variáveis de `leia()`.


### PR DESCRIPTION
Resolve #771 