### PR TITLE
Implementa suporte a caracteres de escape em strings

### DIFF
--- a/fontes/lexador/dialetos/lexador-pitugues.ts
+++ b/fontes/lexador/dialetos/lexador-pitugues.ts
@@ -182,8 +182,45 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
 
     analisarTexto(delimitador = '"', ehFString: boolean = false): void {
         const linhaPrimeiroCaracter: number = this.linha;
+        let valor = '';
 
         while (this.simboloAtual() !== delimitador && !this.eFinalDoCodigo()) {
+            const caractereAtual = this.simboloAtual();
+
+            if (caractereAtual === '\\') {
+                this.avancar();
+                const proximoCaractere = this.simboloAtual();
+
+                switch (proximoCaractere) {
+                    case 'r':
+                        valor += '\r';
+                        break;
+                    case 'b':
+                        valor += '\b';
+                        break;
+                    case 'n':
+                        valor += '\n';
+                        break;
+                    case 't':
+                        valor += '\t';
+                        break;
+                    case "'":
+                        valor += "'";
+                        break;
+                    case '"':
+                        valor += '"';
+                        break;
+                    case '\\':
+                        valor += '\\';
+                        break;
+                    default:
+                        valor += '\\' + proximoCaractere;
+                        break;
+                }
+            } else {
+                valor += caractereAtual;
+            }
+
             this.avancar();
         }
 
@@ -214,7 +251,7 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
             new Simbolo(
                 tipoSimbolo,
                 textoCompleto,
-                textoCompleto,
+                valor,
                 linhaPrimeiroCaracter + 1,
                 this.hashArquivo
             )

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -2308,6 +2308,41 @@ describe('Interpretador (Pituguês)', () => {
                 expect(retornoInterpretador.erros).toHaveLength(0);
                 expect(_saidas[0]).toEqual('20');
             });
+
+            describe('Caracteres de Escape', () => {
+                it('Deve interpretar quebra de linha (\\n) na saída', async () => {
+                    const retornoLexador = lexador.mapear(['escreva("Linha 1\\nLinha 2")'], -1);
+                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('Linha 1\nLinha 2');
+                });
+
+                it('Deve interpretar tabulação (\\t) em variável', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        texto = "Coluna1\\tColuna2"
+                        escreva(texto)
+                    `], -1);
+                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('Coluna1\tColuna2');
+                });
+
+                it('Deve interpretar aspas duplas escapadas (\\") sem quebrar a string', async () => {
+                    const retornoLexador = lexador.mapear(['escreva("Ela disse: \\"Olá!\\"")'], -1);
+                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('Ela disse: "Olá!"');
+                });
+            });
         });
 
         it('termina_com - sufixo encontrado no final', async () => {

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -2312,7 +2312,7 @@ describe('Interpretador (Pituguês)', () => {
             describe('Caracteres de Escape', () => {
                 it('Deve interpretar quebra de linha (\\n) na saída', async () => {
                     const retornoLexador = lexador.mapear(['escreva("Linha 1\\nLinha 2")'], -1);
-                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
 
@@ -2325,7 +2325,7 @@ describe('Interpretador (Pituguês)', () => {
                         texto = "Coluna1\\tColuna2"
                         escreva(texto)
                     `], -1);
-                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
 
@@ -2335,7 +2335,7 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Deve interpretar aspas duplas escapadas (\\") sem quebrar a string', async () => {
                     const retornoLexador = lexador.mapear(['escreva("Ela disse: \\"Olá!\\"")'], -1);
-                    const retornoAvaliador = avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliador.declaracoes);
 

--- a/testes/pitugues/lexador.test.ts
+++ b/testes/pitugues/lexador.test.ts
@@ -206,6 +206,49 @@ describe('Lexador (Pituguês)', () => {
                 expect(resultado.simbolos[2].tipo).toBe('MULTIPLICACAO_IGUAL');
                 expect(resultado.simbolos[3].tipo).toBe('DIVISAO_IGUAL');
             });
+
+            it('Deve mapear caractere de escape \\r (quebra de linha)', () => {
+                const codigo = ['t = "linha 1\\rlinha 2"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].tipo).toBe('TEXTO');
+                expect(resultado.simbolos[2].literal).toBe('linha 1\rlinha 2');
+            });
+
+            it('Deve mapear caractere de escape \\b (backspace)', () => {
+                const codigo = ['t = "texto\\b"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].literal).toBe('texto\b');
+            });
+
+            it('Deve mapear aspas duplas escapadas dentro de string com aspas duplas', () => {
+                const codigo = ['t = "Ela disse \\"Oi\\""'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].literal).toBe('Ela disse "Oi"');
+            });
+
+            it('Deve mapear aspas simples escapadas dentro de string com aspas simples', () => {
+                const codigo = ["t = 'D\\'agua'"];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].literal).toBe("D'agua");
+            });
+
+            it('Deve mapear barra invertida literal (\\\\)', () => {
+                const codigo = ['caminho = "C:\\\\Windows"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].literal).toBe('C:\\Windows');
+            });
+
+            it('Deve mapear múltiplos escapes na mesma string', () => {
+                const codigo = ['t = "L1\\nL2\\tTab"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.simbolos[2].literal).toBe('L1\nL2\tTab');
+            });
         });
 
         describe('Cenários de falha', () => {
@@ -261,6 +304,30 @@ describe('Lexador (Pituguês)', () => {
                     expect(resultado.simbolos[0].lexema).toBe('fa');
                     expect(resultado.simbolos[1].tipo).toBe(tiposDeSimbolos.TEXTO);
                 });
+            });
+
+            it('Deve falhar ao terminar o código com uma string aberta', () => {
+                const codigo = ['t = "Texto sem fechar'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.erros.length).toBeGreaterThan(0);
+                expect(resultado.erros[0].mensagem).toBe('Texto não finalizado.');
+            });
+
+            it('Deve falhar se a aspa de fechamento for escapada', () => {
+                const codigo = ['t = "texto\\"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.erros.length).toBeGreaterThan(0);
+                expect(resultado.erros[0].mensagem).toBe('Texto não finalizado.');
+            });
+
+            it('Deve manter a barra se o caractere de escape for desconhecido', () => {
+                const codigo = ['t = "\\z"'];
+                const resultado = lexador.mapear(codigo, -1);
+
+                expect(resultado.erros).toHaveLength(0);
+                expect(resultado.simbolos[2].literal).toBe('\\z');
             });
         });
     });


### PR DESCRIPTION
### O que foi feito

Este PR implementa o processamento de caracteres de escape dentro de strings literais para o dialeto Pituguês. Foi refatorada a lógica de analisarTexto no lexador para reconhecer a barra invertida (`\`) e traduzi-la nos caracteres correspondentes:
- **`\n`:** Nova linha
- **`\t`:** Tabulação
- **`\r`:** Retorna quebra de linha e move o cursor para a linha atual sem descer para a próxima linha
- **`\b`:** Backspace
- **`\\`:** Barra invertida literal
- **`\"`:** Aspas duplas
- **`\'`:** Aspas simples

### Por que foi feito

Atualmente, as strings no dialeto Pituguês eram tratadas apenas como literais puros, o que impedia a formatação de textos (como pular linhas) ou a inclusão de aspas dentro de uma string delimitada pelo mesmo caractere. Essa implementação aproxima o Pituguês de outras linguagens modernas e aumenta a flexibilidade para o desenvolvedor.

Closes #913