### PR TITLE
Implementação de funções e métodos de conversão entre tuplas e vetores

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -97,6 +97,7 @@ import primitivasDicionario from '../../bibliotecas/primitivas-dicionario';
 import primitivasNumero from '../../bibliotecas/primitivas-numero';
 import primitivasTexto from '../../bibliotecas/primitivas-texto';
 import primitivasVetor from '../../bibliotecas/primitivas-vetor';
+import primitivasTupla from '../../bibliotecas/dialetos/pitugues/primitivas-tupla';
 import { MicroLexadorPitugues } from '../../lexador/micro-lexador-pitugues';
 import { MicroAvaliadorSintaticoPitugues } from './micro-avaliador-sintatico-pitugues';
 
@@ -140,6 +141,7 @@ export class AvaliadorSintaticoPitugues
         registrarPrimitiva(this.primitivasConhecidas, 'número', primitivasNumero);
         registrarPrimitiva(this.primitivasConhecidas, 'texto', primitivasTexto);
         registrarPrimitiva(this.primitivasConhecidas, 'vetor', primitivasVetor);
+        registrarPrimitiva(this.primitivasConhecidas, 'tupla', primitivasTupla);
     }
 
     protected logicaComumInferenciaTiposVariaveisEConstantes(

--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -17,6 +17,7 @@ import {
     Sexteto,
     Trio,
     Tupla,
+    TuplaN
 } from '../construtos';
 
 import { RetornoQuebra } from '../quebras';
@@ -228,197 +229,31 @@ export async function clonar(
         }
 
         // Tuplas
-        const nomeClasseTupla = valorAtual.constructor?.name;
-        if (
-            nomeClasseTupla &&
-            /^(Dupla|Trio|Quarteto|Quinteto|Sexteto|Septeto|Octeto|Noneto|Deceto)$/.test(
-                nomeClasseTupla
-            )
-        ) {
-            const valoresClonados: any[] = [];
-            visitados.set(valorAtual, valoresClonados);
+        if (valorAtual instanceof TuplaN || (valorAtual.constructor && valorAtual.constructor.name === 'TuplaN')) {
+            const elementosClonados: any[] = [];
+            visitados.set(valorAtual, elementosClonados);
 
-            // Extrair valores da tupla baseado no tipo
-            let valores: any[] = [];
-
-            switch (nomeClasseTupla) {
-                case 'Dupla':
-                    valores = [valorAtual.primeiro, valorAtual.segundo];
-                    break;
-                case 'Trio':
-                    valores = [valorAtual.primeiro, valorAtual.segundo, valorAtual.terceiro];
-                    break;
-                case 'Quarteto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                    ];
-                    break;
-                case 'Quinteto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                    ];
-                    break;
-                case 'Sexteto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                        valorAtual.sexto,
-                    ];
-                    break;
-                case 'Septeto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                        valorAtual.sexto,
-                        valorAtual.setimo,
-                    ];
-                    break;
-                case 'Octeto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                        valorAtual.sexto,
-                        valorAtual.setimo,
-                        valorAtual.oitavo,
-                    ];
-                    break;
-                case 'Noneto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                        valorAtual.sexto,
-                        valorAtual.setimo,
-                        valorAtual.oitavo,
-                        valorAtual.nono,
-                    ];
-                    break;
-                case 'Deceto':
-                    valores = [
-                        valorAtual.primeiro,
-                        valorAtual.segundo,
-                        valorAtual.terceiro,
-                        valorAtual.quarto,
-                        valorAtual.quinto,
-                        valorAtual.sexto,
-                        valorAtual.setimo,
-                        valorAtual.oitavo,
-                        valorAtual.nono,
-                        valorAtual.decimo,
-                    ];
-                    break;
-                default:
-                    // Se não conseguir identificar, tentar extrair valores diretamente
-                    if (valorAtual.valor) {
-                        valores = Array.isArray(valorAtual.valor)
-                            ? valorAtual.valor
-                            : [valorAtual.valor];
-                    }
+            for (const elemento of valorAtual.elementos) {
+                if (elemento instanceof Literal || (elemento.constructor && elemento.constructor.name === 'Literal')) {
+                    const valorClonado = clonarProfundo(elemento.valor);
+                    elementosClonados.push(
+                        new Literal(
+                            elemento.hashArquivo,
+                            elemento.linha,
+                            valorClonado,
+                            elemento.tipo
+                        )
+                    );
+                } else {
+                    elementosClonados.push(clonarProfundo(elemento));
+                }
             }
 
-            // Clonar valores
-            for (let i = 0; i < valores.length; i++) {
-                valoresClonados.push(clonarProfundo(valores[i]));
-            }
-
-            // Recriar a tupla com valores clonados
-            switch (nomeClasseTupla) {
-                case 'Dupla':
-                    return new Dupla(valoresClonados[0], valoresClonados[1]);
-                case 'Trio':
-                    return new Trio(valoresClonados[0], valoresClonados[1], valoresClonados[2]);
-                case 'Quarteto':
-                    return new Quarteto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3]
-                    );
-                case 'Quinteto':
-                    return new Quinteto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4]
-                    );
-                case 'Sexteto':
-                    return new Sexteto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4],
-                        valoresClonados[5]
-                    );
-                case 'Septeto':
-                    return new Septeto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4],
-                        valoresClonados[5],
-                        valoresClonados[6]
-                    );
-                case 'Octeto':
-                    return new Octeto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4],
-                        valoresClonados[5],
-                        valoresClonados[6],
-                        valoresClonados[7]
-                    );
-                case 'Noneto':
-                    return new Noneto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4],
-                        valoresClonados[5],
-                        valoresClonados[6],
-                        valoresClonados[7],
-                        valoresClonados[8]
-                    );
-                case 'Deceto':
-                    return new Deceto(
-                        valoresClonados[0],
-                        valoresClonados[1],
-                        valoresClonados[2],
-                        valoresClonados[3],
-                        valoresClonados[4],
-                        valoresClonados[5],
-                        valoresClonados[6],
-                        valoresClonados[7],
-                        valoresClonados[8],
-                        valoresClonados[9]
-                    );
-                default:
-                    // Se não conseguir recriar, retornar os valores clonados como array
-                    return valoresClonados;
-            }
+            return new TuplaN(
+                interpretador.hashArquivoDeclaracaoAtual,
+                interpretador.linhaDeclaracaoAtual,
+                elementosClonados
+            );
         }
 
         // DeleguaFuncao e FuncaoPadrao - funções não são clonadas profundamente
@@ -1355,7 +1190,7 @@ export async function todosEmCondicao(
 export async function tupla(
     interpretador: InterpretadorInterface,
     vetor: VariavelInterface | any[]
-): Promise<Tupla> {
+): Promise<TuplaN> {
     const valorVetor: any[] =
         !Array.isArray(vetor) && vetor.hasOwnProperty('valor') ? vetor.valor : vetor;
 
@@ -1373,114 +1208,45 @@ export async function tupla(
         );
     }
 
-    switch (valorVetor.length) {
-        case 2:
-            return Promise.resolve(
-                new Dupla(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                )
-            );
-        case 3:
-            return Promise.resolve(new Trio(
-                new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-            ));
-        case 4:
-            return Promise.resolve(
-                new Quarteto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                )
-            );
-        case 5:
-            return Promise.resolve(
-                new Quinteto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                )
-            );
-        case 6:
-            return Promise.resolve(
-                new Sexteto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[5], inferirTipoVariavel(valorVetor[5]) as any),
-                )
-            );
-        case 7:
-            return Promise.resolve(
-                new Septeto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[5], inferirTipoVariavel(valorVetor[5]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[6], inferirTipoVariavel(valorVetor[6]) as any),
-                )
-            );
-        case 8:
-            return Promise.resolve(
-                new Octeto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[5], inferirTipoVariavel(valorVetor[5]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[6], inferirTipoVariavel(valorVetor[6]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[7], inferirTipoVariavel(valorVetor[7]) as any),
-                )
-            );
-        case 9:
-            return Promise.resolve(
-                new Noneto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[5], inferirTipoVariavel(valorVetor[5]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[6], inferirTipoVariavel(valorVetor[6]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[7], inferirTipoVariavel(valorVetor[7]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[8], inferirTipoVariavel(valorVetor[8]) as any),
-                )
-            );
-        case 10:
-            return Promise.resolve(
-                new Deceto(
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[0], inferirTipoVariavel(valorVetor[0]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[1], inferirTipoVariavel(valorVetor[1]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[2], inferirTipoVariavel(valorVetor[2]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[3], inferirTipoVariavel(valorVetor[3]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[4], inferirTipoVariavel(valorVetor[4]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[5], inferirTipoVariavel(valorVetor[5]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[6], inferirTipoVariavel(valorVetor[6]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[7], inferirTipoVariavel(valorVetor[7]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[8], inferirTipoVariavel(valorVetor[8]) as any),
-                    new Literal(interpretador.hashArquivoDeclaracaoAtual, interpretador.linhaDeclaracaoAtual, valorVetor[9], inferirTipoVariavel(valorVetor[9]) as any),
-                )
-            );
-        case 1:
-        default:
-            return Promise.reject(
-                new ErroEmTempoDeExecucao(
-                    {
-                        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
-                        linha: interpretador.linhaDeclaracaoAtual,
-                    } as SimboloInterface,
-                    'Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.'
-                )
-            );
+    const elementos = valorVetor.map(item => {
+        return new Literal(
+            interpretador.hashArquivoDeclaracaoAtual,
+            interpretador.linhaDeclaracaoAtual,
+            item,
+            inferirTipoVariavel(item) as any
+        );
+    });
+
+    return new TuplaN(
+        interpretador.hashArquivoDeclaracaoAtual,
+        interpretador.linhaDeclaracaoAtual,
+        elementos
+    );
+}
+
+export async function vetor(
+    interpretador: InterpretadorInterface,
+    tupla: TuplaN | any
+): Promise<any[]> {
+    const objetoTupla = tupla.hasOwnProperty('valor') ? tupla.valor : tupla;
+
+    // TODO: As lógicas de validação abaixo deixam de fazer sentido com a validação de argumentos feita
+    // na avaliação sintática. Estudar remoção.
+    if (!(objetoTupla instanceof TuplaN)) {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                {
+                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                    linha: interpretador.linhaDeclaracaoAtual,
+                } as SimboloInterface,
+                'Argumento de função nativa `vetor` não parece ser uma tupla.'
+            )
+        );
     }
+
+    const resultado = objetoTupla.elementos.map((elemento: any) => {
+        return elemento.hasOwnProperty('valor') ? elemento.valor : elemento;
+    });
+
+    return Promise.resolve(resultado);
 }

--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -23,6 +23,42 @@ import {
 import { RetornoQuebra } from '../quebras';
 import { inferirTipoVariavel } from '../inferenciador';
 
+const configTuplas: { [key: string]: { Classe: any, props: string[] } } = {
+    'Dupla': { Classe: Dupla, props: ['primeiro', 'segundo'] },
+    'Trio': { Classe: Trio, props: ['primeiro', 'segundo', 'terceiro'] },
+    'Quarteto': { Classe: Quarteto, props: ['primeiro', 'segundo', 'terceiro', 'quarto'] },
+    'Quinteto': { Classe: Quinteto, props: ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto'] },
+    'Sexteto': { Classe: Sexteto, props: [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto'] },
+    'Septeto': { Classe: Septeto, props: [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo' ] },
+    'Octeto': { Classe: Octeto, props: [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo' ] },
+    'Noneto': { Classe: Noneto, props: [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono' ] },
+    'Deceto': { Classe: Deceto, props: [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono', 'decimo' ] },
+};
+
+const mapaConstrutoresTupla: { [tamanho: number]: any } = {
+    2: Dupla,
+    3: Trio,
+    4: Quarteto,
+    5: Quinteto,
+    6: Sexteto,
+    7: Septeto,
+    8: Octeto,
+    9: Noneto,
+    10: Deceto
+};
+
+const mapaPropriedadesTuplas: { [nomeClasse: string]: string[] } = {
+    'Dupla': ['primeiro', 'segundo'],
+    'Trio': ['primeiro', 'segundo', 'terceiro'],
+    'Quarteto': ['primeiro', 'segundo', 'terceiro', 'quarto'],
+    'Quinteto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto' ],
+    'Sexteto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto' ],
+    'Septeto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo' ],
+    'Octeto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo' ],
+    'Noneto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono' ],
+    'Deceto': [ 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono', 'decimo' ],
+};
+
 /**
  * Retorna um número aleatório entre 0 e 1.
  * @returns {Promise<number>} Número real.
@@ -228,32 +264,35 @@ export async function clonar(
             return objetoClonado;
         }
 
-        // Tuplas
-        if (valorAtual instanceof TuplaN || (valorAtual.constructor && valorAtual.constructor.name === 'TuplaN')) {
+        // Tuplas com 11 elementos ou mais
+        if (valorAtual instanceof TuplaN) {
             const elementosClonados: any[] = [];
             visitados.set(valorAtual, elementosClonados);
 
-            for (const elemento of valorAtual.elementos) {
-                if (elemento instanceof Literal || (elemento.constructor && elemento.constructor.name === 'Literal')) {
-                    const valorClonado = clonarProfundo(elemento.valor);
-                    elementosClonados.push(
-                        new Literal(
-                            elemento.hashArquivo,
-                            elemento.linha,
-                            valorClonado,
-                            elemento.tipo
-                        )
-                    );
-                } else {
-                    elementosClonados.push(clonarProfundo(elemento));
-                }
+            for (let i = 0; i < valorAtual.elementos.length; i++) {
+                elementosClonados.push(clonarProfundo(valorAtual.elementos[i]));
             }
 
             return new TuplaN(
-                interpretador.hashArquivoDeclaracaoAtual,
-                interpretador.linhaDeclaracaoAtual,
+                valorAtual.hashArquivo,
+                valorAtual.linha,
                 elementosClonados
             );
+        }
+
+        // Tuplas com até 10 elementos
+        const nomeClasseTupla = valorAtual.constructor?.name;
+        if (nomeClasseTupla && configTuplas[nomeClasseTupla]) {
+            const config = configTuplas[nomeClasseTupla];
+            const argsClonados = [];
+
+            visitados.set(valorAtual, argsClonados);
+
+            for (const prop of config.props) {
+                argsClonados.push(clonarProfundo(valorAtual[prop]));
+            }
+
+            return new config.Classe(...argsClonados);
         }
 
         // DeleguaFuncao e FuncaoPadrao - funções não são clonadas profundamente
@@ -1190,7 +1229,7 @@ export async function todosEmCondicao(
 export async function tupla(
     interpretador: InterpretadorInterface,
     vetor: VariavelInterface | any[]
-): Promise<TuplaN> {
+): Promise<Tupla | TuplaN> {
     const valorVetor: any[] =
         !Array.isArray(vetor) && vetor.hasOwnProperty('valor') ? vetor.valor : vetor;
 
@@ -1208,31 +1247,50 @@ export async function tupla(
         );
     }
 
-    const elementos = valorVetor.map(item => {
-        return new Literal(
-            interpretador.hashArquivoDeclaracaoAtual,
-            interpretador.linhaDeclaracaoAtual,
-            item,
-            inferirTipoVariavel(item) as any
-        );
-    });
+    const tamanho = valorVetor.length;
 
-    return new TuplaN(
+    if (tamanho < 2) {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                {
+                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                    linha: interpretador.linhaDeclaracaoAtual,
+                } as SimboloInterface,
+                'Para ser transformado em uma tupla, vetor precisa ter no mínimo 2 elementos.'
+            )
+        );
+    }
+
+    const criarLiteral = (valor: any) => new Literal(
         interpretador.hashArquivoDeclaracaoAtual,
         interpretador.linhaDeclaracaoAtual,
-        elementos
+        valor,
+        inferirTipoVariavel(valor) as any
     );
+
+    if (mapaConstrutoresTupla.hasOwnProperty(tamanho)) {
+        const Construtor = mapaConstrutoresTupla[tamanho];
+        const args = valorVetor.map(criarLiteral);
+        return Promise.resolve(new Construtor(...args));
+    }
+
+    const elementos = valorVetor.map(criarLiteral);
+    return Promise.resolve(new TuplaN(
+       interpretador.hashArquivoDeclaracaoAtual,
+       interpretador.linhaDeclaracaoAtual,
+       elementos
+    ));
 }
 
 export async function vetor(
     interpretador: InterpretadorInterface,
-    tupla: TuplaN | any
+    tupla: Tupla | TuplaN | any
 ): Promise<any[]> {
-    const objetoTupla = tupla.hasOwnProperty('valor') ? tupla.valor : tupla;
+    const objetoTupla = interpretador.resolverValor(tupla);
 
     // TODO: As lógicas de validação abaixo deixam de fazer sentido com a validação de argumentos feita
     // na avaliação sintática. Estudar remoção.
-    if (!(objetoTupla instanceof TuplaN)) {
+    if (!(objetoTupla instanceof Tupla || objetoTupla instanceof TuplaN)) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {
@@ -1244,9 +1302,24 @@ export async function vetor(
         );
     }
 
-    const resultado = objetoTupla.elementos.map((elemento: any) => {
-        return elemento.hasOwnProperty('valor') ? elemento.valor : elemento;
-    });
+    let resultado: any[] = [];
 
-    return Promise.resolve(resultado);
+    if (objetoTupla instanceof TuplaN) {
+        resultado = objetoTupla.elementos;
+    } else {
+        const nomeClasse = objetoTupla.constructor.name;
+
+        if (mapaPropriedadesTuplas.hasOwnProperty(nomeClasse)) {
+            const props = mapaPropriedadesTuplas[nomeClasse];
+            resultado = props.map(prop => (objetoTupla as any)[prop]);
+        } else if ((objetoTupla as any).elementos && Array.isArray((objetoTupla as any).elementos)) {
+            resultado = (objetoTupla as any).elementos;
+        }
+    }
+
+    const resultadoFinal = resultado.map(item =>
+        (item && item.hasOwnProperty('valor')) ? item.valor : item
+    );
+
+    return Promise.resolve(resultadoFinal);
 }

--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -1114,7 +1114,7 @@ export async function vetor(
     interpretador: InterpretadorInterface,
     tupla: TuplaN | any
 ): Promise<any[]> {
-    const objetoTupla = tupla.hasOwnProperty('valor') ? tupla.valor : tupla;
+    const objetoTupla = interpretador.resolverValor(tupla);
 
     // TODO: As lógicas de validação abaixo deixam de fazer sentido com a validação de argumentos feita
     // na avaliação sintática. Estudar remoção.

--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -6,18 +6,13 @@ import { SimboloInterface, VariavelInterface } from '../../../interfaces';
 import { InterpretadorInterface } from '../../../interfaces';
 import { DeleguaFuncao } from '../../../interpretador/estruturas';
 import {
-    Deceto,
-    Dupla,
-    Noneto,
-    Octeto,
-    Quarteto,
-    Quinteto,
-    Septeto,
-    Sexteto,
-    Trio,
+    TuplaN,
     Tupla,
+    Literal
 } from '../../../construtos';
 import { RetornoQuebra } from '../../../quebras';
+
+import { inferirTipoVariavel } from '../../../inferenciador';
 
 /**
  * Retorna um número aleatório entre 0 e 1.
@@ -1081,7 +1076,7 @@ export async function todos_em_condicao(
 export async function tupla(
     interpretador: InterpretadorInterface,
     vetor: VariavelInterface | any[]
-): Promise<Tupla> {
+): Promise<TuplaN> {
     const valorVetor: any[] =
         !Array.isArray(vetor) && vetor.hasOwnProperty('valor') ? vetor.valor : vetor;
 
@@ -1099,100 +1094,45 @@ export async function tupla(
         );
     }
 
-    switch (valorVetor.length) {
-        case 2:
-            return Promise.resolve(new Dupla(valorVetor[0], valorVetor[1]));
-        case 3:
-            return Promise.resolve(new Trio(valorVetor[0], valorVetor[1], valorVetor[2]));
-        case 4:
-            return Promise.resolve(
-                new Quarteto(valorVetor[0], valorVetor[1], valorVetor[2], valorVetor[3])
-            );
-        case 5:
-            return Promise.resolve(
-                new Quinteto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4]
-                )
-            );
-        case 6:
-            return Promise.resolve(
-                new Sexteto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4],
-                    valorVetor[5]
-                )
-            );
-        case 7:
-            return Promise.resolve(
-                new Septeto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4],
-                    valorVetor[5],
-                    valorVetor[6]
-                )
-            );
-        case 8:
-            return Promise.resolve(
-                new Octeto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4],
-                    valorVetor[5],
-                    valorVetor[6],
-                    valorVetor[7]
-                )
-            );
-        case 9:
-            return Promise.resolve(
-                new Noneto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4],
-                    valorVetor[5],
-                    valorVetor[6],
-                    valorVetor[7],
-                    valorVetor[8]
-                )
-            );
-        case 10:
-            return Promise.resolve(
-                new Deceto(
-                    valorVetor[0],
-                    valorVetor[1],
-                    valorVetor[2],
-                    valorVetor[3],
-                    valorVetor[4],
-                    valorVetor[5],
-                    valorVetor[6],
-                    valorVetor[7],
-                    valorVetor[8],
-                    valorVetor[9]
-                )
-            );
-        case 1:
-        default:
-            return Promise.reject(
-                new ErroEmTempoDeExecucao(
-                    {
-                        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
-                        linha: interpretador.linhaDeclaracaoAtual,
-                    } as SimboloInterface,
-                    'Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.'
-                )
-            );
+    const elementos = valorVetor.map(item => {
+        return new Literal(
+            interpretador.hashArquivoDeclaracaoAtual,
+            interpretador.linhaDeclaracaoAtual,
+            item,
+            inferirTipoVariavel(item) as any
+        );
+    });
+
+    return new TuplaN(
+        interpretador.hashArquivoDeclaracaoAtual,
+        interpretador.linhaDeclaracaoAtual,
+        elementos
+    );
+}
+
+export async function vetor(
+    interpretador: InterpretadorInterface,
+    tupla: TuplaN | any
+): Promise<any[]> {
+    const objetoTupla = tupla.hasOwnProperty('valor') ? tupla.valor : tupla;
+
+    // TODO: As lógicas de validação abaixo deixam de fazer sentido com a validação de argumentos feita
+    // na avaliação sintática. Estudar remoção.
+    if (!(objetoTupla instanceof TuplaN)) {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                {
+                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                    linha: interpretador.linhaDeclaracaoAtual,
+                } as SimboloInterface,
+                'Argumento de função nativa `vetor` não parece ser uma tupla.'
+            )
+        );
     }
+
+    const resultado = objetoTupla.elementos.map((elemento: any) => {
+        return elemento.hasOwnProperty('valor') ? elemento.valor : elemento;
+    });
+
+    return Promise.resolve(resultado);
 }

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-tupla.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-tupla.ts
@@ -1,0 +1,38 @@
+import { InterpretadorInterface, PrimitivaInterface } from '../../../interfaces';
+import { ErroEmTempoDeExecucao } from '../../../excecoes';
+import { TuplaN } from '../../../construtos';
+
+export default {
+    paraVetor: {
+        tipoRetorno: 'vetor',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            nomePrimitiva: string,
+            tupla: TuplaN
+        ): Promise<any> => {
+            const objetoTupla = interpretador.resolverValor(tupla);
+
+            if (!(objetoTupla instanceof TuplaN)) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `A função "${nomePrimitiva}" só pode ser chamada em tuplas.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            const valoresPuros = objetoTupla.elementos.map(elemento =>
+                interpretador.resolverValor(elemento)
+            );
+
+            return Promise.resolve(valoresPuros);
+        },
+        assinaturaFormato: 'tupla.paraVetor()',
+        documentacao:
+            '# `tupla.paraVetor()` \n \n' +
+            'Converte a tupla atual em um array.',
+        exemploCodigo: 'tupla.paraVetor()',
+    }
+} as { [nome: string]: PrimitivaInterface };

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -1,6 +1,8 @@
 import { DeleguaFuncao } from '../../../interpretador/estruturas';
 import { InterpretadorInterface, PrimitivaInterface, SimboloInterface } from '../../../interfaces';
 import { InformacaoElementoSintatico } from '../../../informacao-elemento-sintatico';
+import { inferirTipoVariavel } from '../../../inferenciador';
+import { Literal, TuplaN } from '../../../construtos';
 
 export default {
     adicionar: {
@@ -440,6 +442,35 @@ export default {
             'escreva(v.ordenar()) // ["a", "aaa", "aba", "abb", "abc"]\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.ordenar()',
+    },
+    paraTupla: {
+        tipoRetorno: 'tupla',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            nomePrimitiva: string,
+            vetor: Array<any>
+        ): Promise<any> => {
+            const elementos = vetor.map(item => {
+                return new Literal(
+                    interpretador.hashArquivoDeclaracaoAtual,
+                    interpretador.linhaDeclaracaoAtual,
+                    item,
+                    inferirTipoVariavel(item) as any
+                );
+            });
+
+            return Promise.resolve(new TuplaN(
+                interpretador.hashArquivoDeclaracaoAtual,
+                interpretador.linhaDeclaracaoAtual,
+                elementos
+            ));
+        },
+        assinaturaFormato: 'vetor.paraTupla()',
+        documentacao:
+            '# `vetor.paraTupla()` \n \n' +
+            'Converte o vetor atual em uma tupla imutável.',
+        exemploCodigo: 'vetor.paraTupla()',
     },
     remover: {
         tipoRetorno: 'qualquer[]',

--- a/fontes/bibliotecas/primitivas-tupla.ts
+++ b/fontes/bibliotecas/primitivas-tupla.ts
@@ -1,6 +1,18 @@
 import { InterpretadorInterface, PrimitivaInterface } from '../interfaces';
 import { ErroEmTempoDeExecucao } from '../excecoes';
-import { TuplaN } from '../construtos';
+import { Tupla, TuplaN } from '../construtos';
+
+const mapaPropriedadesTuplas: { [nomeClasse: string]: string[] } = {
+    'Dupla': ['primeiro', 'segundo'],
+    'Trio': ['primeiro', 'segundo', 'terceiro'],
+    'Quarteto': ['primeiro', 'segundo', 'terceiro', 'quarto'],
+    'Quinteto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto'],
+    'Sexteto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto'],
+    'Septeto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo'],
+    'Octeto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo'],
+    'Noneto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono'],
+    'Deceto': ['primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'setimo', 'oitavo', 'nono', 'decimo'],
+};
 
 export default {
     paraVetor: {
@@ -9,11 +21,11 @@ export default {
         implementacao: (
             interpretador: InterpretadorInterface,
             nomePrimitiva: string,
-            tupla: TuplaN
+            tupla: Tupla | TuplaN
         ): Promise<any> => {
             const objetoTupla = interpretador.resolverValor(tupla);
 
-            if (!(objetoTupla instanceof TuplaN)) {
+            if (!(objetoTupla instanceof Tupla || objetoTupla instanceof TuplaN)) {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         null,
@@ -23,11 +35,23 @@ export default {
                 );
             }
 
-            const valoresPuros = objetoTupla.elementos.map(elemento =>
+            let elementosBrutos: any[] = [];
+
+            if (objetoTupla instanceof TuplaN) {
+                elementosBrutos = objetoTupla.elementos;
+            } else {
+                const nomeClasse = objetoTupla.constructor.name;
+                if (mapaPropriedadesTuplas.hasOwnProperty(nomeClasse)) {
+                    const props = mapaPropriedadesTuplas[nomeClasse];
+                    elementosBrutos = props.map(prop => objetoTupla[prop]);
+                }
+            }
+
+            const valoresResolvidos = elementosBrutos.map(elemento =>
                 interpretador.resolverValor(elemento)
             );
 
-            return Promise.resolve(valoresPuros);
+            return Promise.resolve(valoresResolvidos);
         },
         assinaturaFormato: 'tupla.paraVetor()',
         documentacao:

--- a/fontes/bibliotecas/primitivas-tupla.ts
+++ b/fontes/bibliotecas/primitivas-tupla.ts
@@ -1,0 +1,38 @@
+import { InterpretadorInterface, PrimitivaInterface } from '../interfaces';
+import { ErroEmTempoDeExecucao } from '../excecoes';
+import { TuplaN } from '../construtos';
+
+export default {
+    paraVetor: {
+        tipoRetorno: 'vetor',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            nomePrimitiva: string,
+            tupla: TuplaN
+        ): Promise<any> => {
+            const objetoTupla = interpretador.resolverValor(tupla);
+
+            if (!(objetoTupla instanceof TuplaN)) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `A função "${nomePrimitiva}" só pode ser chamada em tuplas.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            const valoresPuros = objetoTupla.elementos.map(elemento =>
+                interpretador.resolverValor(elemento)
+            );
+
+            return Promise.resolve(valoresPuros);
+        },
+        assinaturaFormato: 'tupla.paraVetor()',
+        documentacao:
+            '# `tupla.paraVetor()` \n \n' +
+            'Converte a tupla atual em um array.',
+        exemploCodigo: 'tupla.paraVetor()',
+    }
+} as { [nome: string]: PrimitivaInterface };

--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -2,7 +2,32 @@ import { DeleguaFuncao } from '../interpretador/estruturas';
 import { InterpretadorInterface, PrimitivaInterface, SimboloInterface } from '../interfaces';
 import { InformacaoElementoSintatico } from '../informacao-elemento-sintatico';
 import { inferirTipoVariavel } from '../inferenciador';
-import { Literal, TuplaN } from '../construtos';
+import {
+    Literal,
+    Dupla,
+    Trio,
+    Quarteto,
+    Quinteto,
+    Sexteto,
+    Septeto,
+    Octeto,
+    Noneto,
+    Deceto,
+    TuplaN
+} from '../construtos';
+import { ErroEmTempoDeExecucao } from '../excecoes';
+
+const mapaConstrutoresTupla: { [tamanho: number]: any } = {
+    2: Dupla,
+    3: Trio,
+    4: Quarteto,
+    5: Quinteto,
+    6: Sexteto,
+    7: Septeto,
+    8: Octeto,
+    9: Noneto,
+    10: Deceto
+};
 
 export default {
     adicionar: {
@@ -447,14 +472,32 @@ export default {
             nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
-            const elementos = vetor.map(item => {
-                return new Literal(
-                    interpretador.hashArquivoDeclaracaoAtual,
-                    interpretador.linhaDeclaracaoAtual,
-                    item,
-                    inferirTipoVariavel(item) as any
+            if (vetor.length < 2) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        {
+                            hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                            linha: interpretador.linhaDeclaracaoAtual,
+                        } as SimboloInterface,
+                        'Para converter um vetor em tupla, ele precisa ter no mínimo 2 elementos.'
+                    )
                 );
-            });
+            }
+
+            const criarLiteral = (item: any) => new Literal(
+                interpretador.hashArquivoDeclaracaoAtual,
+                interpretador.linhaDeclaracaoAtual,
+                item,
+                inferirTipoVariavel(item) as any
+            );
+
+            if (mapaConstrutoresTupla.hasOwnProperty(vetor.length)) {
+                const Construtor = mapaConstrutoresTupla[vetor.length];
+                const args = vetor.map(criarLiteral);
+                return Promise.resolve(new Construtor(...args));
+            }
+
+            const elementos = vetor.map(criarLiteral);
 
             return Promise.resolve(new TuplaN(
                 interpretador.hashArquivoDeclaracaoAtual,
@@ -465,7 +508,7 @@ export default {
         assinaturaFormato: 'vetor.paraTupla()',
         documentacao:
             '# `vetor.paraTupla()` \n \n' +
-            'Converte o vetor atual em uma tupla imutável.',
+            'Converte o vetor atual em uma tupla imutável. Requer no mínimo 2 elementos.',
         exemploCodigo: 'vetor.paraTupla()',
     },
     remover: {

--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -1,6 +1,8 @@
 import { DeleguaFuncao } from '../interpretador/estruturas';
 import { InterpretadorInterface, PrimitivaInterface, SimboloInterface } from '../interfaces';
 import { InformacaoElementoSintatico } from '../informacao-elemento-sintatico';
+import { inferirTipoVariavel } from '../inferenciador';
+import { Literal, TuplaN } from '../construtos';
 
 export default {
     adicionar: {
@@ -436,6 +438,35 @@ export default {
             'escreva(v.ordenar()) // ["a", "aaa", "aba", "abb", "abc"]\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.ordenar()',
+    },
+    paraTupla: {
+        tipoRetorno: 'tupla',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            nomePrimitiva: string,
+            vetor: Array<any>
+        ): Promise<any> => {
+            const elementos = vetor.map(item => {
+                return new Literal(
+                    interpretador.hashArquivoDeclaracaoAtual,
+                    interpretador.linhaDeclaracaoAtual,
+                    item,
+                    inferirTipoVariavel(item) as any
+                );
+            });
+
+            return Promise.resolve(new TuplaN(
+                interpretador.hashArquivoDeclaracaoAtual,
+                interpretador.linhaDeclaracaoAtual,
+                elementos
+            ));
+        },
+        assinaturaFormato: 'vetor.paraTupla()',
+        documentacao:
+            '# `vetor.paraTupla()` \n \n' +
+            'Converte o vetor atual em uma tupla imutável.',
+        exemploCodigo: 'vetor.paraTupla()',
     },
     remover: {
         tipoRetorno: 'qualquer[]',

--- a/fontes/interpretador/dialetos/pitugues/comum.ts
+++ b/fontes/interpretador/dialetos/pitugues/comum.ts
@@ -9,6 +9,7 @@ import primitivasDicionario from "../../../bibliotecas/dialetos/pitugues/primiti
 import primitivasNumero from "../../../bibliotecas/dialetos/pitugues/primitivas-numero";
 import primitivasTexto from "../../../bibliotecas/dialetos/pitugues/primitivas-texto";
 import primitivasVetor from "../../../bibliotecas/dialetos/pitugues/primitivas-vetor";
+import primitivasTupla from "../../../bibliotecas/dialetos/pitugues/primitivas-tupla";
 
 import tipoDeDadosPrimitivos from '../../../tipos-de-dados/primitivos';
 import tipoDeDadosPitugues from '../../../tipos-de-dados/dialetos/pitugues';
@@ -33,6 +34,19 @@ export async function visitarExpressaoAcessoMetodo(
 
     if (objeto.constructor === ObjetoDeleguaClasse) {
         return (objeto as ObjetoDeleguaClasse).obterMetodo(expressao.nomeMetodo) || null;
+    }
+
+    if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+        const metodoDePrimitivaTupla = primitivasTupla[expressao.nomeMetodo];
+        if (metodoDePrimitivaTupla) {
+            return new MetodoPrimitiva(
+                nomeObjeto,
+                objeto,
+                metodoDePrimitivaTupla.implementacao,
+                expressao.nomeMetodo,
+                'tupla'
+            );
+        }
     }
 
     // Objeto simples do JavaScript, ou dicionário de Delégua.
@@ -144,6 +158,19 @@ export async function visitarExpressaoAcessoMetodoOuPropriedade(
 
     if (objeto.constructor === ObjetoDeleguaClasse) {
         return (objeto as ObjetoDeleguaClasse).obter(expressao.simbolo);
+    }
+
+    if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+        const metodoDePrimitivaTupla = primitivasTupla[expressao.simbolo.lexema];
+        if (metodoDePrimitivaTupla) {
+            return new MetodoPrimitiva(
+                nomeObjeto,
+                objeto,
+                metodoDePrimitivaTupla.implementacao,
+                expressao.simbolo.lexema,
+                'tupla'
+            );
+        }
     }
 
     // Objeto simples do JavaScript, ou dicionário de Delégua.
@@ -284,6 +311,19 @@ export async function visitarExpressaoAcessoPropriedade(
         (objeto.constructor === ObjetoDeleguaClasse)
     ) {
         return (objeto as ObjetoDeleguaClasse).obterMetodo(expressao.nomePropriedade) || null;
+    }
+
+    if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+        const metodoPrimitivaTupla = primitivasTupla[expressao.nomePropriedade];
+        if (metodoPrimitivaTupla) {
+            return new MetodoPrimitiva(
+                nomeObjeto,
+                objeto,
+                metodoPrimitivaTupla.implementacao,
+                expressao.nomePropriedade,
+                'tupla'
+            );
+        }
     }
 
     // Objeto simples do JavaScript, ou dicionário de Delégua.

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -319,7 +319,18 @@ export class InterpretadorBase implements InterpretadorInterface {
     }
 
     async visitarExpressaoTuplaN(expressao: TuplaN): Promise<any> {
-        throw new Error('Método não implementado.');
+        const elementos = [];
+
+        for (let i = 0; i < expressao.elementos.length; i++) {
+            const res = await this.avaliar(expressao.elementos[i]);
+            elementos.push(this.resolverValor(res));
+        }
+
+        const elementosComoConstrutos = elementos.map(valor =>
+            new Literal(expressao.hashArquivo, expressao.linha, valor)
+        );
+
+        return new TuplaN(expressao.hashArquivo, expressao.linha, elementosComoConstrutos);
     }
 
     async visitarExpressaoAtribuicaoPorIndicesMatriz(expressao: any): Promise<any> {
@@ -795,7 +806,7 @@ export class InterpretadorBase implements InterpretadorInterface {
                     if (!isNaN(textoParaNumero)) {
                         return textoParaNumero * valorQuantidade;
                     }
-                    
+
                     if (!Number.isInteger(valorQuantidade)) {
                         throw new ErroEmTempoDeExecucao(
                             expressao.operador,
@@ -1674,6 +1685,39 @@ export class InterpretadorBase implements InterpretadorInterface {
             }
 
             return objeto[valorIndice];
+        }
+
+        if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+            if (!Number.isInteger(valorIndice)) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        expressao.simboloFechamento,
+                        'Somente inteiros podem ser usados para indexar uma tupla.',
+                        expressao.linha
+                    )
+                );
+            }
+
+            if (valorIndice < 0 && objeto.elementos.length !== 0) {
+                valorIndice += objeto.elementos.length;
+            }
+
+            if (valorIndice >= objeto.elementos.length || valorIndice < 0) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        expressao.simboloFechamento,
+                        'Índice da tupla fora de intervalo.',
+                        expressao.linha
+                    )
+                );
+            }
+
+            const elemento = objeto.elementos[valorIndice];
+            if (elemento && elemento.constructor && elemento.constructor.name === 'Literal') {
+                return elemento.valor;
+            }
+
+            return elemento;
         }
 
         if (objeto instanceof Vetor) {

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -82,6 +82,7 @@ import primitivasDicionario from '../bibliotecas/primitivas-dicionario';
 import primitivasNumero from '../bibliotecas/primitivas-numero';
 import primitivasTexto from '../bibliotecas/primitivas-texto';
 import primitivasVetor from '../bibliotecas/primitivas-vetor';
+import primitivasTupla from '../bibliotecas/dialetos/pitugues/primitivas-tupla';
 
 import tipoDeDadosPrimitivos from '../tipos-de-dados/primitivos';
 import tipoDeDadosDelegua from '../tipos-de-dados/delegua';
@@ -628,6 +629,39 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             return objeto[valorIndice];
         }
 
+        if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+            if (!Number.isInteger(valorIndice)) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        expressao.simboloFechamento,
+                        'Somente inteiros podem ser usados para indexar uma tupla.',
+                        expressao.linha
+                    )
+                );
+            }
+
+            if (valorIndice < 0 && objeto.elementos.length !== 0) {
+                valorIndice += objeto.elementos.length;
+            }
+
+            if (valorIndice >= objeto.elementos.length || valorIndice < 0) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        expressao.simboloFechamento,
+                        'Índice da tupla fora de intervalo.',
+                        expressao.linha
+                    )
+                );
+            }
+
+            const elemento = objeto.elementos[valorIndice];
+            if (elemento && elemento.constructor && elemento.constructor.name === 'Literal') {
+                return elemento.valor;
+            }
+
+            return elemento;
+        }
+
         if (objeto instanceof Vetor) {
             return objeto.valores[valorIndice];
         }
@@ -700,6 +734,19 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
         if (objeto.constructor && objeto.constructor === ObjetoDeleguaClasse) {
             return (objeto as ObjetoDeleguaClasse).obterMetodo(expressao.nomeMetodo) || null;
+        }
+
+        if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+            const metodoDePrimitivaTupla = primitivasTupla[expressao.nomeMetodo];
+            if (metodoDePrimitivaTupla) {
+                return new MetodoPrimitiva(
+                    nomeObjeto,
+                    objeto,
+                    metodoDePrimitivaTupla.implementacao,
+                    expressao.nomeMetodo,
+                    'tupla'
+                );
+            }
         }
 
         // Objeto simples do JavaScript, ou dicionário de Delégua.
@@ -810,6 +857,19 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
         if (objeto.constructor === ObjetoDeleguaClasse) {
             return (objeto as ObjetoDeleguaClasse).obter(expressao.simbolo);
+        }
+
+        if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+            const metodoDePrimitivaTupla = primitivasTupla[expressao.simbolo.lexema];
+            if (metodoDePrimitivaTupla) {
+                return new MetodoPrimitiva(
+                    nomeObjeto,
+                    objeto,
+                    metodoDePrimitivaTupla.implementacao,
+                    expressao.simbolo.lexema,
+                    'tupla'
+                );
+            }
         }
 
         // Objeto simples do JavaScript, ou dicionário de Delégua.
@@ -944,6 +1004,19 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         // então testamos também o nome do construtor.
         if (objeto.constructor === ObjetoDeleguaClasse) {
             return (objeto as ObjetoDeleguaClasse).obterMetodo(expressao.nomePropriedade) || null;
+        }
+
+        if (objeto instanceof TuplaN || objeto.constructor.name === 'TuplaN') {
+            const metodoPrimitivaTupla = primitivasTupla[expressao.nomePropriedade];
+            if (metodoPrimitivaTupla) {
+                return new MetodoPrimitiva(
+                    nomeObjeto,
+                    objeto,
+                    metodoPrimitivaTupla.implementacao,
+                    expressao.nomePropriedade,
+                    'tupla'
+                );
+            }
         }
 
         // Objeto simples do JavaScript, ou dicionário de Delégua.

--- a/testes/bibliotecas/biblioteca-global.test.ts
+++ b/testes/bibliotecas/biblioteca-global.test.ts
@@ -205,7 +205,7 @@ describe('Biblioteca Global', () => {
             const codigo = [
                 "var original = tupla([1, 2])",
                 "var copia = clonar(original)",
-                "escreva(copia[0])"
+                "escreva(copia.primeiro)"
             ];
             let _saida = "";
             interpretador.funcaoDeRetorno = (saida: string) => {
@@ -650,26 +650,21 @@ describe('Biblioteca Global', () => {
             const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
             expect(retornoInterpretador.erros).toHaveLength(0);
-            expect(_saidas).toBe('(1, 2, 3)');
+            expect(_saidas).toBe('[(1, 2, 3)]');
         });
-    });
 
-    describe('vetor()', () => {
-        it('Trivial', async () => {
-            let _saidas = "";
-            interpretador.funcaoDeRetorno = (saida: string) => {
-                _saidas += saida;
-            }
-
-            const retornoLexador = lexador.mapear([
-                'escreva(vetor((1, 2, 3)))'
-            ], -1);
+        it('Falha - Vetor com mais de 10 elementos', async () => {
+            const retornoLexador = lexador.mapear(["escreva(tupla([1,2,3,4,5,6,7,8,9,10,11]))"], -1);
             const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
-            const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+            const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
-            expect(retornoInterpretador.erros).toHaveLength(0);
-            expect(_saidas).toEqual("[1, 2, 3]");
+            expect(retornoInterpretador).toBeTruthy
+            expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+            const erro = retornoInterpretador.erros[0];
+            expect(erro.erroInterno).toBeDefined();
+            expect(erro.erroInterno.mensagem).toBeDefined();
+            expect(erro.erroInterno.mensagem).toBe('Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.');
         });
     });
 });

--- a/testes/bibliotecas/biblioteca-global.test.ts
+++ b/testes/bibliotecas/biblioteca-global.test.ts
@@ -140,7 +140,7 @@ describe('Biblioteca Global', () => {
                 "copia['a'] = 99",
                 "escreva(valorOriginal)"
             ];
-            
+
             let _saida = "";
             interpretador.funcaoDeRetorno = (saida: string) => {
                 _saida += saida;
@@ -205,7 +205,7 @@ describe('Biblioteca Global', () => {
             const codigo = [
                 "var original = tupla([1, 2])",
                 "var copia = clonar(original)",
-                "escreva(copia.primeiro)"
+                "escreva(copia[0])"
             ];
             let _saida = "";
             interpretador.funcaoDeRetorno = (saida: string) => {
@@ -650,21 +650,26 @@ describe('Biblioteca Global', () => {
             const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
             expect(retornoInterpretador.erros).toHaveLength(0);
-            expect(_saidas).toBe('[(1, 2, 3)]');
+            expect(_saidas).toBe('(1, 2, 3)');
         });
+    });
 
-        it('Falha - Vetor com mais de 10 elementos', async () => {
-            const retornoLexador = lexador.mapear(["escreva(tupla([1,2,3,4,5,6,7,8,9,10,11]))"], -1);
+    describe('vetor()', () => {
+        it('Trivial', async () => {
+            let _saidas = "";
+            interpretador.funcaoDeRetorno = (saida: string) => {
+                _saidas += saida;
+            }
+
+            const retornoLexador = lexador.mapear([
+                'escreva(vetor((1, 2, 3)))'
+            ], -1);
             const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
 
-            const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+            const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
 
-            expect(retornoInterpretador).toBeTruthy
-            expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-            const erro = retornoInterpretador.erros[0];
-            expect(erro.erroInterno).toBeDefined();
-            expect(erro.erroInterno.mensagem).toBeDefined();
-            expect(erro.erroInterno.mensagem).toBe('Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.');
+            expect(retornoInterpretador.erros).toHaveLength(0);
+            expect(_saidas).toEqual("[1, 2, 3]");
         });
     });
 });

--- a/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
@@ -3,6 +3,7 @@ import {
     todos_em_condicao,
     primeiro_em_condicao,
     tupla,
+    vetor,
     tamanho,
     mapear,
     ordenar,
@@ -13,6 +14,7 @@ import { DeleguaFuncao } from '../../../../fontes/interpretador/estruturas/deleg
 import { DescritorTipoClasse } from '../../../../fontes/interpretador/estruturas/descritor-tipo-classe';
 import { ObjetoDeleguaClasse } from '../../../../fontes/interpretador/estruturas/objeto-delegua-classe';
 import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
+import { Literal, TuplaN } from '../../../../fontes/construtos';
 
 describe('biblioteca-global (pituguês)', () => {
     describe('reduzir', () => {
@@ -243,35 +245,78 @@ describe('biblioteca-global (pituguês)', () => {
             });
         });
 
-        it('retorna Dupla para vetor de tamanho 2', async () => {
+        it('Transforma vetor em tupla', async () => {
             const interpretador = criarInterpretadorMock();
-            const resultado = await tupla(interpretador, [1, 2]);
-            expect(resultado.constructor.name).toBe('Dupla');
+            const resultado = await tupla(interpretador, [1, 2, 3, 4, 5]);
+            expect(resultado.constructor.name).toBe('TuplaN')
+            expect(resultado.paraTextoSaida()).toBe('(1, 2, 3, 4, 5)')
         });
 
-        it('retorna Trio para vetor de tamanho 3', async () => {
+        it('Transforma vetor com um único elemento em tupla', async () => {
             const interpretador = criarInterpretadorMock();
-            const resultado = await tupla(interpretador, [1, 2, 3]);
-            expect(resultado.constructor.name).toBe('Trio');
+            const resultado = await tupla(interpretador, [1]);
+            expect(resultado.constructor.name).toBe('TuplaN');
+            expect(resultado.paraTextoSaida()).toBe('(1)')
         });
 
-            it('retorna Quarteto..Deceto para vetores maiores (4..10)', async () => {
-                const interpretador = criarInterpretadorMock();
+        it('cria tupla com tipos misturados', async () => {
+            const interpretador = criarInterpretadorMock();
+            const resultado = await tupla(interpretador, [1, 'texto', true, null]);
+            expect(resultado.constructor.name).toBe('TuplaN');
+            expect(resultado.paraTextoSaida()).toBe('(1, "texto", true, null)');
+        });
+    });
 
-                const nomes = ['Quarteto','Quinteto','Sexteto','Septeto','Octeto','Noneto','Deceto'];
-                for (let tamanho = 4; tamanho <= 10; ++tamanho) {
-                    const vetor = Array.from({ length: tamanho }, (_, i) => i + 1);
-                    const resultado = await tupla(interpretador, vetor);
-                    expect(resultado.constructor.name).toBe(nomes[tamanho - 4]);
-                }
+    describe('vetor', () => {
+        it('Rejeita quando argumento não é uma tupla', async () => {
+            const interpretador = criarInterpretadorMock();
+            await expect(vetor(interpretador, 1 as any)).rejects.toMatchObject({
+                mensagem: 'Argumento de função nativa `vetor` não parece ser uma tupla.'
             });
+        });
 
-            it('rejeita quando vetor tem tamanho 1 (mensagem apropriada)', async () => {
-                const interpretador = criarInterpretadorMock();
-                await expect(tupla(interpretador, [1])).rejects.toMatchObject({
-                    mensagem: 'Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.',
-                });
-            });
+        it('Transforma tupla em vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [
+                new Literal(0, 1, 1, 'número'),
+                new Literal(0, 1, 2, 'número'),
+                new Literal(0, 1, 3, 'número'),
+                new Literal(0, 1, 4, 'número'),
+                new Literal(0, 1, 5, 'número'),
+            ];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+            const resultado = await vetor(interpretador, entradaTupla);
+
+            expect(resultado.constructor.name).toBe('Array')
+            expect(resultado).toEqual([1, 2, 3, 4, 5])
+        });
+
+        it('Transforma tupla com um único elemento em vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [
+                new Literal(0, 1, 1, 'número'),
+            ];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+            const resultado = await vetor(interpretador, entradaTupla);
+
+            expect(resultado.constructor.name).toBe('Array');
+            expect(resultado).toEqual([1]);
+        });
+
+        it('Cria vetor com tipos misturados', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [
+                new Literal(0, 1, 1, 'número'),
+                new Literal(0, 1, "texto", 'texto'),
+                new Literal(0, 1, true, 'qualquer'),
+                new Literal(0, 1, null, 'nulo'),
+            ];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+            const resultado = await vetor(interpretador, entradaTupla);
+
+            expect(resultado.constructor.name).toBe('Array');
+            expect(resultado).toEqual([1, "texto", true, null]);
+        });
     });
 
     describe('tamanho', () => {
@@ -440,43 +485,6 @@ describe('biblioteca-global (pituguês)', () => {
             const interpretador = criarInterpretadorMock();
             await expect(tamanho(interpretador, 123)).rejects.toMatchObject({
                 mensagem: 'Função global tamanho() não funciona com números.',
-            });
-        });
-    });
-
-    describe('tupla', () => {
-        it('cria tupla com valores fornecidos', async () => {
-            const interpretador = criarInterpretadorMock();
-            const resultado = await tupla(interpretador, [1, 2, 3]);
-            expect(resultado).toMatchObject({
-                primeiro: 1,
-                segundo: 2,
-                terceiro: 3
-            });
-        });
-
-        it('rejeita tupla vazia', async () => {
-            const interpretador = criarInterpretadorMock();
-            await expect(tupla(interpretador, [])).rejects.toMatchObject({
-                mensagem: 'Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.',
-            });
-        });
-
-        it('rejeita tupla com um único elemento', async () => {
-            const interpretador = criarInterpretadorMock();
-            await expect(tupla(interpretador, ['único'])).rejects.toMatchObject({
-                mensagem: 'Para ser transformado em uma tupla, vetor precisa ter de 2 a 10 elementos.',
-            });
-        });
-
-        it('cria tupla com tipos misturados', async () => {
-            const interpretador = criarInterpretadorMock();
-            const resultado = await tupla(interpretador, [1, 'texto', true, null]);
-            expect(resultado).toMatchObject({
-                primeiro: 1,
-                segundo: 'texto',
-                terceiro: true,
-                quarto: null
             });
         });
     });

--- a/testes/bibliotecas/dialetos/pitugues/primitiva-tupla.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitiva-tupla.test.ts
@@ -1,0 +1,60 @@
+import primitivaTupla from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-tupla';
+import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
+import { Literal, TuplaN } from '../../../../fontes/construtos';
+import { DeleguaFuncaoMock } from '../../../_mocks/delegua-funcao.mock';
+
+describe('primitiva-tupla', () => {
+    describe('paraVetor', () => {
+        it('Transforma tupla para vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [
+                new Literal(0, 1, 1, 'número'),
+                new Literal(0, 1, 2, 'número'),
+                new Literal(0, 1, 3, 'número'),
+                new Literal(0, 1, 4, 'número'),
+                new Literal(0, 1, 5, 'número'),
+            ];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+
+            const resultado = await primitivaTupla.paraVetor.implementacao(
+                interpretador,
+                'paraVetor',
+                entradaTupla
+            );
+
+            expect(resultado).toEqual([1, 2, 3, 4, 5]);
+        });
+
+        it('Transforma tupla vazia para vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+
+            const resultado = await primitivaTupla.paraVetor.implementacao(
+                interpretador,
+                'paraVetor',
+                entradaTupla
+            );
+
+            expect(resultado).toEqual([]);
+        });
+
+        it('Transforma tupla com valores de diversos tipos para vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const elementosTupla = [
+                new Literal(0, 1, 1, 'número'),
+                new Literal(0, 1, true, 'qualquer'),
+                new Literal(0, 1, '3', 'texto'),
+            ];
+            const entradaTupla = new TuplaN(0, 1, elementosTupla);
+
+            const resultado = await primitivaTupla.paraVetor.implementacao(
+                interpretador,
+                'paraVetor',
+                entradaTupla
+            );
+
+            expect(resultado).toEqual([1, true, "3"]);
+        });
+    });
+});

--- a/testes/bibliotecas/dialetos/pitugues/primitiva-vetor.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitiva-vetor.test.ts
@@ -183,4 +183,45 @@ describe('primitiva-vetor', () => {
             );
         });
     });
+
+    describe('paraTupla', () => {
+        it('Transforma vetor para tupla', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, 2, 3, 4, 5];
+
+            const resultado = await primitivaVetor.paraTupla.implementacao(
+                interpretador,
+                'paraTupla',
+                vetor
+            );
+
+            expect(resultado.paraTextoSaida()).toBe('(1, 2, 3, 4, 5)');
+        });
+
+        it('Transforma vetor vazio para tupla', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [];
+
+            const resultado = await primitivaVetor.paraTupla.implementacao(
+                interpretador,
+                'paraTupla',
+                vetor
+            );
+
+            expect(resultado.paraTextoSaida()).toBe('()');
+        });
+
+        it('Transforma vetor com valores de diversos tipos para tupla', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, true, '3'];
+
+            const resultado = await primitivaVetor.paraTupla.implementacao(
+                interpretador,
+                'paraTupla',
+                vetor
+            );
+
+            expect(resultado.paraTextoSaida()).toBe('(1, true, "3")');
+        });
+    });
 });

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -620,6 +620,48 @@ describe('Interpretador (Pituguês)', () => {
                 });
             });
 
+            describe('tupla() e vetor()', () => {
+                it('Transformando tupla para vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        tupla = (1, 2, 3)
+                        vetor = vetor(tupla)
+                        escreva(vetor);
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toEqual([1, 2, 3]);
+                });
+
+                it('Transformando vetor para tupla', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        vetor = [1, 2, 3]
+                        tupla = tupla(vetor)
+                        escreva(tupla);
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('(1, 2, 3)');
+                });
+            });
+
             describe('leia', () => {
                 it('Trivial', async () => {
                     let _saida: string = '';
@@ -1617,6 +1659,102 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('20');
                 });
+
+                describe('paraTupla', () => {
+                    it('paraTupla', async () => {
+                        const codigo = [
+                            'lista = [1, 2, 3]',
+                            'tupla = lista.paraTupla()',
+                            'escreva(tupla)'
+                        ];
+
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('(1, 2, 3)');
+                    });
+
+                    it('paraTupla - vetor vazio', async () => {
+                        const codigo = [
+                            'lista = []',
+                            'tupla = lista.paraTupla()',
+                            'escreva(tupla)'
+                        ];
+
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes,
+                            true
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('()');
+                    });
+                });
+            });
+
+            describe('Uso de primitivas de tupla', () => {
+                describe('paraVetor', () => {
+                    it('paraVetor - uso simples', async () => {
+                        const codigo = [
+                            'tupla = (1, 2, 3)',
+                            'lista = tupla.paraVetor()',
+                            'escreva(lista)'
+                        ];
+
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('[1, 2, 3]');
+                    });
+
+                    it('paraVetor - tupla vazia', async () => {
+                        const codigo = [
+                            'tupla = ()',
+                            'vetor = tupla.paraVetor()',
+                            'escreva(vetor)'
+                        ];
+
+                        const retornoLexador = lexador.mapear(codigo, -1);
+                        const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+                        const retornoInterpretador = await interpretador.interpretar(
+                            retornoAvaliadorSintatico.declaracoes
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                        expect(_saidas[0]).toBe('[]');
+                    });
+                });
             });
 
             describe('Interpolação (f-strings)', () => {
@@ -2366,6 +2504,125 @@ describe('Interpretador (Pituguês)', () => {
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                     });
+                });
+            });
+
+            describe('tupla() e vetor()', () => {
+                it('Erro em transformar vetor para vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        tupla = [1, 2, 3]
+                        vetor = vetor(tupla)
+                        escreva(vetor);
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
+
+                it('Erro em transformar tupla para tupla', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        vetor = (1, 2, 3)
+                        tupla = tupla(vetor)
+                        escreva(tupla);
+                    `], -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
+            });
+
+            describe('Uso de primitivas de vetor e tupla', () => {
+                it('paraTupla - não sendo uma lista', async () => {
+                    const codigo = [
+                        'lista = (1, 2, 3)',
+                        'tupla = lista.paraTupla()'
+                    ];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
+
+                it('paraTupla - tupla vazia', async () => {
+                    const codigo = [
+                        'lista = ()',
+                        'tupla = lista.paraTupla()',
+                        'escreva(tupla)'
+                    ];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
+
+                it('paraVetor - não sendo uma tupla', async () => {
+                    const codigo = [
+                        'tupla = [1, 2, 3]',
+                        'lista = tupla.paraVetor()',
+                        'escreva(lista)'
+                    ];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
+
+                it('paraVetor - vetor vazio', async () => {
+                    const codigo = [
+                        'tupla = []',
+                        'vetor = tupla.paraVetor()',
+                        'escreva(vetor)'
+                    ];
+
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
                 });
             });
         });


### PR DESCRIPTION
### O que foi feito

Este Pull Request implementa as funcionalidades de conversão entre as estruturas de dados Tupla e Vetor, conforme proposto para a linguagem. Foram adicionados os seguintes métodos e funções globais:
- Método `paraTupla()`: Adicionado aos protótipos de Vetores, permitindo a conversão direta (ex: `[1, 2, 3].paraTupla()`).
- Método `paraVetor()`: Adicionado às instâncias de Tuplas, permitindo a conversão para vetores (ex: `(1, 2, 3).paraVetor()`).
- Função Global `tupla()`: Recebe um vetor como argumento e retorna uma Tupla correspondente.
- Função Global `vetor()`: Recebe uma tupla como argumento e retorna um Vetor (array nativo) correspondente.

### Por que foi feito

A implementação visa aproximar a experiência de desenvolvimento em Pituguês à de linguagens como Python, onde a conversão entre listas (mutáveis) e tuplas (imutáveis) é uma operação comum e essencial para a manipulação flexível de coleções de dados.

Closes #884