### PR TITLE
adiciona avaliador sintático para pituguês

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues.ts
@@ -1,0 +1,287 @@
+import {
+    AcessoIndiceVariavel,
+    AcessoMetodoOuPropriedade,
+    Agrupamento,
+    Binario,
+    Chamada,
+    Construto,
+    Literal,
+    Logico,
+    Unario,
+    Vetor,
+} from '../../construtos';
+import { Declaracao } from '../../declaracoes';
+import { SimboloInterface } from '../../interfaces';
+import { RetornoAvaliadorSintatico, RetornoLexador } from '../../interfaces/retornos';
+import { MicroAvaliadorSintaticoBase } from '../micro-avaliador-sintatico-base';
+
+import tiposDeSimbolos from '../../tipos-de-simbolos/pitugues';
+
+/**
+ * O MicroAvaliadorSintatico funciona apenas dentro de interpolações de texto.
+ */
+export class MicroAvaliadorSintaticoPitugues extends MicroAvaliadorSintaticoBase {
+    primario(): Construto {
+        const simboloAtual = this.simbolos[this.atual];
+        let valores = [];
+        switch (simboloAtual.tipo) {
+            // TODO: Verificar se vamos usar isso.
+            /* case tiposDeSimbolos.CHAVE_ESQUERDA:
+                this.avancarEDevolverAnterior();
+                const chaves = [];
+                valores = [];
+
+                if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_DIREITA)) {
+                    return new Dicionario(-1, Number(this.linha), [], []);
+                }
+
+                while (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CHAVE_DIREITA)) {
+                    const chave = this.atribuir();
+                    this.consumir(tiposDeSimbolos.DOIS_PONTOS, "Esperado ':' entre chave e valor.");
+                    const valor = this.atribuir();
+
+                    chaves.push(chave);
+                    valores.push(valor);
+
+                    if (this.simbolos[this.atual].tipo !== tiposDeSimbolos.CHAVE_DIREITA) {
+                        this.consumir(tiposDeSimbolos.VIRGULA, 'Esperado vírgula antes da próxima expressão.');
+                    }
+                }
+
+                return new Dicionario(-1, Number(this.linha), chaves, valores); */
+
+            // TODO: Verificar se vamos usar isso.
+            case tiposDeSimbolos.COLCHETE_ESQUERDO:
+                this.avancarEDevolverAnterior();
+                valores = [];
+
+                if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_DIREITO)) {
+                    return new Vetor(-1, Number(this.linha), []);
+                }
+
+                while (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_DIREITO)) {
+                    const valor = this.declaracao();
+                    valores.push(valor);
+                    if (this.simbolos[this.atual].tipo !== tiposDeSimbolos.COLCHETE_DIREITO) {
+                        this.consumir(
+                            tiposDeSimbolos.VIRGULA,
+                            'Esperado vírgula antes da próxima expressão.'
+                        );
+                    }
+                }
+
+                return new Vetor(-1, Number(this.linha), valores);
+
+            case tiposDeSimbolos.FALSO:
+                this.avancarEDevolverAnterior();
+                return new Literal(-1, Number(this.linha), false);
+
+
+            case tiposDeSimbolos.NULO:
+                this.avancarEDevolverAnterior();
+                return new Literal(-1, Number(this.linha), null);
+
+            case tiposDeSimbolos.NUMERO:
+            case tiposDeSimbolos.TEXTO:
+                const simboloNumeroTexto: SimboloInterface = this.avancarEDevolverAnterior();
+                return new Literal(-1, Number(this.linha), simboloNumeroTexto.literal);
+
+            case tiposDeSimbolos.PARENTESE_ESQUERDO:
+                this.avancarEDevolverAnterior();
+                const expressao = this.ou();
+                this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após a expressão.");
+
+                return new Agrupamento(-1, Number(this.linha), expressao);
+
+            case tiposDeSimbolos.VERDADEIRO:
+                this.avancarEDevolverAnterior();
+                return new Literal(-1, Number(this.linha), true);
+        }
+
+        throw this.erro(this.simbolos[this.atual], 'Esperado expressão.');
+    }
+
+    finalizarChamada(entidadeChamada: Construto): Construto {
+        const argumentos: Array<Construto> = [];
+
+        if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.PARENTESE_DIREITO)) {
+            do {
+                if (argumentos.length >= 255) {
+                    throw this.erro(
+                        this.simbolos[this.atual],
+                        'Não pode haver mais de 255 argumentos.'
+                    );
+                }
+                argumentos.push(this.ou());
+            } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
+        }
+
+        this.consumir(tiposDeSimbolos.PARENTESE_DIREITO, "Esperado ')' após os argumentos.");
+
+        return new Chamada(-1, entidadeChamada, argumentos);
+    }
+
+    chamar(): Construto {
+        let expressao = this.primario();
+
+        while (true) {
+            if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARENTESE_ESQUERDO)) {
+                expressao = this.finalizarChamada(expressao);
+            } else if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO)) {
+                const nome = this.consumir(
+                    tiposDeSimbolos.IDENTIFICADOR,
+                    "Esperado nome do método após '.'."
+                );
+                expressao = new AcessoMetodoOuPropriedade(-1, expressao, nome);
+            } else if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_ESQUERDO)) {
+                const indice = this.ou();
+                const simboloFechamento = this.consumir(
+                    tiposDeSimbolos.COLCHETE_DIREITO,
+                    "Esperado ']' após escrita do indice."
+                );
+                expressao = new AcessoIndiceVariavel(-1, expressao, indice, simboloFechamento);
+            } else {
+                break;
+            }
+        }
+
+        return expressao;
+    }
+
+    override unario(): Construto {
+        if (
+            this.verificarSeSimboloAtualEIgualA(
+                tiposDeSimbolos.NEGACAO,
+                tiposDeSimbolos.SUBTRACAO,
+                tiposDeSimbolos.BIT_NOT
+            )
+        ) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.unario();
+            return new Unario(-1, operador, direito, 'ANTES');
+        }
+
+        return this.chamar();
+    }
+
+
+
+    override exponenciacao(): Construto {
+        let expressao = this.unario();
+
+        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.unario();
+            expressao = new Binario(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    protected bitShift(): Construto {
+        let expressao = this.adicaoOuSubtracao();
+
+        while (
+            this.verificarSeSimboloAtualEIgualA(
+                tiposDeSimbolos.MENOR_MENOR,
+                tiposDeSimbolos.MAIOR_MAIOR
+            )
+        ) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.adicaoOuSubtracao();
+            expressao = new Binario(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    protected bitE(): Construto {
+        let expressao = this.bitShift();
+
+        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.BIT_AND)) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.bitShift();
+            expressao = new Binario(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    protected bitOu(): Construto {
+        let expressao = this.bitE();
+
+        while (
+            this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.BIT_OR, tiposDeSimbolos.BIT_XOR)
+        ) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.bitE();
+            expressao = new Binario(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    override comparar(): Construto {
+        let expressao = this.bitOu();
+
+        while (
+            this.verificarSeSimboloAtualEIgualA(
+                tiposDeSimbolos.MAIOR,
+                tiposDeSimbolos.MAIOR_IGUAL,
+                tiposDeSimbolos.MENOR,
+                tiposDeSimbolos.MENOR_IGUAL
+            )
+        ) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.bitOu();
+            expressao = new Binario(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    protected em(): Construto {
+        let expressao = this.comparacaoIgualdade();
+
+        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EM)) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.comparacaoIgualdade();
+            expressao = new Logico(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    override e(): Construto {
+        let expressao = this.em();
+
+        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.E)) {
+            const operador = this.simbolos[this.atual - 1];
+            const direito = this.em();
+            expressao = new Logico(-1, expressao, operador, direito);
+        }
+
+        return expressao;
+    }
+
+    analisar(
+        retornoLexador: RetornoLexador<SimboloInterface>,
+        linha: number
+    ): RetornoAvaliadorSintatico<Declaracao> {
+        this.erros = [];
+        this.atual = 0;
+        this.linha = linha;
+
+        this.simbolos = retornoLexador?.simbolos || [];
+
+        const declaracoes: Declaracao[] = [];
+        while (this.atual < this.simbolos.length) {
+            declaracoes.push(this.declaracao() as Declaracao);
+        }
+
+        return {
+            declaracoes: declaracoes,
+            erros: this.erros,
+        } as RetornoAvaliadorSintatico<Declaracao>;
+    }
+}

--- a/testes/pitugues/micro-avaliador-sintatico.test.ts
+++ b/testes/pitugues/micro-avaliador-sintatico.test.ts
@@ -1,0 +1,31 @@
+
+import  {MicroAvaliadorSintaticoPitugues}  from '../../fontes/avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues';
+import { LexadorPitugues } from "../../fontes/lexador/dialetos";
+
+describe('MicroAvaliadorSintatico (Pituguês)', () => {
+    describe('analisar()', () => {
+        let lexador: LexadorPitugues;
+        let microAvaliadorSintatico: MicroAvaliadorSintaticoPitugues;
+        const HASH_ARQUIVO_EXEMPLO = -1; // valor usado nos testes (identificador/fonte)
+
+        beforeEach(() => {
+            lexador = new LexadorPitugues();
+            microAvaliadorSintatico = new MicroAvaliadorSintaticoPitugues();
+        });
+        describe('Casos de sucesso', () => {
+            it('Olá Mundo', () => {
+                const retornoLexador = lexador.mapear(
+                    ["var nome = 'Design Liquido'",
+                        "imprima(Olá, {nome}!)"
+                    ],
+                    HASH_ARQUIVO_EXEMPLO
+                );
+                const retornoMicroAvaliadorSintatico =
+                    microAvaliadorSintatico.analisar(retornoLexador, HASH_ARQUIVO_EXEMPLO);
+                expect(retornoMicroAvaliadorSintatico).toBeTruthy();
+                expect(retornoMicroAvaliadorSintatico.declaracoes).toHaveLength(2);
+            });
+            
+        });
+    });
+});


### PR DESCRIPTION
Adiciona avaliador sintático para pituguês para lidar com texto independentemente.
## Modificações 
- Adicionados: `testes\pitugues\micro-avaliador-sintatico.test.ts` e `testes\pitugues\micro-avaliador-sintatico.test.ts` 



fix #940 