### PR TITLE
Validação de limites para índices negativos em listas, tuplas e textos

### DIFF
--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -56,12 +56,16 @@ export class InterpretadorPitugues extends Interpretador {
     override async visitarExpressaoAcessoIndiceVariavel(expressao: AcessoIndiceVariavel): Promise<any> {
         const objeto = await this.avaliar(expressao.entidadeChamada);
         const indice = await this.avaliar(expressao.indice);
-        const valorIndice = this.resolverValor(indice);
+        let valorIndice = this.resolverValor(indice);
         const objetoResolvido = this.resolverValor(objeto);
 
         if (objetoResolvido instanceof TuplaN) {
             if (!Number.isInteger(valorIndice)) {
                 throw new ErroEmTempoDeExecucao(expressao.simboloFechamento, 'Índice deve ser inteiro.', expressao.linha);
+            }
+
+            if (valorIndice < 0 && objetoResolvido.elementos.length !== 0) {
+                valorIndice += objetoResolvido.elementos.length;
             }
 
             if (valorIndice < 0 || valorIndice >= objetoResolvido.elementos.length) {

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -612,12 +612,10 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             }
 
             if (valorIndice < 0 && objeto.length !== 0) {
-                while (valorIndice < 0) {
-                    valorIndice += objeto.length;
-                }
+                valorIndice += objeto.length;
             }
 
-            if (valorIndice >= objeto.length) {
+            if (valorIndice >= objeto.length || valorIndice < 0) {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         expressao.simboloFechamento,
@@ -657,12 +655,10 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             }
 
             if (valorIndice < 0 && objeto.length !== 0) {
-                while (valorIndice < 0) {
-                    valorIndice += objeto.length;
-                }
+                valorIndice += objeto.length;
             }
 
-            if (valorIndice >= objeto.length) {
+            if (valorIndice >= objeto.length || valorIndice < 0) {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         expressao.simboloFechamento,

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1719,6 +1719,24 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas[0]).toBe('20');
                 });
 
+                it('Deve permitir acesso de elemento da tupla através de índice negativo', async () => {
+                    const retornoLexador = lexador.mapear([`
+                       t = (1, 2, 3)
+                       escreva(t[-1])
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('3');
+                });
+
                 it('Deve suportar tupla com diferentes tipos de dados (Inteiro, Texto, Booleano, Real)', async () => {
                     const retornoLexador = lexador.mapear([
                         't = (1, "pituguês", verdadeiro, 2.5)',
@@ -1998,6 +2016,40 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                 });
 
+                it('Acesso a elementos negativos fora do tamanho do vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        a = [1, 2, 3]
+                        escreva(a[-4])
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                    );
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Acesso a elementos negativos fora do tamanho da tupla', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        a = (1, 2, 3)
+                        escreva(a[-4])
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                    );
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
                 it('Acesso a elementos de dicionário', async () => {
                     const retornoLexador = lexador.mapear(
                         ["a = {'a': 1, 'b': 2}\nescreva(a['c'])"],
@@ -2262,6 +2314,9 @@ describe('Interpretador (Pituguês)', () => {
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                     });
+                });
+            });
+
             describe('Repetição de Strings', () => {
                 it('Deve dar erro ao tentar multiplicar texto por texto ("Olá" * "Mundo")', async () => {
                     const retornoLexador = lexador.mapear([


### PR DESCRIPTION
### O que foi feito

Foi realizada uma correção estrutural na lógica de acesso a elementos via índice negativo. Como o Pituguês herda o comportamento base do Delégua, a correção foi aplicada em dois níveis:

- **Core (Delégua):** No `interpretador.ts`, a lógica de while (que causava um comportamento cíclico infinito/incorreto) foi substituída por uma validação estrita para **Vetores** e **Textos**.
- **Dialeto (Pituguês):** No `interpretador-pitugues.ts`, a mesma lógica foi aplicada especificamente para o objeto de Tuplas.

A nova lógica segue o padrão de indexação do Python:
- Soma-se o tamanho do objeto ao índice negativo apenas uma vez.
- Se, após a soma, o índice resultante permanecer negativo (indicando que o valor absoluto era maior que o tamanho da lista) ou for maior que o tamanho, o sistema lança um `ErroEmTempoDeExecucao`.

### Por que foi feito?

Para resolver a issue #1016. O bug originava-se no núcleo do Delégua e, por consequência, afetava o Pituguês.

O comportamento anterior permitia que índices negativos "dessem a volta" na lista múltiplas vezes. Por exemplo: em uma lista de 5 itens, acessar o índice `-6` resultava no elemento do índice `4`, quando o comportamento esperado é o lançamento de um erro de índice fora do intervalo.

Closes #1016