### PR TITLE
Implementando exponenciação com resolução à direita para Delégua e todos os dialetos.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -153,7 +153,7 @@ export abstract class AvaliadorSintaticoBase
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simbolos[this.atual - 1];
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(this.hashArquivo, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-base.ts
@@ -148,6 +148,11 @@ export abstract class AvaliadorSintaticoBase
         return this.chamar();
     }
 
+    /**
+     * A exponenciacão é uma exceção na ordem de avaliação (resolve primeiro à direita). 
+     * Por isso `direito` chama `exponenciacao()`, e não `unario()`.
+     * @returns {Binario} A expressão binária na forma do construto `Binario`. 
+     */
     protected exponenciacao(): Construto {
         let expressao = this.unario();
 

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -1263,23 +1263,12 @@ export class AvaliadorSintatico
         return this.chamar();
     }
 
-    protected elvis(): Construto {
-        let expressao = this.unario();
-
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ELVIS)) {
-            const direito = this.unario();
-            return new Elvis(this.hashArquivo, expressao, direito);
-        }
-
-        return expressao;
-    }
-
     override exponenciacao(): Construto {
-        let expressao = this.elvis();
+        let expressao = this.unario();
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simbolos[this.atual - 1];
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(this.hashArquivo, expressao, operador, direito);
         }
 
@@ -1491,8 +1480,19 @@ export class AvaliadorSintatico
         return expressao;
     }
 
+    protected elvis(): Construto {
+        let expressao = this.ou();
+
+        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ELVIS)) {
+            const direito = this.ou();
+            return new Elvis(this.hashArquivo, expressao, direito);
+        }
+
+        return expressao;
+    }
+
     protected seTernario(): Construto {
-        let expressaoOuCondicao = this.ou();
+        let expressaoOuCondicao = this.elvis();
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.INTERROGACAO)) {
             const operador = this.simbolos[this.atual - 1];

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -1263,6 +1263,11 @@ export class AvaliadorSintatico
         return this.chamar();
     }
 
+    /**
+     * A exponenciacão é uma exceção na ordem de avaliação (resolve primeiro à direita). 
+     * Por isso `direito` chama `exponenciacao()`, e não `unario()`.
+     * @returns {Binario} A expressão binária na forma do construto `Binario`. 
+     */
     override exponenciacao(): Construto {
         let expressao = this.unario();
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
@@ -302,8 +302,8 @@ export class AvaliadorSintaticoEguaClassico
     }
 
     /**
-     * A exponenciacão é uma exceção na ordem de avaliação (resolve primeiro à direita). 
-     * Por isso `direito` chama `exponenciacao()`, e não `unario()`.
+     * A exponenciacão de Égua [é implementada com resolução à esquerda](https://github.com/eguadev/egua/blob/main/src/parser.js#L230). 
+     * Por isso esse dialeto resolve `direito` chamando `unario()`, e não `exponenciacao()` como os demais.
      * @returns {Binario} A expressão binária na forma do construto `Binario`. 
      */
     exponenciacao(): Construto {
@@ -311,7 +311,7 @@ export class AvaliadorSintaticoEguaClassico
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simboloAnterior();
-            const direito = this.exponenciacao();
+            const direito = this.unario();
             expressao = new Binario(this.hashArquivo, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-egua-classico.ts
@@ -301,12 +301,17 @@ export class AvaliadorSintaticoEguaClassico
         return this.chamar();
     }
 
+    /**
+     * A exponenciacão é uma exceção na ordem de avaliação (resolve primeiro à direita). 
+     * Por isso `direito` chama `exponenciacao()`, e não `unario()`.
+     * @returns {Binario} A expressão binária na forma do construto `Binario`. 
+     */
     exponenciacao(): Construto {
         let expressao = this.unario();
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simboloAnterior();
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(this.hashArquivo, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -579,7 +579,7 @@ export class AvaliadorSintaticoPitugues
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simboloAnterior();
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(this.hashArquivo, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-portugol-ipt.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-portugol-ipt.ts
@@ -24,8 +24,9 @@ import {
 import { RetornoLexador, RetornoAvaliadorSintatico } from '../../interfaces/retornos';
 import { AvaliadorSintaticoBase } from '../avaliador-sintatico-base';
 
-import tiposDeSimbolos from '../../tipos-de-simbolos/portugol-ipt';
 import { SimboloInterface } from '../../interfaces';
+
+import tiposDeSimbolos from '../../tipos-de-simbolos/portugol-ipt';
 
 export class AvaliadorSintaticoPortugolIpt extends AvaliadorSintaticoBase {
     primario(): Construto {

--- a/fontes/avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/micro-avaliador-sintatico-pitugues.ts
@@ -168,7 +168,7 @@ export class MicroAvaliadorSintaticoPitugues extends MicroAvaliadorSintaticoBase
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simbolos[this.atual - 1];
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(-1, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/micro-avaliador-sintatico-base.ts
+++ b/fontes/avaliador-sintatico/micro-avaliador-sintatico-base.ts
@@ -64,7 +64,7 @@ export abstract class MicroAvaliadorSintaticoBase {
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simbolos[this.atual - 1];
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(-1, expressao, operador, direito);
         }
 

--- a/fontes/avaliador-sintatico/micro-avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/micro-avaliador-sintatico.ts
@@ -190,23 +190,12 @@ export class MicroAvaliadorSintatico extends MicroAvaliadorSintaticoBase {
         return this.chamar();
     }
 
-    protected elvis(): Construto {
-        let expressao = this.unario();
-
-        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ELVIS)) {
-            const direito = this.unario();
-            return new Elvis(-1, expressao, direito);
-        }
-
-        return expressao;
-    }
-
     override exponenciacao(): Construto {
-        let expressao = this.elvis();
+        let expressao = this.unario();
 
         while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.EXPONENCIACAO)) {
             const operador = this.simbolos[this.atual - 1];
-            const direito = this.unario();
+            const direito = this.exponenciacao();
             expressao = new Binario(-1, expressao, operador, direito);
         }
 
@@ -297,6 +286,21 @@ export class MicroAvaliadorSintatico extends MicroAvaliadorSintaticoBase {
         }
 
         return expressao;
+    }
+
+    protected elvis(): Construto {
+        let expressao = this.ou();
+
+        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.ELVIS)) {
+            const direito = this.ou();
+            return new Elvis(-1, expressao, direito);
+        }
+
+        return expressao;
+    }
+
+    override declaracao(): Declaracao | Construto {
+        return this.elvis();
     }
 
     analisar(

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -660,7 +660,8 @@ export class InterpretadorBase implements InterpretadorInterface {
         switch (expressao.operador.tipo) {
             case tiposDeSimbolos.EXPONENCIACAO:
                 this.verificarOperandosNumeros(expressao.operador, esquerda, direita);
-                return Math.pow(valorEsquerdo, valorDireito);
+                const resultadoExponenciacao = Math.pow(valorEsquerdo, valorDireito);
+                return resultadoExponenciacao;
 
             case tiposDeSimbolos.MAIOR:
                 if (

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -1167,6 +1167,18 @@ describe('Interpretador', () => {
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
+
+                it('Exponenciação encadeada', async () => {
+                    const codigo = ['escreva(5 ** 2 ** 3)'];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe("390625");
+                });
             });
 
             describe('Operadores binários diversos', () => {

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -275,6 +275,18 @@ describe('Interpretador (Pituguês)', () => {
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
+
+                it('Exponenciação encadeada', async () => {
+                    const codigo = ['escreva(5 ** 2 ** 3)'];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe("390625");
+                });
             });
 
             describe('Operações lógicas', () => {


### PR DESCRIPTION
Resolve #989 para Delégua, Pituguês, e demais dialetos, exceto Égua.

[Devido a um código diretamente de Égua](https://github.com/eguadev/egua/blob/main/src/parser.js#L230), a exponenciação é implementada com resolução à esquerda. Isso é mantido na nossa implementação. 