### PR TITLE
[Pituguês] Implementa declaração implícita de variáveis

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -260,6 +260,102 @@ export class AvaliadorSintaticoPitugues
         throw new Error('Método não implementado.');
     }
 
+    private variavelJaDeclarada(nome: string): boolean {
+        try {
+            this.pilhaEscopos.obterTipoVariavelPorNome(nome);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private declaracaoImplicita(): Var {
+        const identificador = this.consumir(
+            tiposDeSimbolos.IDENTIFICADOR,
+            'Esperado nome de variável.'
+        );
+
+        this.consumir(tiposDeSimbolos.IGUAL, "Esperado '=' após identificador.");
+
+        if (this.estaNoFinal()) {
+            throw this.erro(
+                this.simboloAnterior(),
+                'Esperado valor após o símbolo de igual.'
+            )
+        }
+
+        const valor = this.expressao();
+        const tipo = this.logicaComumInferenciaTiposVariaveisEConstantes(valor, 'qualquer');
+
+        this.pilhaEscopos.definirInformacoesVariavel(
+            identificador.lexema,
+            new InformacaoElementoSintatico(identificador.lexema, tipo)
+        );
+
+        return new Var(identificador, valor, tipo);
+    }
+
+    private temPadraoMultiplaAtribuicao(): boolean {
+        // Verifica padrão: IDENTIFICADOR, VIRGULA, IDENTIFICADOR, ..., IGUAL
+        let pos = this.atual;
+        let contadorIdentificadores = 0;
+
+        while (pos < this.simbolos.length) {
+            if (this.simbolos[pos].tipo === tiposDeSimbolos.IDENTIFICADOR) {
+                contadorIdentificadores++;
+                pos++;
+
+                if (pos >= this.simbolos.length) return false;
+
+                // Se encontrou =, verifica se tinha mais de 1 identificador
+                if (this.simbolos[pos].tipo === tiposDeSimbolos.IGUAL) {
+                    return contadorIdentificadores > 1;
+                }
+
+                // Se não é vírgula, não é padrão múltiplo
+                if (this.simbolos[pos].tipo !== tiposDeSimbolos.VIRGULA) {
+                    return false;
+                }
+
+                pos++;
+                continue;
+            }
+            break;
+        }
+        return false;
+    }
+
+    private temPadraoVarComoPalavraChave(): boolean {
+        // Verifica padrão: var identificador = ...
+
+        if (this.simbolos[this.atual].lexema !== 'var') {
+            return false;
+        }
+
+        // Exemplos permitidos: var = 10 | var, a = 10, 20
+        if (this.simbolos[this.atual + 1]?.tipo !== tiposDeSimbolos.IDENTIFICADOR) {
+            return false;
+        }
+
+        let pos = this.atual + 1;
+
+        while (pos < this.simbolos.length) {
+            if (this.simbolos[pos].tipo === tiposDeSimbolos.IGUAL) {
+                return true; // Encontrou padrão var identificador = ...
+            }
+
+            // Se encontrou algo que não seja IDENTIFICADOR ou VIRGULA, não é o padrão
+            if (this.simbolos[pos].tipo !== tiposDeSimbolos.IDENTIFICADOR &&
+                this.simbolos[pos].tipo !== tiposDeSimbolos.VIRGULA) {
+                return false;
+            }
+
+            pos++;
+        }
+
+        return false;
+    }
+
     declaracaoDeVariaveis(): any {
         const identificadores: SimboloInterface[] = [];
         let retorno: Declaracao[] = [];
@@ -271,14 +367,7 @@ export class AvaliadorSintaticoPitugues
             );
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
-        if (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.IGUAL)) {
-            // Inicialização de variáveis sem valor.
-            for (let [indice, identificador] of identificadores.entries()) {
-                retorno.push(new Var(identificador, null));
-            }
-            this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO_E_VIRGULA);
-            return retorno;
-        }
+        this.consumir(tiposDeSimbolos.IGUAL, 'Esperado o símbolo igual(=) após identificador.');
 
         const inicializadores = [];
         do {
@@ -1612,6 +1701,30 @@ export class AvaliadorSintaticoPitugues
     }
 
     resolverDeclaracao(): any {
+        // Detecção de declaração implícita
+        if (this.simbolos[this.atual].tipo === tiposDeSimbolos.IDENTIFICADOR) {
+            // Detecta e bloqueia "var x = 10"
+            if (this.temPadraoVarComoPalavraChave()) {
+                throw this.erro(
+                    this.simbolos[this.atual],
+                    'Palavra "var" não pode ser usada como palavra-chave para declaração. Use declarações implícitas: "x = 10" em vez de "var x = 10".'
+                )
+            }
+
+            // Verifica se é múltipla atribuição (a, b, c = 1, 2, 3)
+            if (this.temPadraoMultiplaAtribuicao()) {
+                return this.declaracaoDeVariaveis();
+            }
+
+            // Verifica se é atribuição simples (a = 1)
+            if (this.simbolos[this.atual + 1]?.tipo === tiposDeSimbolos.IGUAL) {
+                const nomeVariavel = this.simbolos[this.atual].lexema;
+                if (!this.variavelJaDeclarada(nomeVariavel)) {
+                    return this.declaracaoImplicita();
+                }
+            }
+        }
+
         switch (this.simbolos[this.atual].tipo) {
             case tiposDeSimbolos.COMENTARIO:
                 return this.declaracaoComentario();
@@ -1660,9 +1773,6 @@ export class AvaliadorSintaticoPitugues
                 return this.declaracaoTente();
             case tiposDeSimbolos.TEXTO_MULTILINHAS:
                 return this.declaracaoTextoDeDocumentacao();
-            case tiposDeSimbolos.VARIAVEL:
-                this.avancarEDevolverAnterior();
-                return this.declaracaoDeVariaveis();
         }
 
         return this.declaracaoExpressao();

--- a/fontes/lexador/dialetos/palavras-reservadas/pitugues.ts
+++ b/fontes/lexador/dialetos/palavras-reservadas/pitugues.ts
@@ -43,9 +43,6 @@ export const palavrasReservadasPitugues = {
     tendo: tiposDeSimbolos.TENDO,
     tente: tiposDeSimbolos.TENTE,
     tipo: tiposDeSimbolos.TIPO,
-    var: tiposDeSimbolos.VARIAVEL,
-    variavel: tiposDeSimbolos.VARIAVEL,
-    variável: tiposDeSimbolos.VARIAVEL,
     verdadeiro: tiposDeSimbolos.VERDADEIRO,
 };
 

--- a/testes/pitugues/avaliador-sintatico.test.ts
+++ b/testes/pitugues/avaliador-sintatico.test.ts
@@ -42,7 +42,7 @@ describe('Avaliador sintático (Pituguês)', () => {
                 const retornoLexador = lexador.mapear(
                     [
                         'imprima(2 + 2)',
-                        'var a = 2',
+                        'a = 2',
                         'imprima(a += 2)',
                         'imprima(a)'
                     ], -1
@@ -72,7 +72,7 @@ describe('Avaliador sintático (Pituguês)', () => {
                 it('Contém', () => {
                     const retornoLexador = lexador.mapear(
                         [
-                            'var a = [1, 2, 3, 4, 5]',
+                            'a = [1, 2, 3, 4, 5]',
                             'escreva(a contém 3)'
                         ],
                         -1);
@@ -90,7 +90,7 @@ describe('Avaliador sintático (Pituguês)', () => {
                 it('Não contém', () => {
                     const retornoLexador = lexador.mapear(
                         [
-                            'var a = [1, 2, 3, 4, 5]',
+                            'a = [1, 2, 3, 4, 5]',
                             'escreva(a não contém 3)'
                         ],
                         -1);
@@ -112,7 +112,7 @@ describe('Avaliador sintático (Pituguês)', () => {
                 it('Trivial', () => {
                     const retornoLexador = lexador.mapear(
                         [
-                            'var vetor = [1, 2, 3]',
+                            'vetor = [1, 2, 3]',
                             'para cada elemento de vetor:',
                             '    escreva(elemento)'
                         ], -1
@@ -128,7 +128,7 @@ describe('Avaliador sintático (Pituguês)', () => {
                 it('Iterando texto', () => {
                     const retornoLexador = lexador.mapear(
                         [
-                            'var texto1 = "Texto"',
+                            'texto1 = "Texto"',
                             'para cada item em texto1:',
                             '    imprima(item)'
                         ], -1
@@ -145,8 +145,8 @@ describe('Avaliador sintático (Pituguês)', () => {
             it('Lista de Compreensão', () => {
                 const retornoLexador = lexador.mapear(
                     [
-                        'var lista = [1, 2, 3, 4, 5]',
-                        'var minhaListaCompreensao = [x para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares'
+                        'lista = [1, 2, 3, 4, 5]',
+                        'minhaListaCompreensao = [x para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares'
                     ], -1
                 );
                 const retornoAvaliadorSintatico =
@@ -160,8 +160,8 @@ describe('Avaliador sintático (Pituguês)', () => {
                 it('Trivial', () => {
                     const retornoLexador = lexador.mapear(
                         [
-                            'var idade = 20',
-                            'var categoria = "Adulto" se idade >= 18 senão "Menor de idade"'
+                            'idade = 20',
+                            'categoria = "Adulto" se idade >= 18 senão "Menor de idade"'
                         ], -1
                     );
                     const retornoAvaliadorSintatico =
@@ -174,7 +174,7 @@ describe('Avaliador sintático (Pituguês)', () => {
             it('Comentário antes de se', () => {
                 const retornoLexador = lexador.mapear(
                     [
-                        'var a = 1',
+                        'a = 1',
                         '# Comentário',
                         'se a > 0:',
                         '    escreva("Teste")',
@@ -203,7 +203,7 @@ describe('Avaliador sintático (Pituguês)', () => {
 
                 it('Múltiplos comandos na mesma linha - variáveis', () => {
                     const retornoLexador = lexador.mapear(
-                        ["var x = 1; var y = 2"],
+                        ["x = 1; y = 2"],
                         -1
                     );
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
@@ -215,7 +215,7 @@ describe('Avaliador sintático (Pituguês)', () => {
 
                 it('Múltiplos tipos de comandos na mesma linha', () => {
                     const retornoLexador = lexador.mapear(
-                        ["var a = 1; escreva(a); var b = a + 1"],
+                        ["a = 1; escreva(a); b = a + 1"],
                         -1
                     );
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
@@ -224,7 +224,70 @@ describe('Avaliador sintático (Pituguês)', () => {
                     expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
                     expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
                 });
-            })
+            });
+
+            describe('Declarações implícitas', () => {
+                it('Declarações implícitas seguidas', () => {
+                    const retornoLexador = lexador.mapear(['a, b, c = 1, 2, 3'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+                })
+
+                it('Reatribuição de variável declarada implicitamente', () => {
+                    const retornoLexador = lexador.mapear(['a = 10', 'a = 20'], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                });
+
+                it('Escopo aninhado com declaração implícita', () => {
+                    const retornoLexador = lexador.mapear([
+                        'a = 1',
+                        'se verdadeiro:',
+                        '    b = 2',
+                        '    escreva(a + b)'
+                    ], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                });
+
+                it('Declaração implícita com diferentes tipos', () => {
+                    const retornoLexador = lexador.mapear([
+                        'a = 1',
+                        'b = "texto"',
+                        'c = [1, 2, 3]',
+                        'd = verdadeiro',
+                    ], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(4);
+                });
+
+                it('Variável sombreando variável externa', () => {
+                    const retornoLexador = lexador.mapear([
+                        'a = "global"',
+                        'se verdadeiro:',
+                        '    a = "local"',
+                        '    escreva(a)',
+                        'escreva(a)'
+                    ], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+                });
+            });
         });
 
         describe('Casos de falha', () => {
@@ -240,23 +303,39 @@ describe('Avaliador sintático (Pituguês)', () => {
             it('Falha - Ponto e Vírgula', () => {
                 const codigo = [
                     "escreva('teste');",
-                    "var a = 1;",
-                    "var b;",
-                    "var x = 1; #comentário"
+                    "a = 1;",
+                    "x = 1; #comentário"
                 ];
 
                 const retornoLexador = lexador.mapear(codigo, -1);
                 const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
-                expect(retornoAvaliadorSintatico.erros).toHaveLength(4);
+                expect(retornoAvaliadorSintatico.erros).toHaveLength(3);
 
                 expect(retornoAvaliadorSintatico.erros[0].simbolo.linha).toBe(1);
                 expect(retornoAvaliadorSintatico.erros[1].simbolo.linha).toBe(2);
                 expect(retornoAvaliadorSintatico.erros[2].simbolo.linha).toBe(3);
-                expect(retornoAvaliadorSintatico.erros[3].simbolo.linha).toBe(4);
 
                 const mensagemEsperada = 'Ponto e vírgula (;) não é permitido no final da sentença de código.';
                 expect(retornoAvaliadorSintatico.erros[0].message).toContain(mensagemEsperada);
+            });
+
+            it('Falha - Uso de "var" como palavra-chave', () => {
+                const retornoLexador = lexador.mapear(['var a = 10'], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                expect(retornoAvaliadorSintatico.erros).toHaveLength(1);
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(0);
+            });
+
+            it('Falha - criação de variável sem valor de forma implícita', () => {
+                const codigo = ['a = '];
+
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                expect(retornoAvaliadorSintatico.erros).toHaveLength(1);
+                expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(0);
             })
         });
     });

--- a/testes/pitugues/lexador.test.ts
+++ b/testes/pitugues/lexador.test.ts
@@ -50,7 +50,7 @@ describe('Lexador (Pituguês)', () => {
 
             it('Atribução de variável e Operação Matemática (diferença, multiplicação e módulo)', () => {
                 const resultado = lexador.mapear(
-                    ['var numero = 1 * 2 - 3 % 4'],
+                    ['numero = 1 * 2 - 3 % 4'],
                     -1
                 );
 
@@ -94,13 +94,13 @@ describe('Lexador (Pituguês)', () => {
                     );
                 });
             });
-            
+
 
             it('Vetor (Lista de Compreensão)', () => {
                 const resultado = lexador.mapear(
                     [
-                        'var lista = [1, 2, 3, 4, 5]',
-                        'var minhaListaCompreensao = [x para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares'
+                        'lista = [1, 2, 3, 4, 5]',
+                        'minhaListaCompreensao = [x para cada x em lista se x % 2 == 0] # Lista de compreensão para números pares'
                     ],
                     -1
                 );
@@ -158,6 +158,14 @@ describe('Lexador (Pituguês)', () => {
                 const retornoLexador = lexador.mapear(codigo, -1);
                 expect(retornoLexador.erros).toHaveLength(0);
                 expect(retornoLexador.simbolos).toHaveLength(23);
+            });
+
+            it('"var" deve ser tratado como identificador, não como palavra reservada', () => {
+                const retornoLexador = lexador.mapear(['var = 10'], -1);
+
+                expect(retornoLexador.simbolos[0].tipo).toBe('IDENTIFICADOR');
+                expect(retornoLexador.simbolos[0].lexema).toBe('var');
+                expect(retornoLexador.erros).toHaveLength(0);
             });
         });
 


### PR DESCRIPTION
### O que foi feito

Este PR implementa a declaração implícita de variáveis no dialeto Pituguês, removendo a necessidade de usar a palavra-chave var (ou suas variações) para declarar variáveis. As principais alterações foram:

1. Remoção de palavras reservadas no Lexador:
- Removidas as palavras var, variável e variavel da lista de palavras reservadas
- Agora var é tratado como um identificador comum
2. Implementação de declaração implícita no Avaliador Sintático:
- Nova sintaxe: a = 10 (em vez de var a = 10)
- Suporte a múltiplas atribuições: a, b, c = 1, 2, 3
- Bloqueio de var como palavra-chave (gera erro sintático)
- Validação contra declarações sem valor: a = (gera erro)
3. Atualização completa dos testes:
- Atualizados testes do lexador para usar nova sintaxe
- Adicionados testes para novos comportamentos
- Testes para casos de erro

### Por que foi feito
- Alinhar com a filosofia Python: Pituguês é inspirado em Python, onde variáveis são declaradas implicitamente
- Cumprir requisito da issue #859: Implementar declaração implícita conforme solicitado

Closes #859 