### PR TITLE
feat(pitugues): adiciona a função de texto 'encontre'

### DIFF
--- a/fontes/bibliotecas/dialetos/egua-classico/textos.ts
+++ b/fontes/bibliotecas/dialetos/egua-classico/textos.ts
@@ -215,3 +215,24 @@ module.exports.apara = function (texto) {
     }
     return texto.trim();
 };
+
+/**
+ * Retornar o índice inicial de texto.
+ *
+ * @param {string} texto o texto original.
+ * @param {string} subtexto o texto que deve ser buscado.
+ * @param {number} indice_inicio [indice_inicio=0] O índice opcional para iniciar a busca.
+ * @returns {number} o índice da primeira ocorrência no texto fornecido ou -1 caso contrário.
+ */
+module.exports.encontre = function (texto, subtexto, indice_inicio=0) {
+     if (typeof texto !== 'string') {
+        throw new ErroEmTempoDeExecucao(this.token, 'O parâmetro passado deve ser um texto');
+    }
+    if (typeof subtexto !== 'string') {
+        throw new ErroEmTempoDeExecucao(this.token, 'O padrão passado deve ser um texto');
+    }
+    if (typeof indice_inicio !== 'number') {
+        throw new ErroEmTempoDeExecucao(this.token, 'O terceiro parâmetro opcional (início) deve ser um número.');
+    }
+   return texto.indexOf(subtexto, indice_inicio);
+};

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -155,15 +155,15 @@ export default {
             }
             return Promise.resolve(texto.indexOf(subtexto));
         },
-        assinaturaFormato: 'texto.encontre(subtexto: texto, indiceInicio?: número)',
+        assinaturaFormato: 'texto.encontrar(subtexto: texto, indiceInicio?: número)',
         documentacao:
-            '# `texto.encontre(subtexto, indiceInicio)` \n \n' +
+            '# `texto.encontrar(subtexto, indiceInicio)` \n \n' +
             'Retorna o índice inicial de um subtexto. Retorna -1 caso não encontre.' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```delegua\nvar t = "um dois três"\n' +
-            't.encontre("dois") // 3\n' +
-            't.encontre("quatro") // -1\n' +
-            't.encontre("dois", 4) // -1\n```' +
+            't.encontrar("dois") // 3\n' +
+            't.encontrar("quatro") // -1\n' +
+            't.encontrar("dois", 4) // -1\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.encontre(subtexto, indiceInicio?)',
     },

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -125,7 +125,7 @@ export default {
             '\n\n ### Formas de uso  \n',
         exemploCodigo: "texto.dividir('<delimitador (, ; ' ')>')",
     },
-    encontre: {
+    encontrar: {
         tipoRetorno: 'inteiro',
         argumentos: [
             new InformacaoElementoSintatico(

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -125,6 +125,48 @@ export default {
             '\n\n ### Formas de uso  \n',
         exemploCodigo: "texto.dividir('<delimitador (, ; ' ')>')",
     },
+    encontre: {
+        tipoRetorno: 'inteiro',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'subtexto',
+                'texto',
+                true,
+                [],
+                'O texto que deve ser buscado.'
+            ),
+            new InformacaoElementoSintatico(
+                'indiceInicio',
+                'número',
+                false,
+                [],
+                '(Opcional) O índice opcional para iniciar a busca.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            nomePrimitiva: string,
+            texto: string,
+            subtexto: string,
+            indiceInicio?: number
+        ): Promise<number> => {
+            if (indiceInicio !== undefined) {
+                return Promise.resolve(texto.indexOf(subtexto, indiceInicio));
+            }
+            return Promise.resolve(texto.indexOf(subtexto));
+        },
+        assinaturaFormato: 'texto.encontre(subtexto: texto, indiceInicio?: número)',
+        documentacao:
+            '# `texto.encontre(subtexto, indiceInicio)` \n \n' +
+            'Retorna o índice inicial de um subtexto. Retorna -1 caso não encontre.' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```delegua\nvar t = "um dois três"\n' +
+            't.encontre("dois") // 3\n' +
+            't.encontre("quatro") // -1\n' +
+            't.encontre("dois", 4) // -1\n```' +
+            '\n\n ### Formas de uso \n',
+        exemploCodigo: 'texto.encontre(subtexto, indiceInicio?)',
+    },
     fatiar: {
         tipoRetorno: 'texto',
         argumentos: [

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -871,7 +871,7 @@ describe('Interpretador (Pituguês)', () => {
                 it('encontre - subtexto não encontrado', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.encontre("abacaxi"))',
+                        'escreva(t.encontrar("abacaxi"))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1,6 +1,6 @@
-import { AvaliadorSintaticoPitugues } from "../../fontes/avaliador-sintatico/dialetos";
-import { Interpretador } from "../../fontes/interpretador";
-import { LexadorPitugues } from "../../fontes/lexador/dialetos";
+import { AvaliadorSintaticoPitugues } from '../../fontes/avaliador-sintatico/dialetos';
+import { Interpretador } from '../../fontes/interpretador';
+import { LexadorPitugues } from '../../fontes/lexador/dialetos';
 
 describe('Interpretador (Pituguês)', () => {
     describe('interpretar()', () => {
@@ -11,7 +11,7 @@ describe('Interpretador (Pituguês)', () => {
         let _saidas: string[] = [];
         const funcaoSaida = (texto: string) => {
             _saidas.push(texto);
-        }
+        };
 
         beforeEach(() => {
             _saidas = [];
@@ -23,24 +23,29 @@ describe('Interpretador (Pituguês)', () => {
         describe('Cenários de sucesso', () => {
             describe('Atribuições', () => {
                 it('Trivial', async () => {
-                    const retornoLexador = lexador.mapear([
-                        "var a = 1",
-                        "var b, c = 1, 2"
-                    ], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['var a = 1', 'var b, c = 1, 2'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Constantes', async () => {
-                    const retornoLexador = lexador.mapear([
-                        "const g, h, i = 1, '2', 3",
-                    ], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(["const g, h, i = 1, '2', 3"], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -51,12 +56,18 @@ describe('Interpretador (Pituguês)', () => {
                             [
                                 'var lista = [1, 2, 3, 4, 5]',
                                 'var minhaListaCompreensao = [x para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares',
-                                'escreva(minhaListaCompreensao)'
-                            ], -1
+                                'escreva(minhaListaCompreensao)',
+                            ],
+                            -1
                         );
-                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
 
-                        const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
 
                         expect(retornoInterpretador.erros).toHaveLength(0);
                         expect(_saidas).toHaveLength(1);
@@ -68,12 +79,18 @@ describe('Interpretador (Pituguês)', () => {
                             [
                                 'var lista = [1, 2, 3, 4, 5]',
                                 'var minhaListaCompreensao = [x * 2 para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares',
-                                'escreva(minhaListaCompreensao)'
-                            ], -1
+                                'escreva(minhaListaCompreensao)',
+                            ],
+                            -1
                         );
-                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
 
-                        const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
 
                         expect(retornoInterpretador.erros).toHaveLength(0);
                         expect(_saidas).toHaveLength(1);
@@ -82,19 +99,29 @@ describe('Interpretador (Pituguês)', () => {
                 });
 
                 it('Vetor', async () => {
-                    const retornoLexador = lexador.mapear(["var a = [1, 2, 3]"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['var a = [1, 2, 3]'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Dicionário', async () => {
                     const retornoLexador = lexador.mapear(["var a = {'a': 1, 'b': 2}"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -102,19 +129,35 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {
-                    const retornoLexador = lexador.mapear(["var a = [1, 2, 3];\nescreva(a[1])"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ['var a = [1, 2, 3];\nescreva(a[1])'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Acesso a elementos de dicionário', async () => {
-                    const retornoLexador = lexador.mapear(["var a = {'a': 1, 'b': 2};\nescreva(a['b'])"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ["var a = {'a': 1, 'b': 2};\nescreva(a['b'])"],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -123,36 +166,56 @@ describe('Interpretador (Pituguês)', () => {
             describe('escreva() e imprima()', () => {
                 it('Olá Mundo (escreva() e literal)', async () => {
                     const retornoLexador = lexador.mapear(["escreva('Olá mundo')"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('nulo', async () => {
-                    const retornoLexador = lexador.mapear(["escreva(nulo)"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['escreva(nulo)'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Olá Mundo (imprima() e literal)', async () => {
                     const retornoLexador = lexador.mapear(["imprima('Olá mundo')"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('nulo', async () => {
-                    const retornoLexador = lexador.mapear(["imprima(nulo)"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['imprima(nulo)'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -169,29 +232,42 @@ describe('Interpretador (Pituguês)', () => {
                         },
                     };
 
-                    const retornoLexador = lexador.mapear([
-                        'var teste = leia("Insira algo:")',
-                        "imprima(teste)",
-                    ], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ['var teste = leia("Insira algo:")', 'imprima(teste)'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
                     interpretador.funcaoDeRetorno = (saida: any) => {
                         _saida = saida;
                     };
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saida).toBeTruthy();
-                    expect(_saida).toBe("5");
+                    expect(_saida).toBe('5');
                 });
             });
 
             describe('Operações matemáticas', () => {
                 it('Trivial', async () => {
-                    const retornoLexador = lexador.mapear(["escreva(5 + 4 * 3 - 2 ** 1 / 6 % 10)"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ['escreva(5 + 4 * 3 - 2 ** 1 / 6 % 10)'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -199,28 +275,43 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Operações lógicas', () => {
                 it('Operações lógicas - ou', async () => {
-                    const retornoLexador = lexador.mapear(["escreva(verdadeiro ou falso)"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['escreva(verdadeiro ou falso)'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Operações lógicas - e', async () => {
-                    const retornoLexador = lexador.mapear(["escreva(verdadeiro e falso)"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['escreva(verdadeiro e falso)'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Operações lógicas - em', async () => {
-                    const retornoLexador = lexador.mapear(["escreva(2 em [1, 2, 3])"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['escreva(2 em [1, 2, 3])'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -229,30 +320,40 @@ describe('Interpretador (Pituguês)', () => {
             describe('Condicionais', () => {
                 it('Condicionais - condição verdadeira', async () => {
                     const codigo = [
-                        "se (1 < 2):",
+                        'se (1 < 2):',
                         "   escreva('Um menor que dois')",
-                        "senao:",
+                        'senao:',
                         "   escreva('Nunca será executado')",
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Condicionais - condição falsa', async () => {
                     const codigo = [
-                        "se (1 > 2):",
+                        'se (1 > 2):',
                         "   escreva('Nunca acontece')",
-                        "senão:",
+                        'senão:',
                         "   escreva('Um não é maior que dois')",
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
@@ -260,34 +361,55 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Laços de repetição', () => {
                 it('Laços de repetição - enquanto', async () => {
-                    const retornoLexador = lexador.mapear(["var a = 0\nenquanto a < 10:\n    a = a + 1"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ['var a = 0\nenquanto a < 10:\n    a = a + 1'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Laços de repetição - fazer ... enquanto', async () => {
-                    const retornoLexador = lexador.mapear(["var a = 0\nfazer:\n    a = a + 1\nenquanto a < 10"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ['var a = 0\nfazer:\n    a = a + 1\nenquanto a < 10'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Laços de repetição - para', async () => {
                     const codigo = [
-                        "para var i = 0; i < 10; i = i + 1:",
-                        "    se i == 3:",
-                        "        continua",
-                        "    escreva(i)",
+                        'para var i = 0; i < 10; i = i + 1:',
+                        '    se i == 3:',
+                        '        continua',
+                        '    escreva(i)',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(9);
@@ -298,13 +420,18 @@ describe('Interpretador (Pituguês)', () => {
                         [
                             'var vetor = [1, 2, 3]',
                             'para cada elemento de vetor:',
-                            '    escreva(elemento)'
-                        ], -1
+                            '    escreva(elemento)',
+                        ],
+                        -1
                     );
-                    const retornoAvaliadorSintatico =
-                        avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(3);
@@ -317,22 +444,27 @@ describe('Interpretador (Pituguês)', () => {
             describe('Classes', () => {
                 it('Trivial', async () => {
                     const codigo = [
-                        "classe Animal:",
-                        "    função correr():",
+                        'classe Animal:',
+                        '    função correr():',
                         "        escreva('Correndo Loucamente')",
-                        "classe Cachorro(Animal):",
-                        "    função latir():",
+                        'classe Cachorro(Animal):',
+                        '    função latir():',
                         "        escreva('Au Au Au Au')",
-                        "var nomeDoCachorro = Cachorro()",
-                        "nomeDoCachorro.correr()",
-                        "nomeDoCachorro.latir()",
-                        "escreva('Classe: OK!')"
+                        'var nomeDoCachorro = Cachorro()',
+                        'nomeDoCachorro.correr()',
+                        'nomeDoCachorro.latir()',
+                        "escreva('Classe: OK!')",
                     ];
 
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(3);
@@ -343,20 +475,25 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Classes - declaração `super()` ', async () => {
                     const codigo = [
-                        "classe Procurando:",
-                        "    construtor():",
+                        'classe Procurando:',
+                        '    construtor():',
                         "        imprima('Amigo, onde está você?')",
-                        "classe Amigo(Procurando):",
-                        "    construtor():",
-                        "        super()",
+                        'classe Amigo(Procurando):',
+                        '    construtor():',
+                        '        super()',
                         "        imprima('Amigo, estou aqui!')",
-                        "var amigo = Amigo()",
+                        'var amigo = Amigo()',
                     ];
 
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(2);
@@ -367,15 +504,16 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Declaração e chamada de funções', () => {
                 it('Trivial', async () => {
-                    const codigo = [
-                        'funcao teste():',
-                        '    imprima("Teste")',
-                        'teste()'
-                    ];
+                    const codigo = ['funcao teste():', '    imprima("Teste")', 'teste()'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -384,33 +522,38 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Fibonacci', async () => {
                     const codigo = [
-                        "função fibonacci(n):",
-                        "    se (n == 0):",
-                        "       retorna(0)",
-                        "    se (n == 1):",
-                        "       retorna(1)",
-                        "    var n1 = n - 1",
-                        "    var n2 = n - 2",
-                        "    var f1 = fibonacci(n1)",
-                        "    var f2 = fibonacci(n2)",
-                        "    retorna(f1 + f2)",
-                        "var a = fibonacci(0)",
-                        "escreva(a)",
-                        "a = fibonacci(1)",
-                        "escreva(a)",
-                        "a = fibonacci(2)",
-                        "escreva(a)",
-                        "a = fibonacci(3)",
-                        "escreva(a)",
-                        "a = fibonacci(4)",
-                        "escreva(a)",
-                        "a = fibonacci(5)",
-                        "escreva(a)"
+                        'função fibonacci(n):',
+                        '    se (n == 0):',
+                        '       retorna(0)',
+                        '    se (n == 1):',
+                        '       retorna(1)',
+                        '    var n1 = n - 1',
+                        '    var n2 = n - 2',
+                        '    var f1 = fibonacci(n1)',
+                        '    var f2 = fibonacci(n2)',
+                        '    retorna(f1 + f2)',
+                        'var a = fibonacci(0)',
+                        'escreva(a)',
+                        'a = fibonacci(1)',
+                        'escreva(a)',
+                        'a = fibonacci(2)',
+                        'escreva(a)',
+                        'a = fibonacci(3)',
+                        'escreva(a)',
+                        'a = fibonacci(4)',
+                        'escreva(a)',
+                        'a = fibonacci(5)',
+                        'escreva(a)',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(6);
@@ -424,15 +567,20 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Uso de funções de ordem superior', async () => {
                     const codigo = [
-                        "var vetor = [1, 2, 3]",
-                        "var fn = funcao(valor):",
-                        "    retorna valor * 2",
-                        "escreva(mapear(vetor, fn))"
+                        'var vetor = [1, 2, 3]',
+                        'var fn = funcao(valor):',
+                        '    retorna valor * 2',
+                        'escreva(mapear(vetor, fn))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -445,12 +593,17 @@ describe('Interpretador (Pituguês)', () => {
                     const codigo = [
                         'var tex = "Eu sou um abacaxi"',
                         'var div = tex.dividir(" ")',
-                        'escreva(div)'
+                        'escreva(div)',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -462,12 +615,17 @@ describe('Interpretador (Pituguês)', () => {
                         'var vetor = [1, 2, 3]',
                         'var fn = funcao(valor):',
                         '    retorna valor * 2',
-                        'escreva(mapear(vetor, fn))'
+                        'escreva(mapear(vetor, fn))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -477,14 +635,16 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Uso de primitivas de número', () => {
                 it('arredondarParaBaixo', async () => {
-                    const codigo = [
-                        'var n1 = 3.1415',
-                        'escreva(n1.arredondarParaBaixo())'
-                    ];
+                    const codigo = ['var n1 = 3.1415', 'escreva(n1.arredondarParaBaixo())'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -492,14 +652,16 @@ describe('Interpretador (Pituguês)', () => {
                 });
 
                 it('arredondarParaCima', async () => {
-                    const codigo = [
-                        'var n1 = 3.1415',
-                        'escreva(n1.arredondarParaCima())'
-                    ];
+                    const codigo = ['var n1 = 3.1415', 'escreva(n1.arredondarParaCima())'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -509,13 +671,16 @@ describe('Interpretador (Pituguês)', () => {
 
             describe('Uso de primitivas de texto', () => {
                 it('aparar', async () => {
-                    const codigo = [
-                        'escreva("   texto com espaços        ".aparar())'
-                    ];
+                    const codigo = ['escreva("   texto com espaços        ".aparar())'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -526,12 +691,17 @@ describe('Interpretador (Pituguês)', () => {
                     const codigo = [
                         'var t1 = "um texto"',
                         'var t2 = " concatenado com outro"',
-                        'escreva(t1.concatenar(t2))'
+                        'escreva(t1.concatenar(t2))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -539,14 +709,16 @@ describe('Interpretador (Pituguês)', () => {
                 });
 
                 it('dividir', async () => {
-                    const codigo = [
-                        'var t1 = "um dois três"',
-                        'escreva(t1.dividir(" "))'
-                    ];
+                    const codigo = ['var t1 = "um dois três"', 'escreva(t1.dividir(" "))'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
@@ -554,33 +726,37 @@ describe('Interpretador (Pituguês)', () => {
                 });
 
                 it('maiusculo', async () => {
-                    const codigo = [
-                        'var t1 = "um dois três"',
-                        'escreva(t1.maiusculo())'
-                    ];
+                    const codigo = ['var t1 = "um dois três"', 'escreva(t1.maiusculo())'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
-                    expect(_saidas[0]).toBe("UM DOIS TRÊS");
+                    expect(_saidas[0]).toBe('UM DOIS TRÊS');
                 });
 
                 it('minusculo', async () => {
-                    const codigo = [
-                        'var t1 = "UM DOIS TRÊS"',
-                        'escreva(t1.minusculo())'
-                    ];
+                    const codigo = ['var t1 = "UM DOIS TRÊS"', 'escreva(t1.minusculo())'];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
-                    expect(_saidas[0]).toBe("um dois três");
+                    expect(_saidas[0]).toBe('um dois três');
                 });
             });
 
@@ -589,12 +765,17 @@ describe('Interpretador (Pituguês)', () => {
                     const codigo = [
                         'var lista = ["Ser", "ou", "não", "ser"]',
                         'escreva(lista.fatiar(2))',
-                        'escreva(lista.fatiar(1, 2))'
+                        'escreva(lista.fatiar(1, 2))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(2);
@@ -608,48 +789,160 @@ describe('Interpretador (Pituguês)', () => {
                         'var lista2 = ["Ser", "ou", "não", "ser"]',
                         'escreva(lista.inclui(5))',
                         'escreva(lista2.inclui("ser"))',
-                        'escreva(lista2.inclui("abc"))'
+                        'escreva(lista2.inclui("abc"))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(3);
-                    expect(_saidas[0]).toBe("verdadeiro");
-                    expect(_saidas[1]).toBe("verdadeiro");
-                    expect(_saidas[2]).toBe("falso");
+                    expect(_saidas[0]).toBe('verdadeiro');
+                    expect(_saidas[1]).toBe('verdadeiro');
+                    expect(_saidas[2]).toBe('falso');
                 });
 
                 it('substituir', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.substituir("Ser", "Salmão"));'
+                        'escreva(t.substituir("Ser", "Salmão"));',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
-                    expect(_saidas[0]).toBe("Salmão ou não ser, eis a questão");
+                    expect(_saidas[0]).toBe('Salmão ou não ser, eis a questão');
                 });
 
                 it('subtexto', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.subtexto(4, 10))'
+                        'escreva(t.subtexto(4, 10))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
-                    expect(_saidas[0]).toBe("ou não");
+                    expect(_saidas[0]).toBe('ou não');
+                });
+
+                it('encontre - índice inicial encontrado', async () => {
+                    const codigo = [
+                        'var t = "Ser ou não ser, eis a questão"',
+                        'escreva(t.encontre("ser"))',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('11');
+                });
+
+                it('encontre - subtexto não encontrado', async () => {
+                    const codigo = [
+                        'var t = "Ser ou não ser, eis a questão"',
+                        'escreva(t.encontre("abacaxi"))',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('-1');
+                });
+
+                it('encontre - com índice inicial', async () => {
+                    const codigo = [
+                        'var t = "Ser ou não ser, eis a questão"',
+                        'escreva(t.encontre("ou", 4))',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('4');
+                });
+
+                it('encontre - índice inicial após última ocorrência', async () => {
+                    const codigo = [
+                        'var t = "Ser ou não ser, eis a questão"',
+                        'escreva(t.encontre("Ser", 5))',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('-1');
+                });
+
+                it('encontre - primeira ocorrência no início', async () => {
+                    const codigo = ['var t = "abcabc"', 'escreva(t.encontre("abc"))'];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('0');
                 });
             });
         });
@@ -657,19 +950,32 @@ describe('Interpretador (Pituguês)', () => {
         describe('Cenários de falha', () => {
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {
-                    const retornoLexador = lexador.mapear(["var a = [1, 2, 3]\nescreva(a[4])"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(['var a = [1, 2, 3]\nescreva(a[4])'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                 });
 
                 it('Acesso a elementos de dicionário', async () => {
-                    const retornoLexador = lexador.mapear(["var a = {'a': 1, 'b': 2}\nescreva(a['c'])"], -1);
-                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoLexador = lexador.mapear(
+                        ["var a = {'a': 1, 'b': 2}\nescreva(a['c'])"],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
 
-                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThanOrEqual(0);
                 });

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -851,7 +851,7 @@ describe('Interpretador (Pituguês)', () => {
                 it('encontre - índice inicial encontrado', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.encontre("ser"))',
+                        'escreva(t.encontrar("ser"))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -891,7 +891,7 @@ describe('Interpretador (Pituguês)', () => {
                 it('encontre - com índice inicial', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.encontre("ou", 4))',
+                        'escreva(t.encontrar("ou", 4))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -911,7 +911,7 @@ describe('Interpretador (Pituguês)', () => {
                 it('encontre - índice inicial após última ocorrência', async () => {
                     const codigo = [
                         'var t = "Ser ou não ser, eis a questão"',
-                        'escreva(t.encontre("Ser", 5))',
+                        'escreva(t.encontrar("Ser", 5))',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(


### PR DESCRIPTION
### O que este PR faz?
Este PR adiciona a função nativa encontre() ao dialeto Pituguês, permitindo a busca literal de subtextos. O comportamento é inspirado na função find() do Python e inclui um parâmetro opcional para definir o índice de início da busca.
### Resolve a issue:
Resolve a issue #934 
### Como foi testado?
Foram adicionados testes unitários de sucesso ao arquivo interpretador.test.ts para cobrir os principais cenários de uso, incluindo buscas bem-sucedidas, falhas, uso do índice inicial e casos de borda.