### PR TITLE
 adiciona suporte à interpolação de variáveis em textos

### DIFF
--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -15,6 +15,8 @@ import tipoDeDadosPrimitivos from '../../../tipos-de-dados/primitivos';
 import tipoDeDadosPitugues from '../../../tipos-de-dados/dialetos/pitugues';
 
 export class InterpretadorPitugues extends Interpretador {
+    
+    regexInterpolacao: RegExp = /\$\{[a-zA-Z_][a-zA-Z0-9_]*\}/g;
     override async visitarExpressaoAcessoMetodo(expressao: AcessoMetodo): Promise<any> {
         const nomeObjeto = this.resolverNomeObjectoAcessado(expressao.objeto);
 
@@ -332,4 +334,29 @@ export class InterpretadorPitugues extends Interpretador {
             )
         );
     }
+
+    protected override async resolverInterpolacoes(textoOriginal: string, linha: number): Promise<any[]> {
+        const variaveis = textoOriginal.match(this.regexInterpolacao);
+
+        if (!variaveis) return [];
+
+        const resultadosAvaliacaoSintatica = variaveis.map((s) => {
+            // s tem a forma "${identificador}" — removemos apenas os dois primeiros e o último caractere
+            const expressaoInterpolacao: string = s.slice(2, -1);
+
+            let microLexador = this.microLexador.mapear(expressaoInterpolacao);
+            const resultadoMicroAvaliadorSintatico = this.microAvaliadorSintatico.analisar(
+                microLexador,
+                linha
+            );
+
+            return {
+                expressaoInterpolacao,
+                resultadoMicroAvaliadorSintatico,
+            };
+        });
+
+        return resultadosAvaliacaoSintatica;
+    }
+
 }

--- a/fontes/lexador/micro-lexador-pitugues.ts
+++ b/fontes/lexador/micro-lexador-pitugues.ts
@@ -6,6 +6,8 @@ import { palavrasReservadasMicroGramatica as palavrasReservadas } from './palavr
 import { Simbolo } from './simbolo';
 
 import tiposDeSimbolos from '../tipos-de-simbolos/pitugues';
+import { MicroLexador } from './micro-lexador';
+import { MicroAvaliadorSintaticoPitugues } from '../avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues';
 
 /**
  * O MicroLexador funciona apenas dentro de interpolações de texto.
@@ -18,7 +20,10 @@ export class MicroLexadorPitugues {
     inicioSimbolo: number;
     atual: number;
     codigo: string;
-
+    microLexador: MicroLexador = new MicroLexadorPitugues();
+    microAvaliadorSintatico: MicroAvaliadorSintaticoPitugues = new MicroAvaliadorSintaticoPitugues();
+    // Aceita apenas interpolações no formato ${identificador} (equivalente a "f-string")
+    regexInterpolacao: RegExp = /\$\{[a-zA-Z_][a-zA-Z0-9_]*\}/g;
     eDigito(caractere: string): boolean {
         return caractere >= '0' && caractere <= '9';
     }
@@ -158,7 +163,7 @@ export class MicroLexadorPitugues {
             case '*':
                 this.atual++;
                 switch (this.codigo[this.atual]) {
-                    case '*':
+                    case '**':
                         this.atual++;
                         this.adicionarSimbolo(tiposDeSimbolos.EXPONENCIACAO);
                         break;
@@ -236,5 +241,35 @@ export class MicroLexadorPitugues {
             simbolos: this.simbolos,
             erros: this.erros,
         } as RetornoLexador<SimboloInterface>;
+    }
+
+    
+    /**
+     * Resolve todas as interpolações em um texto.
+     * @param {texto} textoOriginal O texto original com as variáveis interpoladas.
+     * @returns Uma lista de variáveis interpoladas.
+     */
+    protected async resolverInterpolacoes(textoOriginal: string, linha: number): Promise<any[]> {
+        const variaveis = textoOriginal.match(this.regexInterpolacao);
+
+        if (!variaveis) return [];
+
+        const resultadosAvaliacaoSintatica = variaveis.map((s) => {
+            // s tem a forma "${identificador}" — removemos apenas os dois primeiros e o último caractere
+            const expressaoInterpolacao: string = s.slice(2, -1);
+
+            let microLexador = this.microLexador.mapear(expressaoInterpolacao);
+            const resultadoMicroAvaliadorSintatico = this.microAvaliadorSintatico.analisar(
+                microLexador,
+                linha
+            );
+
+            return {
+                expressaoInterpolacao,
+                resultadoMicroAvaliadorSintatico,
+            };
+        });
+
+        return resultadosAvaliacaoSintatica;
     }
 }

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1081,7 +1081,26 @@ describe('Interpretador (Pituguês)', () => {
             expect(_saidas).toHaveLength(1);
             expect(_saidas[0]).toBe('falso');
         });
+        it('interpolação de variáveis em textos', async () => {
+            const codigo = [
+                'var nome = "Maria"',
+                'var idade = 30',
+                'escreva(f"Meu nome é ${nome} e eu tenho ${idade} anos.")',
+            ];
+            const retornoLexador = lexador.mapear(codigo, -1);
+            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(  
+                retornoLexador,
+                -1
+            );
+            const retornoInterpretador = await interpretador.interpretar(
+                retornoAvaliadorSintatico.declaracoes
+            );
+            expect(retornoInterpretador.erros).toHaveLength(0);
+            expect(_saidas).toHaveLength(1);
+            expect(_saidas[0]).toBe('Meu nome é Maria e eu tenho 30 anos.');
+        });
 
+        
         describe('Cenários de falha', () => {
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1082,6 +1082,25 @@ describe('Interpretador (Pituguês)', () => {
             expect(_saidas[0]).toBe('falso');
         });
 
+        it('interpolação de variáveis em textos', async () => {
+            const codigo = [
+                'var nome = "Maria"',
+                'var idade = 30',
+                'escreva(f"Meu nome é ${nome} e eu tenho ${idade} anos.")',
+            ];
+            const retornoLexador = lexador.mapear(codigo, -1);
+            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(  
+                retornoLexador,
+                -1
+            );
+            const retornoInterpretador = await interpretador.interpretar(
+                retornoAvaliadorSintatico.declaracoes
+            );
+            expect(retornoInterpretador.erros).toHaveLength(0);
+            expect(_saidas).toHaveLength(1);
+            expect(_saidas[0]).toBe('Meu nome é Maria e eu tenho 30 anos.');
+        });
+
         describe('Cenários de falha', () => {
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {

--- a/testes/pitugues/micro-lexador.test.ts
+++ b/testes/pitugues/micro-lexador.test.ts
@@ -59,7 +59,12 @@ describe('Lexador', () => {
                 expect(resultado).toBeTruthy();
                 expect(resultado.simbolos).toHaveLength(11);
             });
-
+            
+            it('Interpolação de variáveis em texto', () => {
+                const resultado = microLexadorPitugues.mapear('f"o valor é ${valor}"');
+                expect(resultado).toBeTruthy();
+                expect(resultado.simbolos).toHaveLength(3);
+            });
         });
     });
 });


### PR DESCRIPTION
Esta PR  adiciona suporte à interpolação de variáveis em textos adicionando f-strings como no Python
## Modificações 
- Modificado: `fontes\avaliador-sintatico\dialetos\avaliador-sintatico-pitugues.ts`, `testes\pitugues\micro-lexador.test.ts` e `testes\pitugues\interpretador.test.ts`
fix #910