### PR TITLE
[Pituguês] Retorna erro ao identificar ; ao final de linha ou instrução

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -903,7 +903,7 @@ export class AvaliadorSintaticoPitugues
                 espacosIndentacaoLinhaAtual = this.localizacoes[simboloAtual.linha].espacosIndentacao;
             }
         }
-        
+
         this.pilhaEscopos.removerUltimo();
         return declaracoes;
     }
@@ -1084,7 +1084,7 @@ export class AvaliadorSintaticoPitugues
         return new Comentario(
             simboloComentario.hashArquivo,
             simboloComentario.linha,
-            simboloComentario.literal, 
+            simboloComentario.literal,
             false
         );
     }
@@ -1139,7 +1139,7 @@ export class AvaliadorSintaticoPitugues
                     variavelExcecao.lexema,
                     new InformacaoElementoSintatico(variavelExcecao.lexema, 'qualquer')
                 );
-                
+
                 const corpo = this.blocoEscopo();
 
                 blocoPegue = new FuncaoConstruto(
@@ -1422,11 +1422,11 @@ export class AvaliadorSintaticoPitugues
         if (this.simbolos[this.atual].tipo === tiposDeSimbolos.TEXTO_MULTILINHAS) {
             const simboloTexto = this.avancarEDevolverAnterior();
             return new TextoDocumentacao(
-                this.hashArquivo, 
-                Number(simboloTexto.linha), 
+                this.hashArquivo,
+                Number(simboloTexto.linha),
                 simboloTexto.lexema
             );
-        }    
+        }
     }
 
     corpoDaFuncao(tipo: string): FuncaoConstruto {
@@ -1455,7 +1455,7 @@ export class AvaliadorSintaticoPitugues
         this.consumir(tiposDeSimbolos.DOIS_PONTOS, `Esperado ':' antes do escopo do ${tipo}.`);
         const documentacao = this.declaracaoTextoDeDocumentacao();
         const corpo = this.blocoEscopo();
-        
+
         tipoRetorno = logicaValidacaoRetornoFuncao(
             this,
             corpo,
@@ -1546,6 +1546,43 @@ export class AvaliadorSintaticoPitugues
             'Esperado texto para explicar falha.'
         );
         return new Falhar(simboloFalha, textoFalha.literal);
+    }
+
+    /**
+     * Verifica se há pontos e vírgula no final de sentenças.
+     * Em Pituguês, ; só é permitido para separar múltiplos comandos na mesma linha,
+     * mas não no final de uma sentença/linha.
+     */
+    private verificarPontosEVirgulasInvalidos(): void {
+        for (let i = 0; i < this.simbolos.length; i++) {
+            const simboloAtual = this.simbolos[i];
+
+            if (simboloAtual.tipo === tiposDeSimbolos.PONTO_E_VIRGULA) {
+                const proximoSimbolo = this.encontrarProximoSimboloNaoComentario(i + 1);
+
+                if (!proximoSimbolo || proximoSimbolo.linha > simboloAtual.linha) {
+                    this.erros.push(
+                        new ErroAvaliadorSintatico(
+                            simboloAtual,
+                            'Ponto e vírgula (;) não é permitido no final da sentença de código.'
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Encontra o próximo símbolo que não seja comentário.
+     * Isso é importante porque comentários não afetam a validade do ponto e vírgula.
+     */
+    private encontrarProximoSimboloNaoComentario(inicio: number): SimboloInterface | null {
+        for (let i = inicio; i < this.simbolos.length; i++) {
+            if (this.simbolos[i].tipo !== tiposDeSimbolos.COMENTARIO) {
+                return this.simbolos[i];
+            }
+        }
+        return null;
     }
 
     /**
@@ -1811,13 +1848,31 @@ export class AvaliadorSintaticoPitugues
         this.simbolos = retornoLexador?.simbolos || [];
         this.localizacoes = retornoLexador?.pragmas || {};
 
+        this.verificarPontosEVirgulasInvalidos();
+
         let declaracoes: Declaracao[] = [];
         while (!this.estaNoFinal()) {
             const retornoDeclaracao = this.resolverDeclaracaoForaDeBloco();
+            if (retornoDeclaracao === null) {
+                continue;
+            }
+
             if (Array.isArray(retornoDeclaracao)) {
                 declaracoes = declaracoes.concat(retornoDeclaracao);
             } else {
                 declaracoes.push(retornoDeclaracao as Declaracao);
+            }
+
+            if (!this.estaNoFinal() && this.verificarTipoSimboloAtual(tiposDeSimbolos.PONTO_E_VIRGULA)) {
+                // Verificar se este ; está na mesma linha da declaração anterior
+                const declaracaoAnterior = declaracoes[declaracoes.length - 1];
+                const linhaDeclaraoAnterior = declaracaoAnterior.linha || 0;
+                const linhaPontoVirgula = this.simboloAtual().linha;
+
+                if (linhaPontoVirgula === linhaDeclaraoAnterior) {
+                    // Está na mesma linha, então é um separador válido
+                    this.avancarEDevolverAnterior();
+                }
             }
         }
 

--- a/fontes/lexador/dialetos/lexador-pitugues.ts
+++ b/fontes/lexador/dialetos/lexador-pitugues.ts
@@ -321,6 +321,7 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
             case '\n':
             case '\0':
             case ';':
+                this.adicionarSimbolo(tiposDeSimbolos.PONTO_E_VIRGULA);
                 this.avancar();
                 break;
 
@@ -488,14 +489,14 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
                 this.avancar();
                 this.analisarTexto('"');
                 this.avancar();
-                
+
                 break;
 
             case "'":
                 this.avancar();
                 this.analisarTexto("'");
                 this.avancar();
-                
+
                 break;
 
             default:

--- a/testes/pitugues/avaliador-sintatico.test.ts
+++ b/testes/pitugues/avaliador-sintatico.test.ts
@@ -187,6 +187,44 @@ describe('Avaliador sintático (Pituguês)', () => {
                 expect(retornoAvaliadorSintatico).toBeTruthy();
                 expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(4);
             });
+
+            describe('Ponto e vírgula - Usos permitidos', () => {
+                it('Múltiplos comandos na mesma linha - escreva', () => {
+                    const retornoLexador = lexador.mapear(
+                        ["escreva('a'); escreva('b')"],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                });
+
+                it('Múltiplos comandos na mesma linha - variáveis', () => {
+                    const retornoLexador = lexador.mapear(
+                        ["var x = 1; var y = 2"],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                });
+
+                it('Múltiplos tipos de comandos na mesma linha', () => {
+                    const retornoLexador = lexador.mapear(
+                        ["var a = 1; escreva(a); var b = a + 1"],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+                });
+            })
         });
 
         describe('Casos de falha', () => {
@@ -198,6 +236,28 @@ describe('Avaliador sintático (Pituguês)', () => {
 
                 expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
             });
+
+            it('Falha - Ponto e Vírgula', () => {
+                const codigo = [
+                    "escreva('teste');",
+                    "var a = 1;",
+                    "var b;",
+                    "var x = 1; #comentário"
+                ];
+
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                expect(retornoAvaliadorSintatico.erros).toHaveLength(4);
+
+                expect(retornoAvaliadorSintatico.erros[0].simbolo.linha).toBe(1);
+                expect(retornoAvaliadorSintatico.erros[1].simbolo.linha).toBe(2);
+                expect(retornoAvaliadorSintatico.erros[2].simbolo.linha).toBe(3);
+                expect(retornoAvaliadorSintatico.erros[3].simbolo.linha).toBe(4);
+
+                const mensagemEsperada = 'Ponto e vírgula (;) não é permitido no final da sentença de código.';
+                expect(retornoAvaliadorSintatico.erros[0].message).toContain(mensagemEsperada);
+            })
         });
     });
 });


### PR DESCRIPTION
Este PR implementa uma validação no dialeto Pituguês para retornar erro quando o ponto e vírgula (;) é utilizado ao final de uma linha ou instrução, aproximando a linguagem do comportamento do Python conforme solicitado na issue #886. A mudança rejeita usos inválidos do ; mantendo sua funcionalidade como separador de múltiplos comandos na mesma linha.

### O que foi feito

1. No Avaliador Sintático (avaliador-sintatico-pitugues.ts):
- Implementada a função verificarPontosEVirgulasInvalidos() que detecta ; no final de linhas
- Adicionada lógica que reporta erro semântico quando ; aparece como último token da linha
- Mantido o comportamento válido de ; como separador de múltiplos comandos na mesma linha

2. Testes (avaliador-sintatico.test.ts):
- Adicionados casos de teste para cenários válidos (múltiplos comandos na linha) e inválidos (; no final)

Closes #886 