### PR TITLE
pituguês: teste unitário de declaração super

### DIFF
--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -304,6 +304,29 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas[1]).toBe('Au Au Au Au');
                     expect(_saidas[2]).toBe('Classe: OK!');
                 });
+
+                it('Classes - declaração `super()` ', async () => {
+                    const codigo = [
+                        "classe Procurando:",
+                        "    construtor():",
+                        "        imprima('Amigo, onde está você?')",
+                        "classe Amigo(Procurando):",
+                        "    construtor():",
+                        "        super()",
+                        "        imprima('Amigo, estou aqui!')",
+                        "var amigo = Amigo()",
+                    ];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(2);
+                    expect(_saidas[0]).toBe('Amigo, onde está você?');
+                    expect(_saidas[1]).toBe('Amigo, estou aqui!');
+                });
             });
 
             describe('Declaração e chamada de funções', () => {


### PR DESCRIPTION
Sugestão de teste unitário a ser incluído, contemplando herança e a declaração `super()` para Pituguês. 