### PR TITLE
Correções no formatador e na forma de inferir tipos de variáveis de constantes

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -2125,8 +2125,10 @@ export class AvaliadorSintatico
             );
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
+        let tipoExplicito: boolean = false;
         if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
             tipo = this.verificarDefinicaoTipoAtual();
+            tipoExplicito = true;
             this.avancarEDevolverAnterior();
         }
 
@@ -2137,7 +2139,7 @@ export class AvaliadorSintatico
                     identificador.lexema,
                     new InformacaoVariavelOuConstante(identificador.lexema, tipo)
                 );
-                retorno.push(new Var(identificador, null, tipo, Array.from(this.pilhaDecoradores)));
+                retorno.push(new Var(identificador, null, tipo, tipoExplicito, Array.from(this.pilhaDecoradores)));
             }
 
             this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
@@ -2172,6 +2174,7 @@ export class AvaliadorSintatico
                     identificador,
                     inicializadores[indice],
                     tipo,
+                    tipoExplicito,
                     Array.from(this.pilhaDecoradores)
                 )
             );
@@ -2239,8 +2242,10 @@ export class AvaliadorSintatico
             );
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
+        let tipoExplicito: boolean = false;
         if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
             tipo = this.verificarDefinicaoTipoAtual();
+            tipoExplicito = true;
             this.avancarEDevolverAnterior();
         }
 
@@ -2279,6 +2284,7 @@ export class AvaliadorSintatico
                     identificador,
                     inicializadores[indice],
                     tipo as TipoDadosElementar,
+                    tipoExplicito,
                     Array.from(this.pilhaDecoradores)
                 )
             );

--- a/fontes/declaracoes/const.ts
+++ b/fontes/declaracoes/const.ts
@@ -1,6 +1,5 @@
 import { Construto, Decorador } from '../construtos';
 import { VisitanteComumInterface, SimboloInterface } from '../interfaces';
-import { TipoDadosElementar } from '../tipo-dados-elementar';
 import { Declaracao } from './declaracao';
 
 /**
@@ -16,6 +15,7 @@ export class Const extends Declaracao {
         simbolo: SimboloInterface,
         inicializador: Construto,
         tipo: string = 'qualquer',
+        tipoExplicito: boolean = false,
         decoradores: Decorador[] = []
     ) {
         super(Number(simbolo.linha), simbolo.hashArquivo, decoradores);
@@ -24,11 +24,11 @@ export class Const extends Declaracao {
 
         if (tipo !== 'qualquer') {
             this.tipo = tipo;
-            this.tipoExplicito = true;
         } else {
             this.tipo = inicializador?.tipo || tipo;
-            this.tipoExplicito = false;
         }
+
+        this.tipoExplicito = tipoExplicito;
     }
 
     async aceitar(visitante: VisitanteComumInterface): Promise<any> {

--- a/fontes/declaracoes/var.ts
+++ b/fontes/declaracoes/var.ts
@@ -18,6 +18,7 @@ export class Var extends Declaracao {
         simbolo: SimboloInterface,
         inicializador: Construto,
         tipo: string = 'qualquer',
+        tipoExplicito: boolean = false,
         decoradores: Decorador[] = []
     ) {
         super(Number(simbolo.linha), simbolo.hashArquivo, decoradores);
@@ -26,12 +27,11 @@ export class Var extends Declaracao {
 
         if (tipo !== 'qualquer') {
             this.tipo = tipo;
-            this.tipoExplicito = true;
         } else {
             this.tipo = inicializador?.tipo || tipo;
-            this.tipoExplicito = false;
         }
 
+        this.tipoExplicito = tipoExplicito;
         this.referencia = false;
         this.desestruturacao = false;
     }

--- a/fontes/formatadores/formatador-delegua.ts
+++ b/fontes/formatadores/formatador-delegua.ts
@@ -203,7 +203,9 @@ export class FormatadorDelegua implements VisitanteComumInterface {
             this.formatarDeclaracaoOuConstruto(expressao.valor);
         }
 
-        this.codigoFormatado += `${this.quebraLinha}`;
+        if (this.devePularLinha) {
+            this.codigoFormatado += `${this.quebraLinha}`;
+        }
     }
 
     visitarDeclaracaoDeExpressao(declaracao: Expressao) {
@@ -262,8 +264,13 @@ export class FormatadorDelegua implements VisitanteComumInterface {
         this.codigoFormatado += `${' '.repeat(this.indentacaoAtual)}escreva(`;
         for (let argumento of declaracao.argumentos) {
             this.formatarDeclaracaoOuConstruto(argumento);
+            this.codigoFormatado += ', ';
         }
 
+        if (declaracao.argumentos.length > 0) {
+            this.codigoFormatado = this.codigoFormatado.slice(0, -2);
+        }
+        
         this.codigoFormatado += `)${this.quebraLinha}`;
     }
 
@@ -387,6 +394,11 @@ export class FormatadorDelegua implements VisitanteComumInterface {
         }
 
         this.codigoFormatado += `var ${declaracao.simbolo.lexema}`;
+
+        if (declaracao.tipoExplicito && declaracao.tipo) {
+            this.codigoFormatado += `: ${declaracao.tipo}`;
+        }
+
         if (declaracao.inicializador) {
             this.codigoFormatado += ` = `;
             this.formatarDeclaracaoOuConstruto(declaracao.inicializador);

--- a/testes/formatadores/formatador-delegua.test.ts
+++ b/testes/formatadores/formatador-delegua.test.ts
@@ -469,5 +469,48 @@ describe('Formatadores > Delégua', () => {
             // console.log(resultado);
             expect(linhasResultado).toHaveLength(8);
         });
+
+        it('FizzBuzz', async () => {
+            const codigo = [
+                "var n = 15",
+                "para var i = 1; i <= n; i = i + 1 {",
+                "    var resultado: texto;",
+                "    se (i % 3 == 0) {",
+                "        resultado = resultado + 'Fizz'",
+                "    }",
+                "    se (i % 5 == 0) {",
+                "        resultado = resultado + 'Buzz'",
+                "    }",
+                "    se (resultado == '') {",
+                "        escreva(i, '\\n')",
+                "    } senão {",
+                "        escreva(resultado, '\\n')",
+                "    }",
+                "}"
+            ];
+            
+            const resultadoLexador = lexador.mapear(codigo, -1);
+            const resultadoAvaliacaoSintatica = avaliadorSintatico.analisar(resultadoLexador, -1);
+            const resultado = formatador.formatar(resultadoAvaliacaoSintatica.declaracoes);
+            const linhasResultado = resultado.split(sistemaOperacional.EOL);
+
+            // console.log(resultado);
+            expect(linhasResultado).toHaveLength(16);
+            expect(linhasResultado[0]).toBe("var n = 15");
+            expect(linhasResultado[1]).toContain("para var i = 1; i <= n; i = i + 1 {");
+            expect(linhasResultado[2]).toBe("    var resultado: texto");
+            expect(linhasResultado[3]).toBe("    se (i % 3 == 0) {");
+            expect(linhasResultado[4]).toBe("        resultado = resultado + 'Fizz'");
+            expect(linhasResultado[5]).toBe("    }");
+            expect(linhasResultado[6]).toBe("    se (i % 5 == 0) {");
+            expect(linhasResultado[7]).toBe("        resultado = resultado + 'Buzz'");
+            expect(linhasResultado[8]).toBe("    }");
+            expect(linhasResultado[9]).toBe("    se (resultado == '') {");
+            expect(linhasResultado[10]).toBe("        escreva(i, '\\n')");
+            expect(linhasResultado[11]).toBe("    } senão {");
+            expect(linhasResultado[12]).toBe("        escreva(resultado, '\\n')");
+            expect(linhasResultado[13]).toBe("    }");
+            expect(linhasResultado[14]).toBe("}");
+        });
     });
 });


### PR DESCRIPTION
Resolve #831 

- Apenas tipos explícitos devem ser formatados com o tipo;
- Separação de argumentos de `escreva()` por vírgula;
- Nào quebrar linha após avaliação de incremento de `para`.