### PR TITLE
Nova sintaxe de importação.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ Delégua executa em qualquer dispositivo que interprete JavaScript, ou seja, com
 
 Para instalar no seu computador ou na sua aplicação, veja o projeto [@designliquido/delegua-node](https://github.com/DesignLiquido/delegua-node).
 
+## Compiladores
+
+Delégua possui alguns compiladores implementados. Compiladores passam código Delégua para binário, gerando executáveis, cuja execução ocorre com a máxima performance possível. São eles:
+
+- [`delegua-llvm`](https://github.com/DesignLiquido/delegua-llvm), o compilador oficial da Design Líquido;
+- [`cgd` (Compilador Geral Delégua)](https://github.com/FernandoTheDev/cgd). Documentação: https://fernandothedev.github.io/cgd/
+
 ## Documentação
 
 - [Delégua é documentada na Wiki deste GitHub](https://github.com/DesignLiquido/delegua/wiki).

--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -7,7 +7,6 @@ import {
     Escreva,
     Expressao,
     FuncaoDeclaracao,
-    Importar,
     Para,
     ParaCada,
     Retorna,
@@ -345,10 +344,6 @@ export abstract class AvaliadorSintaticoBase
     }
 
     protected declaracaoExpressao(simboloAnterior?: SimboloInterface): Expressao {
-        throw new Error('Método não implementado.');
-    }
-
-    protected declaracaoImportar(): Importar {
         throw new Error('Método não implementado.');
     }
 

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -21,6 +21,7 @@ import {
     ExpressaoRegular,
     FazerComoConstruto,
     FuncaoConstruto,
+    ImportarComoConstruto,
     Isto,
     Leia,
     Literal,
@@ -266,6 +267,14 @@ export class AvaliadorSintatico
             chaves,
             valores
         );
+    }
+
+    protected construtoImportar(): ImportarComoConstruto {
+        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
+        const caminho = this.expressao();
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
+
+        return new ImportarComoConstruto(caminho as Literal);
     }
 
     protected construtoTupla(): Tupla {
@@ -543,7 +552,7 @@ export class AvaliadorSintatico
 
             case tiposDeSimbolos.IMPORTAR:
                 this.avancarEDevolverAnterior();
-                return this.declaracaoImportar();
+                return this.construtoImportar();
 
             case tiposDeSimbolos.ISTO:
                 this.avancarEDevolverAnterior();
@@ -1680,12 +1689,72 @@ export class AvaliadorSintatico
      * sobrescrito em `delegua-node`.
      * @returns {Importar} Uma declaração `Importar`.
      */
-    override declaracaoImportar(): Importar {
-        this.consumir(tiposDeSimbolos.PARENTESE_ESQUERDO, "Esperado '(' após declaração.");
-        const caminho = this.expressao();
-        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após declaração.");
+    declaracaoImportar(): Importar {
+        let identificadorDeTudo: SimboloInterface | null = null;
+        const elementosImportacao: SimboloInterface[] = [];
 
-        return new Importar(caminho as Literal);
+        switch (this.simbolos[this.atual].tipo) {
+            case tiposDeSimbolos.TUDO:
+                this.avancarEDevolverAnterior();
+                this.consumir(tiposDeSimbolos.COMO, "Esperado 'como' após 'tudo' em declaração de importação.");
+                identificadorDeTudo = this.consumir(
+                    tiposDeSimbolos.IDENTIFICADOR,
+                    "Esperado identificador após 'como' em declaração de importação de 'tudo'."
+                );
+                break;
+            case tiposDeSimbolos.CHAVE_ESQUERDA:
+                this.avancarEDevolverAnterior();
+                
+                do {
+                    const identificadorImportacao = this.consumir(
+                        tiposDeSimbolos.IDENTIFICADOR,
+                        "Esperado identificador de elemento a ser importado."
+                    );
+                    elementosImportacao.push(identificadorImportacao);
+                } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
+
+                this.consumir(
+                    tiposDeSimbolos.CHAVE_DIREITA,
+                    "Esperado '}' após lista de elementos a serem importados."
+                );
+                break;
+            default:
+                throw this.erro(
+                    this.simbolos[this.atual],
+                    "Esperado ou palavra reservada 'tudo' ou abertura de chaves após palavra reservada 'importar'."
+                );
+        }        
+
+        this.consumir(tiposDeSimbolos.DE, "Esperado 'de' após identificador em declaração de importação de 'tudo'.");
+        let construtoCaminhoModulo: Construto;
+        switch (this.simbolos[this.atual].tipo) {
+            case tiposDeSimbolos.TEXTO:
+                const simboloCaminhoModulo = this.avancarEDevolverAnterior();
+                construtoCaminhoModulo = new Literal(
+                    simboloCaminhoModulo.hashArquivo,
+                    Number(simboloCaminhoModulo.linha),
+                    simboloCaminhoModulo.literal
+                );
+                break;
+            case tiposDeSimbolos.IDENTIFICADOR:
+                const identificadorModulo = this.avancarEDevolverAnterior();
+                construtoCaminhoModulo = new Literal(
+                    identificadorModulo.hashArquivo,
+                    Number(identificadorModulo.linha),
+                    identificadorModulo.lexema
+                );
+                    
+                break;
+        }
+
+        const importar = new Importar(construtoCaminhoModulo);
+        if (identificadorDeTudo !== null) {
+            importar.simboloTudo = identificadorDeTudo;
+        } else {
+            importar.elementosImportacao = elementosImportacao;
+        }
+        
+        return importar;
     }
 
     override declaracaoPara(): Para | ParaCada {
@@ -2115,6 +2184,9 @@ export class AvaliadorSintatico
             case tiposDeSimbolos.FAZER:
                 const simboloFazer = this.avancarEDevolverAnterior();
                 return this.declaracaoFazer(simboloFazer);
+            case tiposDeSimbolos.IMPORTAR:
+                this.avancarEDevolverAnterior();
+                return this.declaracaoImportar();
             case tiposDeSimbolos.LINHA_COMENTARIO:
                 return this.declaracaoComentarioMultilinha();
             case tiposDeSimbolos.PARA:

--- a/fontes/construtos/importar-como-construto.ts
+++ b/fontes/construtos/importar-como-construto.ts
@@ -1,0 +1,31 @@
+
+import { VisitanteDeleguaInterface } from "../interfaces";
+import { Construto } from "./construto";
+import { Literal } from "./literal";
+
+/**
+ * Expressão usada para importação resolvida em tempo de execução.
+ * Implementa a primeira forma de importação, também conhecida como importação dinâmica.
+ */
+export class ImportarComoConstruto implements Construto {
+    linha: number;
+    hashArquivo: number;
+    caminho: Literal;
+    
+    constructor(caminho: Literal) {
+        this.hashArquivo = caminho.hashArquivo;
+        this.linha = caminho.linha;
+        this.caminho = caminho;
+    }
+    
+    valor?: any;
+    tipo?: string;
+
+    async aceitar(visitante: VisitanteDeleguaInterface): Promise<any> {
+        return await visitante.visitarExpressaoImportar(this);
+    }
+
+    paraTexto(): string {
+        return `<importar-como-construto caminho=${this.caminho.valor} />`;
+    }
+}

--- a/fontes/construtos/index.ts
+++ b/fontes/construtos/index.ts
@@ -23,6 +23,7 @@ export * from './fazer-como-construto';
 export * from './fim-para';
 export * from './formatacao-escrita';
 export * from './funcao';
+export * from './importar-como-construto';
 export * from './isto';
 export * from './leia';
 export * from './lista-compreensao';

--- a/fontes/declaracoes/importar.ts
+++ b/fontes/declaracoes/importar.ts
@@ -1,21 +1,23 @@
-import { Literal } from '../construtos';
-import { VisitanteComumInterface } from '../interfaces';
+import { Construto } from '../construtos';
+import { SimboloInterface, VisitanteDeleguaInterface } from '../interfaces';
 import { Declaracao } from './declaracao';
 
 /**
- * Declaração usada para importação resolvida em tempo de execução.
+ * Declaração usada para segunda forma de importação.
  * Para Delégua, a partir da versão 0.40.0, importações de módulos resolvem
  * no avaliador sintático, já que alguma resolução de tipo é necessária.
  */
 export class Importar extends Declaracao {
-    caminho: Literal;
+    caminho: Construto;
+    simboloTudo: SimboloInterface | null = null;
+    elementosImportacao: SimboloInterface[] = [];
 
-    constructor(caminho: Literal) {
+    constructor(caminho: Construto) {
         super(caminho.linha, caminho.hashArquivo);
         this.caminho = caminho;
     }
 
-    async aceitar(visitante: VisitanteComumInterface): Promise<any> {
+    async aceitar(visitante: VisitanteDeleguaInterface): Promise<any> {
         return await visitante.visitarDeclaracaoImportar(this);
     }
 

--- a/fontes/interfaces/visitante-comum-interface.ts
+++ b/fontes/interfaces/visitante-comum-interface.ts
@@ -76,7 +76,6 @@ export interface VisitanteComumInterface {
     visitarDeclaracaoEscreva(declaracao: Escreva): Promise<any> | void;
     visitarDeclaracaoEscrevaMesmaLinha(declaracao: EscrevaMesmaLinha): Promise<any> | void;
     visitarDeclaracaoFazer(declaracao: Fazer): Promise<any> | void;
-    visitarDeclaracaoImportar(declaracao: Importar): Promise<any> | void;
     visitarDeclaracaoInicioAlgoritmo(declaracao: InicioAlgoritmo): Promise<any> | void;
     visitarDeclaracaoPara(declaracao: Para): Promise<any> | void;
     visitarDeclaracaoSe(declaracao: Se): Promise<any> | void;

--- a/fontes/interfaces/visitante-delegua-interface.ts
+++ b/fontes/interfaces/visitante-delegua-interface.ts
@@ -1,12 +1,13 @@
-import { EnquantoComoConstruto, FazerComoConstruto, ListaCompreensao, ParaComoConstruto } from "../construtos";
-import { ParaCadaComoConstruto } from "../construtos/para-cada-como-construto";
-import { ParaCada } from "../declaracoes";
+import { EnquantoComoConstruto, FazerComoConstruto, ImportarComoConstruto, ListaCompreensao, ParaCadaComoConstruto, ParaComoConstruto } from "../construtos";
+import { Importar, ParaCada } from "../declaracoes";
 import { VisitanteComumInterface } from "./visitante-comum-interface";
 
 export interface VisitanteDeleguaInterface extends VisitanteComumInterface {
+    visitarDeclaracaoImportar(declaracao: Importar): Promise<any> | void;
     visitarDeclaracaoParaCada(declaracao: ParaCada): Promise<any> | void;
     visitarExpressaoEnquanto(expressao: EnquantoComoConstruto): Promise<any> | void;
     visitarExpressaoFazer(expressao: FazerComoConstruto): Promise<any> | void;
+    visitarExpressaoImportar(expressao: ImportarComoConstruto): Promise<any> | void;
     visitarExpressaoPara(expressao: ParaComoConstruto): Promise<any> | void;
     visitarExpressaoParaCada(expressao: ParaCadaComoConstruto): Promise<any> | void;
     visitarExpressaoListaCompreensao(listaCompreensao: ListaCompreensao): Promise<any> | void;

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -26,6 +26,7 @@ import {
     Unario,
     Variavel,
     Vetor,
+    ImportarComoConstruto,
 } from '../construtos';
 import {
     DeleguaFuncao,
@@ -1131,6 +1132,10 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
     visitarExpressaoFazer(expressao: FazerComoConstruto): Promise<any> | void {
         return this.logicaComumExecucaoFazer(expressao, true);
+    }
+
+    visitarExpressaoImportar(expressao: ImportarComoConstruto): Promise<any> | void {
+        throw new Error('Importações não são suportadas neste interpretador.');
     }
 
     async visitarExpressaoListaCompreensao(listaCompreensao: ListaCompreensao): Promise<any> {

--- a/fontes/lexador/palavras-reservadas.ts
+++ b/fontes/lexador/palavras-reservadas.ts
@@ -43,6 +43,7 @@ export const palavrasReservadas = {
     tendo: tiposDeSimbolos.TENDO,
     tente: tiposDeSimbolos.TENTE,
     tipo: tiposDeSimbolos.TIPO,
+    tudo: tiposDeSimbolos.TUDO,
     var: tiposDeSimbolos.VARIAVEL,
     variavel: tiposDeSimbolos.VARIAVEL,
     variável: tiposDeSimbolos.VARIAVEL,

--- a/fontes/tipos-de-simbolos/delegua.ts
+++ b/fontes/tipos-de-simbolos/delegua.ts
@@ -86,6 +86,7 @@ export default {
     TENTE: 'TENTE',
     TEXTO: 'TEXTO',
     TIPO: 'TIPO',
+    TUDO: 'TUDO',
     VARIAVEL: 'VARIAVEL',
     VERDADEIRO: 'VERDADEIRO',
     VIRGULA: 'VIRGULA',

--- a/fontes/tradutores/tradutor-javascript.ts
+++ b/fontes/tradutores/tradutor-javascript.ts
@@ -14,6 +14,7 @@ import {
     DefinirValor,
     Dicionario,
     FuncaoConstruto,
+    ImportarComoConstruto,
     Isto,
     Leia,
     Literal,
@@ -520,7 +521,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return `'importar() não é suportado por este padrão de JavaScript'`;
     }
 
-    traduzirConstrutoLeia(declaracaoLeia: Leia) {
+    traduzirExpressaoLeia(declaracaoLeia: Leia) {
         return `'leia() não é suportado por este padrão de JavaScript.'`;
     }
 
@@ -687,15 +688,11 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         if (!declaracaoVar?.inicializador && adicionarPontoEVirgula) resultado += ';';
         else {
             resultado += ' = ';
-            if (this.dicionarioConstrutos[declaracaoVar.inicializador.constructor.name]) {
-                resultado += this.dicionarioConstrutos[
-                    declaracaoVar.inicializador.constructor.name
-                ](declaracaoVar.inicializador);
-            } else {
-                resultado += this.dicionarioDeclaracoes[
-                    declaracaoVar.inicializador.constructor.name
-                ](declaracaoVar.inicializador);
-            }
+            
+            resultado += this.dicionarioConstrutos[
+                declaracaoVar.inicializador.constructor.name
+            ](declaracaoVar.inicializador);
+
             if (adicionarPontoEVirgula) resultado += ';';
         }
 
@@ -707,7 +704,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return '';
     }
 
-    traduzirAcessoMetodoVetor(
+    traduzirExpressaoAcessoMetodoVetor(
         objeto: Construto,
         nomeMetodo: string,
         argumentos: Construto[]
@@ -755,7 +752,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         }
     }
 
-    traduzirConstrutoAcessoMetodo(acessoMetodo: AcessoMetodo, argumentos: Construto[]): string {
+    traduzirExpressaoAcessoMetodo(acessoMetodo: AcessoMetodo, argumentos: Construto[]): string {
         switch (acessoMetodo.objeto.constructor.name) {
             case 'Isto':
                 return `this.${acessoMetodo.nomeMetodo}`;
@@ -767,7 +764,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
                     argumentos
                 );
             case 'Vetor':
-                return this.traduzirAcessoMetodoVetor(
+                return this.traduzirExpressaoAcessoMetodoVetor(
                     acessoMetodo.objeto,
                     acessoMetodo.nomeMetodo,
                     argumentos
@@ -780,7 +777,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         }
     }
 
-    traduzirConstrutoAcessoMetodoOuPropriedade(
+    traduzirExpressaoAcessoMetodoOuPropriedade(
         acessoMetodo: AcessoMetodoOuPropriedade,
         argumentos: Construto[]
     ): string {
@@ -792,7 +789,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return `this.${acessoMetodo.simbolo.lexema}`;
     }
 
-    traduzirConstrutoAcessoPropriedade(
+    traduzirExpressaoAcessoPropriedade(
         acessoMetodo: AcessoPropriedade,
         argumentos: Construto[]
     ): string {
@@ -820,7 +817,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return resultado;
     }
 
-    traduzirConstrutoLogico(logico: Logico): string {
+    traduzirExpressaoLogica(logico: Logico): string {
         let direita = this.dicionarioConstrutos[logico.direita.constructor.name](logico.direita);
         let operador = this.traduzirSimboloOperador(logico.operador);
         let esquerda = this.dicionarioConstrutos[logico.esquerda.constructor.name](logico.esquerda);
@@ -829,7 +826,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
     }
 
     // TODO: Eliminar o soft cast para `any`.
-    traduzirConstrutoAtribuicaoPorIndice(AtribuicaoPorIndice: AtribuicaoPorIndice): string {
+    traduzirExpressaoAtribuicaoPorIndice(AtribuicaoPorIndice: AtribuicaoPorIndice): string {
         let resultado = '';
 
         resultado += (AtribuicaoPorIndice.objeto as any).simbolo.lexema + '[';
@@ -850,7 +847,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return resultado;
     }
 
-    traduzirConstrutoAcessoIndiceVariavel(acessoIndiceVariavel: AcessoIndiceVariavel): string {
+    traduzirExpressaoAcessoIndiceVariavel(acessoIndiceVariavel: AcessoIndiceVariavel): string {
         let resultado = '';
 
         resultado += this.dicionarioConstrutos[
@@ -863,7 +860,7 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return resultado;
     }
 
-    traduzirConstrutoArgumentoReferenciaFuncao(
+    traduzirExpressaoArgumentoReferenciaFuncao(
         argumentoReferenciaFuncao: ArgumentoReferenciaFuncao,
         argumentos: Construto[]
     ): string {
@@ -883,7 +880,11 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         return `${argumentoReferenciaFuncao.simboloFuncao.lexema}(${textoArgumentos})`;
     }
 
-    traduzirConstrutoReferenciaFuncao(
+    traduzirExpressaoImportar(_: ImportarComoConstruto) {
+        return `'importar() não é suportado por este padrão de JavaScript'`;
+    }
+
+    traduzirExpressaoReferenciaFuncao(
         referenciaFuncao: ReferenciaFuncao,
         argumentos: Construto[]
     ): string {
@@ -970,13 +971,13 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
     }
 
     dicionarioConstrutos = {
-        AcessoIndiceVariavel: this.traduzirConstrutoAcessoIndiceVariavel.bind(this),
-        AcessoMetodo: this.traduzirConstrutoAcessoMetodo.bind(this),
-        AcessoMetodoOuPropriedade: this.traduzirConstrutoAcessoMetodoOuPropriedade.bind(this),
-        AcessoPropriedade: this.traduzirConstrutoAcessoPropriedade.bind(this),
+        AcessoIndiceVariavel: this.traduzirExpressaoAcessoIndiceVariavel.bind(this),
+        AcessoMetodo: this.traduzirExpressaoAcessoMetodo.bind(this),
+        AcessoMetodoOuPropriedade: this.traduzirExpressaoAcessoMetodoOuPropriedade.bind(this),
+        AcessoPropriedade: this.traduzirExpressaoAcessoPropriedade.bind(this),
         Agrupamento: this.traduzirConstrutoAgrupamento.bind(this),
-        ArgumentoReferenciaFuncao: this.traduzirConstrutoArgumentoReferenciaFuncao.bind(this),
-        AtribuicaoPorIndice: this.traduzirConstrutoAtribuicaoPorIndice.bind(this),
+        ArgumentoReferenciaFuncao: this.traduzirExpressaoArgumentoReferenciaFuncao.bind(this),
+        AtribuicaoPorIndice: this.traduzirExpressaoAtribuicaoPorIndice.bind(this),
         Atribuir: this.traduzirConstrutoAtribuir.bind(this),
         Binario: this.traduzirConstrutoBinario.bind(this),
         ComentarioComoConstruto: this.traduzirDeclaracaoComentario.bind(this),
@@ -984,11 +985,12 @@ export class TradutorJavaScript implements TradutorInterface<Declaracao> {
         DefinirValor: this.traduzirConstrutoDefinirValor.bind(this),
         Dicionario: this.traduzirConstrutoDicionario.bind(this),
         FuncaoConstruto: this.traduzirFuncaoConstruto.bind(this),
+        ImportarComoConstruto: this.traduzirExpressaoImportar.bind(this),
         Isto: () => 'this',
-        Leia: this.traduzirConstrutoLeia.bind(this),
+        Leia: this.traduzirExpressaoLeia.bind(this),
         Literal: this.traduzirConstrutoLiteral.bind(this),
-        Logico: this.traduzirConstrutoLogico.bind(this),
-        ReferenciaFuncao: this.traduzirConstrutoReferenciaFuncao.bind(this),
+        Logico: this.traduzirExpressaoLogica.bind(this),
+        ReferenciaFuncao: this.traduzirExpressaoReferenciaFuncao.bind(this),
         Separador: this.traduzirConstrutoSeparador.bind(this),
         TipoDe: this.traduzirConstrutoTipoDe.bind(this),
         Unario: this.traduzirConstrutoUnario.bind(this),

--- a/testes/avaliador-sintatico/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/avaliador-sintatico.test.ts
@@ -174,7 +174,7 @@ describe('Avaliador sintático', () => {
                 });
 
                 it('Segunda forma', () => {
-                    const retornoLexador = lexador.mapear(['importar tudo como matematica de "matematica"'], -1);
+                    const retornoLexador = lexador.mapear(['importar tudo como matematica de matematica'], -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
                     expect(retornoAvaliadorSintatico).toBeTruthy();
@@ -186,7 +186,7 @@ describe('Avaliador sintático', () => {
                 });
 
                 it('Segunda forma com desestruturação', () => {
-                    const retornoLexador = lexador.mapear(['importar { logaritmo, potencia } de "matematica"'], -1);
+                    const retornoLexador = lexador.mapear(['importar { logaritmo, potencia } de matematica'], -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
                     expect(retornoAvaliadorSintatico).toBeTruthy();

--- a/testes/avaliador-sintatico/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/avaliador-sintatico.test.ts
@@ -1,6 +1,6 @@
 import { Lexador } from '../../fontes/lexador';
 import { AvaliadorSintatico } from '../../fontes/avaliador-sintatico';
-import { Bloco, Classe, Const, Escreva, Expressao, FuncaoDeclaracao, ParaCada, Retorna, TendoComo, Var } from '../../fontes/declaracoes';
+import { Bloco, Classe, Const, Escreva, Expressao, FuncaoDeclaracao, Importar, ParaCada, Retorna, TendoComo, Var } from '../../fontes/declaracoes';
 import { Binario, Chamada, FuncaoConstruto, Leia, Literal, Variavel } from '../../fontes/construtos';
 
 describe('Avaliador sintático', () => {
@@ -159,6 +159,42 @@ describe('Avaliador sintático', () => {
                     expect(declaracaoTipada.inicializador.constructor.name).toBe('Leia');
                     const declaracaoLeia = declaracaoTipada.inicializador as Leia;
                     expect(declaracaoLeia.argumentos.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('Importar', () => {
+                it('Primeira forma', () => {
+                    const retornoLexador = lexador.mapear(['const matematica = importar("matematica")'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(1);
+                    expect(retornoAvaliadorSintatico.declaracoes[0].constructor).toBe(Const);
+                });
+
+                it('Segunda forma', () => {
+                    const retornoLexador = lexador.mapear(['importar tudo como matematica de "matematica"'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(1);
+                    expect(retornoAvaliadorSintatico.declaracoes[0].constructor).toBe(Importar);
+                    const importar = retornoAvaliadorSintatico.declaracoes[0] as Importar;
+                    expect(importar.simboloTudo).not.toBeNull();
+                });
+
+                it('Segunda forma com desestruturação', () => {
+                    const retornoLexador = lexador.mapear(['importar { logaritmo, potencia } de "matematica"'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(1);
+                    expect(retornoAvaliadorSintatico.declaracoes[0].constructor).toBe(Importar);
+                    const importar = retornoAvaliadorSintatico.declaracoes[0] as Importar;
+                    expect(importar.elementosImportacao).toHaveLength(2);
                 });
             });
 


### PR DESCRIPTION
Novas formas:

```js
importar tudo como matematica de matematica
// Ou
importar { logaritmo, potencia } de matematica
```