### PR TITLE
Implementação de Desempacotamento de Coleções no Pituguês #911

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -365,14 +365,14 @@ export class AvaliadorSintaticoPitugues
         return false;
     }
 
-    declaracaoDeVariaveis(): any {
+    private consumirIdentificadores(): { simbolos: SimboloInterface[], indexResto: number } {
         const identificadores: SimboloInterface[] = [];
         let indexResto = -1;
 
         do {
             let ehRestoAtual = false;
 
-            // Verifica se o * veio como token separado
+            // Verifica * como token separado
             if (this.verificarTipoSimboloAtual(tiposDeSimbolos.MULTIPLICACAO)) {
                 this.consumir(tiposDeSimbolos.MULTIPLICACAO, '');
                 ehRestoAtual = true;
@@ -381,9 +381,9 @@ export class AvaliadorSintaticoPitugues
             const identificador = this.consumir(
                 tiposDeSimbolos.IDENTIFICADOR,
                 ehRestoAtual ? 'Esperado nome de variável após operador *.' : 'Esperado nome de variável.'
-            )
+            );
 
-            // Verifica se o * veio como parte do nome da variável
+            // Verifica * no nome da variável
             if (identificador.lexema.startsWith('*')) {
                 ehRestoAtual = true;
                 identificador.lexema = identificador.lexema.slice(1);
@@ -398,36 +398,117 @@ export class AvaliadorSintaticoPitugues
                 }
                 indexResto = identificadores.length;
             }
-
             identificadores.push(identificador);
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
-        this.consumir(tiposDeSimbolos.IGUAL, 'Esperado o símbolo igual(=) após identificador.');
+        return { simbolos: identificadores, indexResto };
+    }
 
+    private consumirInicializadores(): Construto[] {
         const inicializadores: Construto[] = [];
         do {
             if (this.estaNoFinal()) {
-                throw this.erro(this.simboloAtual(),'Esperado inicializador após vírgula.');
+                throw this.erro(this.simboloAtual(), 'Esperado inicializador após vírgula.');
             }
             inicializadores.push(this.expressao());
         } while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA));
 
+        return inicializadores;
+    }
+
+    private construirValidacaoDesempacotamento(
+        identificador: SimboloInterface,
+        origem: Construto,
+        qtdEsperada: number
+    ): Declaracao {
+        const linha = identificador.linha;
+
+        const chamadaTamanho = new Chamada(
+            this.hashArquivo,
+            new Variavel(this.hashArquivo,
+                new Simbolo(tiposDeSimbolos.IDENTIFICADOR, "tamanho", null, linha, -1)
+            ),
+            [origem]
+        );
+
+        const condicaoErro = new Binario(
+            this.hashArquivo,
+            chamadaTamanho,
+            new Simbolo(tiposDeSimbolos.DIFERENTE, "!=", null, linha, -1),
+            new Literal(this.hashArquivo, linha, qtdEsperada, 'número')
+        );
+
+        const mensagem = `Erro de execução: Você tentou desempacotar em ${qtdEsperada} variáveis, mas o vetor possui tamanho diferente.`;
+        const falha = new Falhar(
+            new Simbolo(tiposDeSimbolos.FALHAR, "falhar", null, linha, -1),
+            new Literal(this.hashArquivo, linha, mensagem, 'texto')
+        );
+
+        return new Se(condicaoErro, new Bloco(this.hashArquivo, linha, [falha]), [], null);
+    }
+
+    declaracaoDeVariaveis(): any {
+        const { simbolos: identificadores, indexResto } = this.consumirIdentificadores();
+
+        this.consumir(tiposDeSimbolos.IGUAL, 'Esperado o símbolo igual(=) após identificador.');
+
+        const inicializadores = this.consumirInicializadores();
+
         const qtdIdentificadores = identificadores.length;
         const qtdValores = inicializadores.length;
+        const ehDesempacotamento = qtdIdentificadores > 1 && qtdValores === 1;
 
         if (indexResto > -1) {
-            // Com resto: precisa de valores suficientes para cobrir as variáveis obrigatórias.
             if (qtdValores < qtdIdentificadores - 1) {
-                throw this.erro(this.simboloAnterior(), 'Quantidade insuficiente de valores para desempacotamento com operador de resto.');
+                if (!ehDesempacotamento || (ehDesempacotamento && inicializadores[0] instanceof Literal)) {
+                    throw this.erro(
+                        this.simboloAnterior(),
+                        'Quantidade insuficiente de valores para desempacotamento com operador de resto.'
+                    );
+                }
             }
         } else {
-            // Sem resto: a quantidade deve ser exata.
-            if (qtdIdentificadores !== qtdValores) {
-                throw this.erro(this.simboloAnterior(), 'Quantidade de inicializadores à esquerda do igual é diferente da quantidade de identificadores à direita.');
+            if (!ehDesempacotamento && qtdIdentificadores !== qtdValores) {
+                throw this.erro(
+                    this.simboloAnterior(),
+                    'Quantidade de inicializadores à esquerda do igual é diferente da quantidade de identificadores à direita.'
+                );
+            }
+            if (ehDesempacotamento && inicializadores[0] instanceof Vetor) {
+                const vetor = inicializadores[0] as Vetor;
+                if (vetor.tamanho !== qtdIdentificadores) {
+                    throw this.erro(
+                        this.simboloAnterior(),
+                        `O vetor possui ${vetor.tamanho} elementos, mas você tentou desempacotar em ${qtdIdentificadores} variáveis.`
+                    );
+                }
             }
         }
 
         const retorno: Declaracao[] = [];
+        let origemParaAtribuicao = inicializadores[0];
+
+        // Injeção de Código (Runtime Check)
+        if (ehDesempacotamento && !(inicializadores[0] instanceof Vetor)) {
+            const linha = identificadores[0].linha;
+
+            // Cria variável temporária para evitar reavaliar a expressão original múltiplas vezes
+            const nomeVarTemp = `__temp_desempacotamento_${new Date().getTime()}_${Math.floor(Math.random() * 1000)}`;
+            const simboloVarTemp = new Simbolo(tiposDeSimbolos.IDENTIFICADOR, nomeVarTemp, null, linha, -1);
+
+            retorno.push(new Var(simboloVarTemp, inicializadores[0], 'qualquer[]'));
+            origemParaAtribuicao = new Variavel(this.hashArquivo, simboloVarTemp);
+
+            // Injeta validação de tamanho se não houver operador de resto
+            if (indexResto === -1) {
+                retorno.push(
+                    this.construirValidacaoDesempacotamento(
+                        identificadores[0], origemParaAtribuicao, qtdIdentificadores
+                    )
+                );
+            }
+        }
+
         let cursorValores = 0;
         const qtdParaResto = qtdValores - (qtdIdentificadores - 1);
 
@@ -437,13 +518,9 @@ export class AvaliadorSintaticoPitugues
             let tipo = "qualquer";
 
             if (i === indexResto) {
-                // Caso Resto (*): absorve N valores em um Vetor e força tipagem de array.
                 const valoresResto = inicializadores.slice(cursorValores, cursorValores + qtdParaResto);
-
                 let tipoInferido = inferirTipoVariavel(valoresResto) as string;
-                if (!tipoInferido.endsWith('[]')) {
-                    tipoInferido = `${tipoInferido}[]`;
-                }
+                if (!tipoInferido.endsWith('[]')) tipoInferido = `${tipoInferido}[]`;
 
                 inicializador = new Vetor(
                     identificador.hashArquivo,
@@ -452,14 +529,22 @@ export class AvaliadorSintaticoPitugues
                     valoresResto.length,
                     tipoInferido
                 );
-
                 tipo = tipoInferido;
                 cursorValores += qtdParaResto;
+            } else if (ehDesempacotamento) {
+                if (inicializadores[0] instanceof Vetor) {
+                    inicializador = inicializadores[0].valores[i];
+                } else {
+                    inicializador = new AcessoIndiceVariavel(
+                        this.hashArquivo,
+                        origemParaAtribuicao,
+                        new Literal(this.hashArquivo, identificador.linha, i, 'número'),
+                        new Simbolo(tiposDeSimbolos.COLCHETE_DIREITO, ']', null, identificador.linha, -1)
+                    );
+                }
             } else {
-                // Caso comum: consome 1 valor
                 inicializador = inicializadores[cursorValores];
                 cursorValores++;
-
                 tipo = this.logicaComumInferenciaTiposVariaveisEConstantes(inicializador, tipo);
             }
 

--- a/testes/pitugues/avaliador-sintatico.test.ts
+++ b/testes/pitugues/avaliador-sintatico.test.ts
@@ -362,6 +362,41 @@ describe('Avaliador sintático (Pituguês)', () => {
                     expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
                 });
             });
+
+            describe('Desempacotamento de coleção (com vetor literal)', () => {
+                it('Desempacotamento válido com valores suficientes', () => {
+                    const retornoLexador = lexador.mapear([
+                        'a, b, c = ["maçã", "banana", "laranja"]'
+                    ], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(3);
+                });
+            });
+
+            it('Gera estrutura de validação para desempacotamento de variáveis', () => {
+                const retornoLexador = lexador.mapear([
+                    'lista = [1, 2]',
+                    'a, b = lista'
+                ], -1);
+
+                const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                expect(retornoAvaliador).toBeTruthy();
+
+                // Esperamos MAIS que 2 declarações.
+                // Deve ter:
+                // 1. Var temporária (__temp...)
+                // 2. Se (tamanho != 2) ...
+                // 3. Var a
+                // 4. Var b
+                expect(retornoAvaliador.declaracoes.length).toBeGreaterThan(2);
+
+                // Verificar se existe a injeção do 'Se'
+                const temValidacaoSe = retornoAvaliador.declaracoes.some(d => d.constructor.name === 'Se');
+                expect(temValidacaoSe).toBe(true);
+            });
         });
 
         describe('Casos de falha', () => {
@@ -444,6 +479,27 @@ describe('Avaliador sintático (Pituguês)', () => {
 
                 it('Quantidade insuficiente de valores para preencher as variáveis obrigatórias (com resto)', () => {
                     const codigo = ['a, *b, c = 1'];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('Desempacotamento de coleção', () => {
+                it('Desempacotamento inválido com itens do vetor maiores que a quantidade de variáveis', () => {
+                    const codigo = ['a, b, c = ["maçã", "banana", "laranja", "uva"]'];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
+                    expect(retornoAvaliadorSintatico.erros[0].message).toContain('O vetor possui 4 elementos');
+                });
+
+                it('Desempacotamento inválido com itens do vetor menores que a quantidade de variáveis', () => {
+                    const codigo = ['a, b, c = ["maçã", "banana"]'];
 
                     const retornoLexador = lexador.mapear(codigo, -1);
                     const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -115,6 +115,31 @@ describe('Interpretador (Pituguês)', () => {
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
+
+                describe('Desempacotamento de Coleção', () => {
+                    it('Desempacota vetor numeros (que possui [1, 2, 3]) em a, b, c', async () => {
+                        const retornoLexador = lexador.mapear([
+                            'numeros = [1, 2, 3]',
+                            'a, b, c = numeros'
+                        ], -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+
+                        const a = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('a');
+                        const b = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('b');
+                        const c = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('c');
+
+                        expect(a.valor).toBe(1);
+                        expect(b.valor).toBe(2);
+                        expect(c.valor).toBe(3);
+                    });
+                });
             });
 
             describe('Acesso a variáveis e objetos', () => {
@@ -1209,7 +1234,7 @@ describe('Interpretador (Pituguês)', () => {
             expect(_saidas).toHaveLength(1);
             expect(_saidas[0]).toBe('Meu nome é Maria e eu tenho 30 anos.');
         });
-        
+
         describe('Cenários de falha', () => {
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {
@@ -1241,6 +1266,45 @@ describe('Interpretador (Pituguês)', () => {
                     );
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThanOrEqual(0);
+                });
+            });
+
+            describe('Desempacotamento de Coleção', () => {
+                it('Vetor maior que variáveis', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'numeros = [1, 2, 3, 4]',
+                            'a, b, c = numeros',
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+
+                    const erro = retornoInterpretador.erros[0];
+                    const mensagem = erro.erroInterno['message'] || String(erro.erroInterno);
+
+                    expect(mensagem).toContain('tamanho diferente');
+                });
+
+                it('Falha: Vetor menor que variáveis (Runtime)', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'numeros = [1, 2]',
+                        'a, b, c = numeros'
+                    ], -1);
+                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                 });
             });
         });


### PR DESCRIPTION
### Descrição
Este PR implementa a funcionalidade de desempacotamento de coleções (vetores) no dialeto Pituguês, seguindo a mesma sintaxe do Python conforme especificado na issue #911.

### O que foi feito
**Funcionalidades principais:**
- Desempacotamento de coleções
- Validação dinâmica em runtime para expressões variáveis

**Alterações no código:**
- Modificado `avaliador-sintatico-pitugues.ts`:
  - Nova lógica em `declaracaoDeVariaveis()` para processar desempacotamento
  - Métodos auxiliares `consumirIdentificadores()`, `consumirInicializadores()` e `construirValidacaoDesempacotamento()`
  - Sistema de validação de tamanhos em tempo de compilação
  - Injeção de validação em runtime via estrutura `Se` + `Falhar`

**Testes adicionados:**
- `avaliador-sintatico.test.ts`: Testes de análise sintática
  - Cenários válidos e inválidos de desempacotamento
  - Validação de quantidades (maior/menor que variáveis)
- `interpretador.test.ts`: Testes de execução
  - Desempacotamento correto de valores
  - Erros em runtime quando tamanhos não correspondem

### Como usar
```pituguês
# Desempacotamento básico
frutas = ["maçã", "banana", "laranja"]
x, y, z = frutas
# x = "maçã", y = "banana", z = "laranja"

# Validação automática
a, b, c = [1, 2]  # Lança erro: vetor menor que variáveis
a, b = [1, 2, 3]  # Lança erro: vetor maior que variáveis
```

Closes #911