### PR TITLE
Fatiamento (Slicing) de Coleções em Pituguês

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -2,6 +2,7 @@ import hrtime from 'browser-process-hrtime';
 
 import {
     AcessoIndiceVariavel,
+    AcessoIntervaloVariavel,
     AcessoMetodoOuPropriedade,
     Agrupamento,
     AtribuicaoPorIndice,
@@ -802,18 +803,54 @@ export class AvaliadorSintaticoPitugues
 
                 expressao = new AcessoMetodoOuPropriedade(this.hashArquivo, expressao, nome);
             } else if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_ESQUERDO)) {
-                const indice = this.expressao();
+                let ehFatiamento = false;
+                let indiceInicio: Construto | null = null;
+                let indiceFim: Construto | null = null;
+
+                if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
+                    // Acesso de itens por intervalo sem ponto de partida definido (ex: [:5] ou [:])
+                    ehFatiamento = true;
+
+                    if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.COLCHETE_DIREITO)) {
+                        // Fatiamento com ponto de parada definido (ex: [:5])
+                        indiceFim = this.expressao();
+                    }
+                } else {
+                    // Tem ponto de início definido (ex: [1:5], [1:] ou [1])
+                    indiceInicio = this.expressao();
+
+                    if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
+                        // É fatiamento (ex: [1:5] ou [1:])
+                        ehFatiamento = true;
+
+                        if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.COLCHETE_DIREITO)) {
+                            // fatiamento com ponto de parada definido (ex: [1:5])
+                            indiceFim = this.expressao();
+                        }
+                    }
+                }
+
                 const simboloFechamento = this.consumir(
                     tiposDeSimbolos.COLCHETE_DIREITO,
                     "Esperado ']' após escrita do indice."
                 );
 
-                expressao = new AcessoIndiceVariavel(
-                    this.hashArquivo,
-                    expressao,
-                    indice,
-                    simboloFechamento
-                );
+                if (ehFatiamento) {
+                    expressao = new AcessoIntervaloVariavel(
+                        this.hashArquivo,
+                        expressao,
+                        indiceInicio,
+                        indiceFim,
+                        simboloFechamento
+                    )
+                } else {
+                    expressao = new AcessoIndiceVariavel(
+                        this.hashArquivo,
+                        expressao,
+                        indiceInicio,
+                        simboloFechamento
+                    );
+                }
             } else {
                 break;
             }

--- a/fontes/construtos/acesso-intervalo-variavel.ts
+++ b/fontes/construtos/acesso-intervalo-variavel.ts
@@ -1,0 +1,55 @@
+import { VisitanteComumInterface, SimboloInterface } from '../interfaces';
+import { Construto } from './construto';
+
+/**
+ * Construto para acesso de intervalos (fatiamento/slicing) em vetores.
+ * Ex: vetor[1:4], vetor[1:], vetor[:3] ou vetor[:]
+ */
+export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> implements Construto {
+    linha: number;
+    hashArquivo: number;
+
+    entidadeChamada: Construto;
+    simboloFechamento: SimboloInterface<TTipoSimbolo>;
+    indiceInicio: Construto | null;
+    indiceFim: Construto | null;
+    tipo: string = 'qualquer';
+
+    constructor(
+        hashArquivo: number,
+        entidadeChamada: Construto,
+        indiceInicio: Construto | null,
+        indiceFim: Construto | null,
+        simboloFechamento: SimboloInterface<TTipoSimbolo>,
+        tipo: string = 'qualquer'
+    ) {
+        this.linha = entidadeChamada.linha;
+        this.hashArquivo = hashArquivo;
+
+        this.entidadeChamada = entidadeChamada;
+        this.indiceInicio = indiceInicio;
+        this.indiceFim = indiceFim;
+        this.simboloFechamento = simboloFechamento;
+        this.tipo = tipo;
+    }
+
+    async aceitar(visitante: VisitanteComumInterface): Promise<any> {
+        return await visitante.visitarExpressaoAcessoIntervaloVariavel(this);
+    }
+
+    paraTexto(): string {
+        const inicio = this.indiceInicio ? this.indiceInicio.paraTexto() : 'sem-início';
+        const fim = this.indiceFim ? this.indiceFim.paraTexto() : 'sem-fim';
+
+        return (
+            `<acesso-índice-variável entidadeChamada=${this.entidadeChamada.paraTexto()} ` +
+            `inicio=${inicio} ` +
+            `fim=${fim}` +
+            `/>`
+        );
+    }
+
+    paraTextoSaida(): string {
+        throw new Error('Método não implementado.');
+    }
+}

--- a/fontes/construtos/index.ts
+++ b/fontes/construtos/index.ts
@@ -1,5 +1,6 @@
 export * from './acesso-elemento-matriz';
 export * from './acesso-indice-variavel';
+export * from './acesso-intervalo-variavel';
 export * from './acesso-metodo';
 export * from './acesso-metodo-ou-propriedade';
 export * from './acesso-propriedade';

--- a/fontes/interfaces/visitante-comum-interface.ts
+++ b/fontes/interfaces/visitante-comum-interface.ts
@@ -1,6 +1,7 @@
 import {
     AcessoElementoMatriz,
     AcessoIndiceVariavel,
+    AcessoIntervaloVariavel,
     AcessoMetodo,
     AcessoMetodoOuPropriedade,
     AcessoPropriedade,
@@ -85,6 +86,7 @@ export interface VisitanteComumInterface {
     visitarDeclaracaoVarMultiplo(declaracao: VarMultiplo): Promise<any> | void;
     visitarExpressaoDeAtribuicao(expressao: Atribuir): Promise<any> | void;
     visitarExpressaoAcessoIndiceVariavel(expressao: AcessoIndiceVariavel): Promise<any> | void;
+    visitarExpressaoAcessoIntervaloVariavel(expressao: AcessoIntervaloVariavel): Promise<any> | void;
     visitarExpressaoAcessoElementoMatriz(expressao: AcessoElementoMatriz): Promise<any> | void;
     visitarExpressaoAcessoMetodo(expressao: AcessoMetodo): Promise<any> | void;
     visitarExpressaoAcessoMetodoOuPropriedade(

--- a/fontes/interpretador/dialetos/pitugues/comum.ts
+++ b/fontes/interpretador/dialetos/pitugues/comum.ts
@@ -1,4 +1,4 @@
-import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade } from "../../../construtos";
+import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade, AcessoIntervaloVariavel } from "../../../construtos";
 import { inferirTipoVariavel } from "../../../inferenciador";
 import { InterpretadorInterface, SimboloInterface, VariavelInterface } from "../../../interfaces";
 import { RetornoQuebra } from "../../../quebras";
@@ -333,7 +333,7 @@ export async function visitarExpressaoAcessoPropriedade(
 
 export async function resolverInterpolacoes(
     interpretador: InterpretadorInterface,
-    textoOriginal: string, 
+    textoOriginal: string,
     linha: number
 ): Promise<any[]> {
     const regexInterpolacao: RegExp = /\$\{[a-zA-Z_][a-zA-Z0-9_]*\}/g;
@@ -367,4 +367,34 @@ export async function resolverInterpolacoes(
         expressaoInterpolacao: resultadosAvaliacaoSintatica[indice].expressaoInterpolacao,
         valor: item,
     }));
+}
+
+export async function visitarExpressaoAcessoIntervaloVariavel(
+    interpretador: InterpretadorInterface,
+    expressao: AcessoIntervaloVariavel
+): Promise<any> {
+    const variavelObjeto: VariavelInterface = await interpretador.avaliar(expressao.entidadeChamada);
+    let objeto = interpretador.resolverValor(variavelObjeto);
+
+    if (!Array.isArray(objeto) && typeof objeto !== 'string') {
+        throw new ErroEmTempoDeExecucao(
+            expressao.simboloFechamento,
+            'Acesso por intervalo só é suportado em vetores e textos.',
+            expressao.linha
+        );
+    }
+
+    let inicio = 0;
+    if (expressao.indiceInicio) {
+        inicio = await interpretador.avaliar(expressao.indiceInicio);
+        inicio = interpretador.resolverValor(inicio);
+    }
+
+    let fim = objeto.length;
+    if (expressao.indiceFim) {
+        fim = await interpretador.avaliar(expressao.indiceFim);
+        fim = interpretador.resolverValor(fim);
+    }
+
+    return objeto.slice(inicio, fim);
 }

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues-com-depuracao.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues-com-depuracao.ts
@@ -1,4 +1,4 @@
-import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade } from "../../../construtos";
+import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade, AcessoIntervaloVariavel } from "../../../construtos";
 import { InterpretadorComDepuracao } from "../../depuracao";
 
 import * as comum from './comum';
@@ -14,5 +14,9 @@ export class InterpretadorPituguesComDepuracao extends InterpretadorComDepuracao
 
     override async visitarExpressaoAcessoPropriedade(expressao: AcessoPropriedade): Promise<any> {
         return comum.visitarExpressaoAcessoPropriedade(this, expressao);
+    }
+
+    override async visitarExpressaoAcessoIntervaloVariavel(expressao: AcessoIntervaloVariavel): Promise<any> {
+        return comum.visitarExpressaoAcessoIntervaloVariavel(this, expressao);
     }
 }

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -1,4 +1,4 @@
-import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade } from "../../../construtos";
+import { AcessoMetodo, AcessoMetodoOuPropriedade, AcessoPropriedade, AcessoIntervaloVariavel } from "../../../construtos";
 import { Interpretador } from "../../interpretador";
 
 import * as comum from './comum';
@@ -14,5 +14,9 @@ export class InterpretadorPitugues extends Interpretador {
 
     override async visitarExpressaoAcessoPropriedade(expressao: AcessoPropriedade): Promise<any> {
         return comum.visitarExpressaoAcessoPropriedade(this, expressao);
+    }
+
+    override async visitarExpressaoAcessoIntervaloVariavel(expressao: AcessoIntervaloVariavel): Promise<any> {
+        return comum.visitarExpressaoAcessoIntervaloVariavel(this, expressao);
     }
 }

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -40,6 +40,7 @@ import {
 } from './estruturas';
 import {
     AcessoIndiceVariavel,
+    AcessoIntervaloVariavel,
     AcessoMetodo,
     AcessoMetodoOuPropriedade,
     AcessoPropriedade,
@@ -232,7 +233,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             case Variavel:
                 return (objetoAcessado as Variavel).simbolo.lexema;
         }
-        
+
         throw new ErroEmTempoDeExecucao((objetoAcessado as any).simbolo, `Construto ${objetoAcessado.constructor.name} não possui resolução de nome apropriada.`);
     }
 
@@ -955,7 +956,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             // Casos que passam aqui: chamadas a métodos de bibliotecas de Delégua.
             if (typeof entidadeChamada === tipoDeDadosPrimitivos.FUNCAO) {
                 let objeto = null;
-                if ((expressao.entidadeChamada as any).objeto) { // TODO: Qual o tipo certo aqui? 
+                if ((expressao.entidadeChamada as any).objeto) { // TODO: Qual o tipo certo aqui?
                     objeto = await this.avaliar((expressao.entidadeChamada as any).objeto);
                 }
                 return entidadeChamada.apply(this.resolverValor(objeto), argumentos);
@@ -1039,8 +1040,8 @@ export class InterpretadorBase implements InterpretadorInterface {
         if (Array.isArray(valorDireitoResolvido) || typeof valorDireitoResolvido === tipoDeDadosPrimitivos.TEXTO) {
             const avaliacao = valorDireitoResolvido.includes(esquerda);
             return expressao.negado ? !avaliacao : avaliacao;
-        } 
-        
+        }
+
         if (valorDireitoResolvido !== null && typeof valorDireitoResolvido === 'object') {
             const avaliacao = esquerda in valorDireitoResolvido;
             return expressao.negado ? !avaliacao : avaliacao;
@@ -1060,7 +1061,7 @@ export class InterpretadorBase implements InterpretadorInterface {
             const direita = await this.avaliar(expressao.direita);
 
             // `3 em lista` é igual a `lista contém 3`.
-            // Portanto, precisamos inverter os operandos de acordo com a 
+            // Portanto, precisamos inverter os operandos de acordo com a
             // palavra reservada usada.
             switch (expressao.operador.tipo) {
                 case tiposDeSimbolos.EM:
@@ -1692,6 +1693,21 @@ export class InterpretadorBase implements InterpretadorInterface {
         );
     }
 
+    /**
+        * Método base para acesso a intervalo.
+        * Por padrão lança erro, pois a maioria dos dialetos (como Delégua padrão)
+        * ainda não suporta isso nativamente, apenas Pituguês.
+    */
+    visitarExpressaoAcessoIntervaloVariavel(expressao: AcessoIntervaloVariavel): Promise<any> {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                expressao.simboloFechamento,
+                "Acesso por intervalo não implementado para este dialeto.",
+                expressao.linha
+            )
+        );
+    }
+
     async visitarExpressaoDefinirValor(expressao: DefinirValor): Promise<any> {
         const variavelObjeto = await this.avaliar(expressao.objeto);
         const objeto = this.resolverValor(variavelObjeto);
@@ -1852,10 +1868,10 @@ export class InterpretadorBase implements InterpretadorInterface {
             if (expressao.simbolo.lexema in primitivasVetor) {
                 const metodoDePrimitivaVetor: Function =
                     primitivasVetor[expressao.simbolo.lexema].implementacao;
-                // TODO: Um problema a ser resolvido na questão de vetores é quando eles pertencem a outro objeto. 
+                // TODO: Um problema a ser resolvido na questão de vetores é quando eles pertencem a outro objeto.
                 // Por exemplo, um dicionário.
                 // Existe uma lógica nas bibliotecas padrão que, quando a primitiva tem um nome, ela deve ser definida na
-                // pilha de escopos, para registrar a mutação do vetor corretamente. 
+                // pilha de escopos, para registrar a mutação do vetor corretamente.
                 // Não é uma boa solução. Algo melhor precisa ser feito.
                 return new MetodoPrimitiva(nomeObjeto, objeto, metodoDePrimitivaVetor, expressao.simbolo.lexema, tipoObjeto);
             }

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -140,6 +140,300 @@ describe('Interpretador (Pituguês)', () => {
                         expect(c.valor).toBe(3);
                     });
                 });
+
+                describe('Fatiamento (Slicing)', () => {
+                    describe('Vetores', () => {
+                        it('Fatiamento com início e fim definidos [início:fim]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[1:4]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual([1, 2, 3]);
+                        });
+
+                        it('Fatiamento sem fim definido [início:]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3]
+                                fatia = numeros[2:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual([2, 3]);
+                        });
+
+                        it('Fatiamento sem início definido [:fim]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [10, 20, 30, 40]
+                                fatia = numeros[:2]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual([10, 20]);
+                        });
+
+                        it('Fatiamento sem início e fim definido [:]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                ciencias = ['física', 'química', 'matemática']
+                                fatia = ciencias[:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual(['física', 'química', 'matemática']);
+                        });
+
+                        it('Fatiamento com início negativo [-n:] (pega os últimos n itens)', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[-2:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual([4, 5]);
+                        });
+
+                        it('Fatiamento com fim negativo [:-n] (exclui os últimos n itens)', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[:-2]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual([0, 1, 2, 3]);
+                        });
+
+                        it('Fatiamento com início e fim negativos [-x:-y]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[-4:-1]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual([2, 3, 4]);
+                        });
+
+                        it('Fatiamento misto (positivo e negativo) [1:-1]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[1:-1]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual([1, 2, 3, 4]);
+                        });
+                    });
+
+                    describe('Textos', () => {
+                        it('Fatiamento [início:fim]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[1:4]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual('itu');
+                        });
+
+                        it('Fatiamento sem fim definido [início:]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[2:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual('tuguês');
+                        });
+
+                        it('Fatiamento sem início definido [:fim]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[:2]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual('Pi');
+                        });
+
+                        it('Fatiamento sem início e fim definido [:]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual('Pituguês');
+                        });
+
+                        it('Deve suportar início negativo [-n:] (pega os últimos n itens)', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[-2:]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual('ês');
+                        });
+
+                        it('Deve suportar fim negativo [:-n] (exclui os últimos n itens)', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[:-2]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual('Pitugu');
+                        });
+
+                        it('Deve suportar início e fim negativos [-x:-y]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[-4:-1]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual('guê');
+                        });
+
+                        it('Deve suportar misto (positivo e negativo) [1:-1]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                texto = 'Pituguês'
+                                fatia = texto[1:-1]
+                            `], -1);
+                            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+                            expect(variavelFatia.valor).toEqual('ituguê');
+                        });
+                    })
+                });
             });
 
             describe('Acesso a variáveis e objetos', () => {
@@ -1303,6 +1597,56 @@ describe('Interpretador (Pituguês)', () => {
                     const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('Fatiamento (Slicing)', () => {
+                it('Tentar fatiar número', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        numero = 123
+                        fatia = numero[0:1]
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+
+                    const erro = retornoInterpretador.erros[0];
+                    expect(erro.erroInterno.message).toContain('só é suportado em vetores e textos.');
+                });
+
+                it('Tentar fatiar booleano', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        logico = verdadeiro
+                        fatia = logico[0:1]
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Tentar fatiar dicionário (não suportado como intervalo)', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        dic = {'a': 1, 'b': 2}
+                        fatia = dic[0:1]
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                 });


### PR DESCRIPTION
Este Pull Request implementa o recurso de fatiamento (slicing) para coleções ordenadas (Vetores/Listas e Textos) no dialeto Pituguês, aproximando sua sintaxe e comportamento do Python.

### O que foi feito

1. **Novo Construto:** Foi criado o construto AcessoIntervaloVariavel para representar a sintaxe de fatiamento no tempo de análise sintática.

2. **Avaliador Sintático:** O método chamar() no avaliador-sintatico-pitugues.ts foi atualizado para reconhecer a sintaxe [inicio:fim], [inicio:], [:fim], [:] e distinguir esses casos de um acesso de índice simples ([indice]).

3. **Lógica de Interpretação:** Foi implementada a função visitarExpressaoAcessoIntervaloVariavel em interpretador/dialetos/pitugues/comum.ts. Esta função executa o fatiamento em Vetores e Textos.

4. **Integração de Tipos:** O método foi adicionado às classes InterpretadorPitugues e InterpretadorPituguesComDepuracao.

### Problemas Resolvidos e Melhorias

- **Implementação do Recurso:** Resolve a Issue #880, adicionando o comportamento de fatiamento conforme especificado.

- **Suporte a Variações:** Implementa todas as variações de fatiamento, incluindo o uso de índices negativos (ex: vetor[-2:] ou vetor[:-1]).

- **Tratamento de Erros:** Adicionada validação em tempo de execução para garantir que o fatiamento só seja aplicado a tipos suportados (Vetores e Textos), evitando crashes em variáveis não-colecionáveis (Números, Booleanos).

### Testes Adicionados

Foram incluídos testes de integração detalhados em testes/pitugues/interpretador.test.ts para cobrir os seguintes casos:

- Fatiamento completo [1:4]

- Fatiamento sem fim [2:]

- Fatiamento sem início [:2]

- Cópia completa [:]

- Fatiamento com índices negativos [-2:], [:-2], [-4:-1]

- Fatiamento misto [1:-1]

- Casos de falha (tentativa de fatiar números ou booleanos)

Closes #880 