### PR TITLE
Implementação do método partition (particao/partição) para Pituguês

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
@@ -1,6 +1,7 @@
 import { InterpretadorInterface } from '../../../interfaces';
 import { PrimitivaInterface } from '../../../interfaces/primitiva-interface';
 import { InformacaoElementoSintatico } from '../../../informacao-elemento-sintatico';
+import { implementacaoParticao } from '../../primitivas-texto';
 
 export default {
     aparar: {
@@ -345,6 +346,44 @@ export default {
             'escreva(t.minusculo()) // "tudo em maiúsculo"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.minusculo()',
+    },
+    particao: {
+        tipoRetorno: 'tupla',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'separador',
+                'texto',
+                true,
+                [],
+                'O separador usado para partir o texto.'
+            ),
+        ],
+        implementacao: implementacaoParticao,
+        assinaturaFormato: 'texto.particao(separador: texto)',
+        documentacao:
+            '# `texto.particao(separador)` \n \n' +
+            'Divide o texto na primeira ocorrência do separador e retorna uma tupla com: ' +
+            'o que vem antes, o separador e o que vem depois.',
+        exemploCodigo: 'texto.particao(" ")',
+    },
+    partição: {
+        tipoRetorno: 'tupla',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'separador',
+                'texto',
+                true,
+                [],
+                'O separador usado para partir o texto.'
+            ),
+        ],
+        implementacao: implementacaoParticao,
+        assinaturaFormato: 'texto.partição(separador: texto)',
+        documentacao:
+            '# `texto.partição(separador)` \n \n' +
+            'Divide o texto na primeira ocorrência do separador e retorna uma tupla com: ' +
+            'o que vem antes, o separador e o que vem depois.',
+        exemploCodigo: 'texto.partição(" ")',
     },
     substituir: {
         tipoRetorno: 'texto',

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -1,6 +1,83 @@
 import { InterpretadorInterface } from '../interfaces';
 import { PrimitivaInterface } from '../interfaces/primitiva-interface';
 import { InformacaoElementoSintatico } from '../informacao-elemento-sintatico';
+import { Construto, TuplaN, Literal } from '../construtos';
+import { ErroEmTempoDeExecucao } from '../excecoes';
+
+export const implementacaoParticao = (
+    interpretador: InterpretadorInterface,
+    nomePrimitiva: string,
+    texto: any,
+    separador: any,
+    ...args: any[]
+): Promise<any> => {
+    if (args.length > 0) {
+        return Promise.reject(new ErroEmTempoDeExecucao(
+            null,
+            `A função "${nomePrimitiva}" aceita apenas um argumento.`,
+            interpretador.linhaDeclaracaoAtual
+        ));
+    }
+
+    if (typeof texto !== 'string') {
+        return Promise.reject(new ErroEmTempoDeExecucao(
+            null,
+            `A função "${nomePrimitiva}" só pode ser chamada em textos.`,
+            interpretador.linhaDeclaracaoAtual
+        ));
+    }
+
+    if (separador === undefined) {
+        return Promise.reject(new ErroEmTempoDeExecucao(
+            null,
+            `A função "${nomePrimitiva}" requer um argumento separador.`,
+            interpretador.linhaDeclaracaoAtual
+        ));
+    }
+
+    if (typeof separador !== 'string') {
+        return Promise.reject(new ErroEmTempoDeExecucao(
+            null,
+            'O separador deve ser do tipo texto.',
+            interpretador.linhaDeclaracaoAtual
+        ));
+    }
+
+    if (separador === '') {
+        return Promise.reject(new ErroEmTempoDeExecucao(
+            null,
+            'O separador não pode ser uma string vazia.',
+            interpretador.linhaDeclaracaoAtual
+        ));
+    }
+
+    const indice = texto.indexOf(separador);
+    let partes: string[];
+
+    if (indice === -1) {
+        partes = [texto, '', ''];
+    } else {
+        const antes = texto.substring(0, indice);
+        const depois = texto.substring(indice + separador.length);
+        partes = [antes, separador, depois];
+    }
+
+    const elementos: Construto[] = partes.map(p => new Literal(
+        interpretador.hashArquivoDeclaracaoAtual,
+        interpretador.linhaDeclaracaoAtual,
+        p,
+        'texto'
+    ));
+
+    const tupla = new TuplaN(
+        interpretador.hashArquivoDeclaracaoAtual,
+        interpretador.linhaDeclaracaoAtual,
+        elementos
+    );
+
+    return Promise.resolve(tupla);
+};
+
 
 export default {
     aparar: {
@@ -289,6 +366,44 @@ export default {
             'escreva(t.minusculo()) // "tudo em maiúsculo"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.minusculo()',
+    },
+    particao: {
+        tipoRetorno: 'tupla',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'separador',
+                'texto',
+                true,
+                [],
+                'O separador usado para partir o texto.'
+            ),
+        ],
+        implementacao: implementacaoParticao,
+        assinaturaFormato: 'texto.particao(separador: texto)',
+        documentacao:
+            '# `texto.particao(separador)` \n \n' +
+            'Divide o texto na primeira ocorrência do separador e retorna uma tupla com: ' +
+            'o que vem antes, o separador e o que vem depois.',
+        exemploCodigo: 'texto.particao(" ")',
+    },
+    partição: {
+        tipoRetorno: 'tupla',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'separador',
+                'texto',
+                true,
+                [],
+                'O separador usado para partir o texto.'
+            ),
+        ],
+        implementacao: implementacaoParticao,
+        assinaturaFormato: 'texto.partição(separador: texto)',
+        documentacao:
+            '# `texto.partição(separador)` \n \n' +
+            'Divide o texto na primeira ocorrência do separador e retorna uma tupla com: ' +
+            'o que vem antes, o separador e o que vem depois.',
+        exemploCodigo: 'texto.partição(" ")',
     },
     substituir: {
         tipoRetorno: 'texto',

--- a/testes/bibliotecas/dialetos/pitugues/primitiva-texto.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitiva-texto.test.ts
@@ -1,0 +1,86 @@
+import primitivaTexto from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-texto';
+import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
+import { TuplaN } from '../../../../fontes/construtos/tupla-n';
+import { Literal } from '../../../../fontes/construtos';
+
+describe('primitiva-texto', () => {
+    const interpretador = criarInterpretadorMock();
+
+    describe('particao / partição', () => {
+        it('deve partir o texto corretamente quando o separador existe', async () => {
+            const texto = "I could eat bananas all day";
+            const separador = "bananas";
+
+            const resultado = await primitivaTexto.particao.implementacao(
+                interpretador,
+                'particao',
+                texto,
+                separador
+            );
+
+            expect(resultado).toBeInstanceOf(TuplaN);
+            expect(resultado.tipo).toBe('tupla');
+
+            const valores = resultado.elementos.map((elemento: Literal) => elemento.valor);
+            expect(valores).toEqual(['I could eat ', 'bananas', ' all day']);
+            expect(resultado.paraTextoSaida()).toBe('("I could eat ", "bananas", " all day")');
+        });
+
+        it('deve retornar tupla com campos vazios quando o separador não existe', async () => {
+            const texto = "fruta";
+            const separador = "carro";
+
+            const resultado = await primitivaTexto.particao.implementacao(
+                interpretador,
+                'particao',
+                texto,
+                separador
+            );
+
+            expect(resultado).toBeInstanceOf(TuplaN);
+            expect(resultado.tipo).toBe('tupla');
+
+            const valores = resultado.elementos.map((elemento: Literal) => elemento.valor);
+            expect(valores).toEqual(['fruta', '', '']);
+            expect(resultado.paraTextoSaida()).toBe('("fruta", "", "")');
+        });
+
+        it('a versão com acento (partição) deve ter o mesmo comportamento', async () => {
+            const texto = "python-pitugues";
+            const separador = "-";
+
+            const resultado = await primitivaTexto.partição.implementacao(
+                interpretador,
+                'partição',
+                texto,
+                separador
+            );
+
+            expect(resultado).toBeInstanceOf(TuplaN);
+            expect(resultado.tipo).toBe('tupla');
+
+            const valores = resultado.elementos.map((elemento: Literal) => elemento.valor);
+            expect(valores).toEqual(['python', '-', 'pitugues']);
+            expect(resultado.paraTextoSaida()).toBe('("python", "-", "pitugues")');
+        });
+
+        it('deve lidar com separadores no início do texto', async () => {
+            const texto = ".texto";
+            const separador = ".";
+
+            const resultado = await primitivaTexto.particao.implementacao(
+                interpretador,
+                'particao',
+                texto,
+                separador
+            );
+
+            expect(resultado).toBeInstanceOf(TuplaN);
+            expect(resultado.tipo).toBe('tupla');
+
+            const valores = resultado.elementos.map((elemento: Literal) => elemento.valor);
+            expect(valores).toEqual(['', '.', 'texto']);
+            expect(resultado.paraTextoSaida()).toBe('("", ".", "texto")');
+        });
+    });
+});

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1280,6 +1280,134 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('um dois três');
                 });
+
+                describe('particao / partição', () => {
+                    it('Deve particionar texto com separador existente (particao)', async () => {
+                        const codigo = [
+                            'txt = "I could eat bananas all day".particao("bananas")\n',
+                            'escreva(txt)'
+                        ];
+
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas[0]).toBe('("I could eat ", "bananas", " all day")');
+                    });
+
+                    it('Deve particionar texto com separador existente (particao)', async () => {
+                        const codigo = [
+                            'txt = "python-pitugues"',
+                            'resultado = txt.particao("-")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('("python", "-", "pitugues")');
+                    });
+
+                    it('Deve retornar tupla com campos vazios quando separador não existe', async () => {
+                        const codigo = [
+                            'txt = "fruta"',
+                            'resultado = txt.particao("carro")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('("fruta", "", "")');
+                    });
+
+                    it('eDve lidar com separador no início do texto (partição)', async () => {
+                        const codigo = [
+                            'txt = ".texto"',
+                            'resultado = txt.partição(".")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('("", ".", "texto")');
+                    });
+
+                    it('Deve lidar com separador no final do texto (partição)', async () => {
+                        const codigo = [
+                            'txt = "texto."',
+                            'resultado = txt.partição(".")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('("texto", ".", "")');
+                    });
+
+                    it('Deve particionar com separador de múltiplos caracteres (partição)', async () => {
+                        const codigo = [
+                            'txt = "isso--separador--texto"',
+                            'resultado = txt.partição("--")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('("isso", "--", "separador--texto")');
+                    });
+                });
             });
 
             describe('Uso de primitivas de vetor', () => {
@@ -1958,6 +2086,107 @@ describe('Interpretador (Pituguês)', () => {
 
                 expect(retornoInterpretador.erros).toHaveLength(1);
                 expect(retornoInterpretador.erros[0].erroInterno.message).toContain('imutáveis');
+            });
+
+            describe('Uso de primitivas de texto', () => {
+                describe('particao / partição', () => {
+                    it('Chamar particao sem argumentos', async () => {
+                        const codigo = [
+                            'txt = "texto de teste"',
+                            'resultado = txt.particao()',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    });
+
+                    it('Chamar particao com tipo errado (número)', async () => {
+                        const codigo = [
+                            'txt = "texto de teste"',
+                            'resultado = txt.partição(123)',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    });
+
+                    it('Chamar particao em um número (não é texto)', async () => {
+                        const codigo = [
+                            'num = 123',
+                            'resultado = num.particao("2")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    });
+
+                    it('Chamar particao com mais argumentos do que o suportado', async () => {
+                        const codigo = [
+                            'txt = "texto de teste"',
+                            'resultado = txt.partição("de", "extra")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    });
+
+                    it('Chamar particao com separador vazio', async () => {
+                        const codigo = [
+                            'txt = "texto de teste"',
+                            'resultado = txt.particao("")',
+                            'escreva(resultado)'
+                        ];
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
### O que foi feito

Implementação do método de primitiva de texto `particao()` e `partição()` para o dialeto Pituguês, trazendo a funcionalidade equivalente ao método `partition()` do Python.

### As alterações incluem:

- **Lógica Central:** Criação da função `implementacaoParticao` em `fontes/bibliotecas/primitivas-texto.ts`, que realiza a divisão do texto na primeira ocorrência do separador e valida os argumentos recebidos.
- **Estrutura de Retorno:** O método retorna uma `TuplaN` contendo três elementos (antes do separador, o separador e depois do separador), mantendo a fidelidade ao comportamento original do Python.
- **Validações e Erros:** Adição de tratamentos para garantir que:
  - O separador não seja vazio.
  - O argumento seja do tipo texto.
  - Apenas um argumento seja passado.

### Por que foi feito

Para resolver a issue #942, aproximando o Pituguês das funcionalidades integradas do Python e fornecendo uma forma eficiente de manipulação de strings.

Closes #942