### PR TITLE
Implantação do 'SE Ternário'

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -722,10 +722,11 @@ export class AvaliadorSintaticoPitugues
      protected seTernario(): Construto {
             let expressaoOuCondicao = this.ou();
     
-            while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAO)) {
+            while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SE)) {
                 const operador = this.simbolos[this.atual - 1];
                 const expressaoEntao = this.seTernario();
-                this.consumir(tiposDeSimbolos.DOIS_PONTOS, `Esperado dois-pontos após caminho positivo em se ternário. Atual: ${this.simbolos[this.atual].lexema}.`);
+              this.consumir(tiposDeSimbolos.SENAO, `Esperado 'senão' ou 'senao' após caminho positivo em se ternário. Atual:
+                 ${this.simbolos[this.atual].lexema}.`);
                 const expressaoSenao = this.seTernario();
                 expressaoOuCondicao = new SeTernario(this.hashArquivo, expressaoOuCondicao, expressaoEntao, operador, expressaoSenao);
             }

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -83,6 +83,7 @@ import primitivasNumero from '../../bibliotecas/primitivas-numero';
 import primitivasTexto from '../../bibliotecas/primitivas-texto';
 import primitivasVetor from '../../bibliotecas/primitivas-vetor';
 import { ListaCompreensao } from '../../construtos/lista-compreensao';
+import { SeTernario } from '../../construtos/se-ternario';
 
 /**
  * O avaliador sintático (_Parser_) é responsável por transformar os símbolos do Lexador em estruturas de alto nível.
@@ -718,6 +719,20 @@ export class AvaliadorSintaticoPitugues
 
         return expressao;
     }
+     protected seTernario(): Construto {
+            let expressaoOuCondicao = this.ou();
+    
+            while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.SENAO)) {
+                const operador = this.simbolos[this.atual - 1];
+                const expressaoEntao = this.seTernario();
+                this.consumir(tiposDeSimbolos.DOIS_PONTOS, `Esperado dois-pontos após caminho positivo em se ternário. Atual: ${this.simbolos[this.atual].lexema}.`);
+                const expressaoSenao = this.seTernario();
+                expressaoOuCondicao = new SeTernario(this.hashArquivo, expressaoOuCondicao, expressaoEntao, operador, expressaoSenao);
+            }
+    
+            return expressaoOuCondicao;
+        }
+    
 
     ou(): Construto {
         let expressao = this.e();

--- a/testes/pitugues/avaliador-sintatico.test.ts
+++ b/testes/pitugues/avaliador-sintatico.test.ts
@@ -95,6 +95,18 @@ describe('Avaliador sintático (Pituguês)', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
             });
+            it('SE ternário', () => {
+                const retornoLexador = lexador.mapear(
+                    [
+                    'var idade = 20',
+                    'var categoria = "Adulto" se idade >= 18 senão "Menor de idade"'
+                    ], -1
+                );
+                const retornoAvaliadorSintatico =
+                    avaliadorSintatico.analisar(retornoLexador, -1);
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+            });
         });
         
         describe('Casos de falha', () => {

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -949,7 +949,7 @@ describe('Interpretador (Pituguês)', () => {
                     const codigo = [
                         'var a = 10',
                         'var b = 20',
-                        'var maior = a > b se a senão b',
+                        'var maior = a se a > b senão b',
                         'escreva(maior)',
                     ];
                     const retornoLexador = lexador.mapear(codigo, -1);
@@ -962,6 +962,8 @@ describe('Interpretador (Pituguês)', () => {
                     );
                     expect(retornoAvaliadorSintatico).toBeTruthy();
                     expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('20');
                 
                     
                 });

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -944,6 +944,27 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('0');
                 });
+                
+                it('SE ternário', async() => {
+                    const codigo = [
+                        'var a = 10',
+                        'var b = 20',
+                        'var maior = a > b se a senão b',
+                        'escreva(maior)',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                
+                    
+                });
             });
         });
 


### PR DESCRIPTION
Implementa 'SE Ternário'
## Modificações 
- Modificado: `fontes\avaliador-sintatico\dialetos\avaliador-sintatico-pitugues.ts` e `testes\pitugues\avaliador-sintatico.test.ts`

fix #904