### PR TITLE
Expandindo `ErroAvaliadorSintatico` para conter hash de arquivo e linha nas propriedades comuns

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -2033,6 +2033,7 @@ export class AvaliadorSintatico
      * @returns Um Construto do tipo Var.
      */
     protected declaracaoDeVariaveis(): Var[] {
+        const simboloVariavel = this.simboloAnterior();
         const identificadores: SimboloInterface[] = [];
         const retorno: Var[] = [];
         let tipo: string = 'qualquer';
@@ -2074,7 +2075,7 @@ export class AvaliadorSintatico
 
         if (identificadores.length !== inicializadores.length) {
             throw this.erro(
-                this.simbolos[this.atual],
+                simboloVariavel,
                 'Quantidade de identificadores à esquerda do igual é diferente da quantidade de valores à direita.'
             );
         }
@@ -2147,6 +2148,7 @@ export class AvaliadorSintatico
      * @returns Um Construto do tipo Const.
      */
     declaracaoDeConstantes(): Const[] {
+        const simboloConstante = this.simboloAnterior();
         const identificadores: SimboloInterface[] = [];
         let tipo: string = 'qualquer';
 
@@ -2177,7 +2179,7 @@ export class AvaliadorSintatico
 
         if (identificadores.length !== inicializadores.length) {
             throw this.erro(
-                this.simbolos[this.atual],
+                simboloConstante,
                 'Quantidade de identificadores à esquerda do igual é diferente da quantidade de valores à direita.'
             );
         }

--- a/fontes/avaliador-sintatico/erro-avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/erro-avaliador-sintatico.ts
@@ -2,10 +2,14 @@ import { SimboloInterface } from '../interfaces';
 
 export class ErroAvaliadorSintatico extends Error {
     simbolo: SimboloInterface;
+    hashArquivo: number;
+    linha: number;
 
     constructor(simbolo: SimboloInterface, mensagem: string) {
         super(mensagem);
         this.simbolo = simbolo;
+        this.hashArquivo = simbolo.hashArquivo;
+        this.linha = simbolo.linha;
         Object.setPrototypeOf(this, ErroAvaliadorSintatico.prototype);
     }
 }

--- a/testes/avaliador-sintatico/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/avaliador-sintatico.test.ts
@@ -896,7 +896,10 @@ describe('Avaliador sintático', () => {
                 const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
                 expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
-                expect(retornoAvaliadorSintatico.erros[0].message).toBe(
+                const erro = retornoAvaliadorSintatico.erros[0];
+                expect(erro.hashArquivo).toBeDefined();
+                expect(erro.linha).toBeDefined();
+                expect(erro.message).toBe(
                     'Quantidade de identificadores à esquerda do igual é diferente da quantidade de valores à direita.'
                 );
             });
@@ -906,7 +909,10 @@ describe('Avaliador sintático', () => {
                 const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
                 expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
-                expect(retornoAvaliadorSintatico.erros[0].message).toBe(
+                const erro = retornoAvaliadorSintatico.erros[0];
+                expect(erro.hashArquivo).toBeDefined();
+                expect(erro.linha).toBeDefined();
+                expect(erro.message).toBe(
                     'Quantidade de identificadores à esquerda do igual é diferente da quantidade de valores à direita.'
                 );
             });
@@ -974,7 +980,10 @@ describe('Avaliador sintático', () => {
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
     
                     expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
-                    expect(retornoAvaliadorSintatico.erros[0].message).toBe(
+                    const erro = retornoAvaliadorSintatico.erros[0];
+                    expect(erro.hashArquivo).toBeDefined();
+                    expect(erro.linha).toBeDefined();
+                    expect(erro.message).toBe(
                         "'continua' precisa estar em um laço de repetição."
                     );
                 });


### PR DESCRIPTION
Resolve https://github.com/DesignLiquido/delegua/issues/791