### PR TITLE
Adiciona testes para o comando 'quebrar'

### DIFF
--- a/testes/analisador-semantico.test.ts
+++ b/testes/analisador-semantico.test.ts
@@ -716,4 +716,57 @@ describe('Analisador semântico', () => {
             });
         });
     });
-});
+    describe('Comando quebrar', () => {
+        describe('Cenários com laço for', () => {
+            it('Sucesso - dentro do laço for', () => {
+                const retornoLexador = lexador.mapear([
+                    "para (var i = 0; i < 10; i++) {",
+                        "   se (i == 5) {",
+                        "       quebrar;",
+                        "   }",
+                ], -1)
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+            it('Sucesso - dentro do laço enquanto', () => {
+                const retornoLexador = lexador.mapear([
+                    "enquanto (verdadeiro) {",
+                        "   se (i == 5) {",
+                        "       quebrar;",
+                        "   }",
+                ], -1)
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+            it('Sucesso - dentro do laço faça...enquanto', () => {
+                const retornoLexador = lexador.mapear([
+                    "faça {",
+                        "   se (i == 5) {",
+                        "       quebrar;",
+                        "   }",
+                    "} enquanto (verdadeiro);",
+                ], -1)
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+            it('Erro - fora de laço', () => {
+                const retornoLexador = lexador.mapear([
+                    "quebrar;",
+                ], -1)
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes)
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe('Comando \'quebrar\' deve estar dentro de um laço.');
+              });
+        }
+        );   
+    });
+}
+)

--- a/testes/analisador-semantico.test.ts
+++ b/testes/analisador-semantico.test.ts
@@ -763,7 +763,7 @@ describe('Analisador semântico', () => {
                 const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes)
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe('Comando \'quebrar\' deve estar dentro de um laço.');
+                expect(retornoAnalisadorSemantico.diagnosticos.filter(item => item.severidade === DiagnosticoSeveridade.ERRO)).toHaveLength(1);
               });
         }
         );   


### PR DESCRIPTION
Este PR adiciona testes para o comando 'quebrar', cobrindo todos os laços de repetição, bem como teste para falha. 