### PR TITLE
Vetores como referência ao montão

### DIFF
--- a/fontes/avaliador-sintatico/comum.ts
+++ b/fontes/avaliador-sintatico/comum.ts
@@ -1,9 +1,7 @@
-import { FuncaoConstruto } from '../construtos';
 import { Bloco, Declaracao, Retorna, Se } from '../declaracoes';
 import { InformacaoElementoSintatico } from '../informacao-elemento-sintatico';
 import {
     AvaliadorSintaticoInterface,
-    InterpretadorInterface,
     PrimitivaInterface,
     SimboloInterface,
 } from '../interfaces';

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
@@ -15,7 +15,6 @@ const contem_comum = (nome: string) => {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object,
             chave: any
         ): Promise<boolean> => Promise.resolve(chave in valor),
@@ -39,7 +38,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             return Promise.resolve(Object.keys(valor));
@@ -62,7 +60,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             const pares = Object.entries(valor).map(([chave, valor]) => {
@@ -89,7 +86,6 @@ export default {
         argumentos: [new InformacaoElementoSintatico('chave', 'texto')],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object,
             chave: string
         ): Promise<boolean> => Promise.resolve(delete valor[chave]),
@@ -100,7 +96,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             return Promise.resolve(Object.values(valor));

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
@@ -7,7 +7,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.abs(valor));
@@ -28,7 +27,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.floor(valor));
@@ -49,7 +47,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.ceil(valor));
@@ -78,7 +75,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number,
             opcoes: { [opcao: string]: any }
         ): Promise<string> => {

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
@@ -9,7 +9,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trim()),
         assinaturaFormato: 'texto.aparar()',
@@ -27,7 +26,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trimEnd()),
         assinaturaFormato: 'texto.aparar_fim()',
@@ -45,7 +43,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trimStart()),
         assinaturaFormato: 'texto.aparar_inicio()',
@@ -71,7 +68,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             ...texto: string[]
         ): Promise<string> => Promise.resolve(''.concat(...texto)),
         assinaturaFormato: 'texto.concatenar(...outroTexto: texto)',
@@ -105,7 +101,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             divisor: string,
             limite?: number
@@ -146,7 +141,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             subtexto: string,
             indiceInicio?: number
@@ -188,7 +182,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             subtexto: string,
             indiceInicio?: number
@@ -244,7 +237,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             inicio: number,
             fim: number
@@ -275,7 +267,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             elemento: string
         ): Promise<boolean> => Promise.resolve(texto.includes(elemento)),
@@ -295,7 +286,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> =>
             Promise.resolve(
@@ -316,7 +306,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.toUpperCase()),
         assinaturaFormato: 'texto.maiusculo()',
@@ -334,7 +323,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.toLowerCase()),
         assinaturaFormato: 'texto.minusculo()',
@@ -399,7 +387,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             elemento: string,
             substituto: string
@@ -434,7 +421,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             inicio: number,
             fim: number
@@ -454,7 +440,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<number> => Promise.resolve(texto.length),
         assinaturaFormato: 'texto.tamanho()',
@@ -480,7 +465,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             sufixo: string
         ): Promise<boolean> => Promise.resolve(texto.endsWith(sufixo)),
@@ -501,7 +485,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<boolean> => Promise.resolve(texto === texto.toUpperCase()),
         assinaturaFormato: 'texto.tudo_maiusculo()',
@@ -521,7 +504,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<boolean> => Promise.resolve(texto === texto.toLowerCase()),
         assinaturaFormato: 'texto.tudo_minusculo()',

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-tupla.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-tupla.ts
@@ -8,7 +8,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             tupla: TuplaN
         ): Promise<any> => {
             const objetoTupla = interpretador.resolverValor(tupla);
@@ -17,7 +16,7 @@ export default {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         null,
-                        `A função "${nomePrimitiva}" só pode ser chamada em tuplas.`,
+                        `A função "paraVetor" só pode ser chamada em tuplas.`,
                         interpretador.linhaDeclaracaoAtual
                     )
                 );

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -18,19 +18,10 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
             vetor.push(elemento);
-            // TODO: Será que apenas isso é suficiente aqui?
-            if (nomePrimitiva !== '') {
-                interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                    { lexema: nomePrimitiva } as SimboloInterface,
-                    vetor
-                );
-            }
-
             return Promise.resolve(vetor);
         },
         assinaturaFormato: 'vetor.adicionar(...elemento: qualquer)',
@@ -58,7 +49,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             outroVetor: Array<any>
         ): Promise<any> => {
@@ -79,7 +69,6 @@ export default {
         argumentos: [new InformacaoElementoSintatico('elemento', 'qualquer', true, [], '')],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
@@ -108,7 +97,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             posicaoInicial: number,
             quantidadeExclusao?: number,
@@ -121,23 +109,9 @@ export default {
                     ? vetor.splice(posicaoInicial, quantidadeExclusao)
                     : vetor.splice(posicaoInicial, quantidadeExclusao, ...itens);
 
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        { lexema: nomePrimitiva } as SimboloInterface,
-                        vetor
-                    );
-                }
-
                 return Promise.resolve(elementos);
             } else {
                 elementos = !itens.length ? vetor.splice(posicaoInicial) : vetor.splice(posicaoInicial, ...itens);
-
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        { lexema: nomePrimitiva } as SimboloInterface,
-                        elementos
-                    );
-                }
 
                 return Promise.resolve(vetor);
             }
@@ -185,7 +159,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             inicio: number,
             fim: number
@@ -218,7 +191,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcao: DeleguaFuncao
         ): Promise<any> => {
@@ -263,7 +235,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => Promise.resolve(vetor.includes(elemento)),
@@ -283,7 +254,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => Promise.resolve(vetor.reverse()),
         assinaturaFormato: 'vetor.inverter()',
@@ -309,7 +279,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             separador: string
         ): Promise<any> => Promise.resolve(vetor.join(separador)),
@@ -337,7 +306,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcao: DeleguaFuncao
         ): Promise<any> => {
@@ -378,7 +346,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcaoOrdenacao: DeleguaFuncao
         ): Promise<any> => {
@@ -400,15 +367,6 @@ export default {
                     }
                 }
 
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        {
-                            lexema: nomePrimitiva,
-                        } as SimboloInterface,
-                        vetor
-                    );
-                }
-
                 return vetor;
             }
 
@@ -416,15 +374,6 @@ export default {
                 vetor.sort();
             } else {
                 vetor.sort((a, b) => a - b);
-            }
-
-            if (nomePrimitiva !== '') {
-                interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                    {
-                        lexema: nomePrimitiva,
-                    } as SimboloInterface,
-                    vetor
-                );
             }
 
             return vetor;
@@ -448,7 +397,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             const elementos = vetor.map(item => {
@@ -485,7 +433,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
@@ -509,7 +456,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             let elemento = vetor.shift();
@@ -532,7 +478,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             let elemento = vetor.pop();
@@ -555,7 +500,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<number | { valor: number }>
         ): Promise<number | { valor: number }> => {
             return Promise.resolve(
@@ -580,7 +524,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => Promise.resolve(vetor.length),
         assinaturaFormato: 'vetor.tamanho()',

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -1,5 +1,5 @@
 import { DeleguaFuncao } from '../../../interpretador/estruturas';
-import { InterpretadorInterface, PrimitivaInterface, SimboloInterface } from '../../../interfaces';
+import { InterpretadorInterface, PrimitivaInterface } from '../../../interfaces';
 import { InformacaoElementoSintatico } from '../../../informacao-elemento-sintatico';
 import { inferirTipoVariavel } from '../../../inferenciador';
 import { Literal, TuplaN } from '../../../construtos';
@@ -316,7 +316,7 @@ export default {
             const retorno = [];
             for (let elemento of vetor) {
                 let resultado = await funcao.chamar(interpretador, [elemento]);
-                retorno.push(resultado);
+                retorno.push(interpretador.resolverValor(resultado));
             }
 
             return retorno;

--- a/fontes/bibliotecas/primitivas-dicionario.ts
+++ b/fontes/bibliotecas/primitivas-dicionario.ts
@@ -16,7 +16,6 @@ const contemComum = (nome: string) => {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object,
             chave: any
         ): Promise<boolean> => Promise.resolve(chave in valor),
@@ -40,7 +39,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             return Promise.resolve(Object.keys(valor));
@@ -65,7 +63,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             const hashArquivo = interpretador.hashArquivoDeclaracaoAtual;
@@ -98,7 +95,6 @@ export default {
         argumentos: [new InformacaoElementoSintatico('chave', 'texto')],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object,
             chave: string
         ): Promise<boolean> => Promise.resolve(delete valor[chave]),
@@ -110,7 +106,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: object
         ): Promise<any> => {
             return Promise.resolve(Object.values(valor));

--- a/fontes/bibliotecas/primitivas-numero.ts
+++ b/fontes/bibliotecas/primitivas-numero.ts
@@ -7,7 +7,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.abs(valor));
@@ -28,7 +27,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.floor(valor));
@@ -49,7 +47,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number
         ): Promise<number> => {
             return Promise.resolve(Math.ceil(valor));
@@ -78,7 +75,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             valor: number,
             opcoes: { [opcao: string]: any }
         ): Promise<string> => {

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -6,7 +6,6 @@ import { ErroEmTempoDeExecucao } from '../excecoes';
 
 export const implementacaoParticao = (
     interpretador: InterpretadorInterface,
-    nomePrimitiva: string,
     texto: any,
     separador: any,
     ...args: any[]
@@ -14,7 +13,7 @@ export const implementacaoParticao = (
     if (args.length > 0) {
         return Promise.reject(new ErroEmTempoDeExecucao(
             null,
-            `A função "${nomePrimitiva}" aceita apenas um argumento.`,
+            `A função "partição" aceita apenas um argumento.`,
             interpretador.linhaDeclaracaoAtual
         ));
     }
@@ -22,7 +21,7 @@ export const implementacaoParticao = (
     if (typeof texto !== 'string') {
         return Promise.reject(new ErroEmTempoDeExecucao(
             null,
-            `A função "particao" só pode ser chamada em textos.`,
+            `A função "partição" só pode ser chamada em textos.`,
             interpretador.linhaDeclaracaoAtual
         ));
     }
@@ -30,7 +29,7 @@ export const implementacaoParticao = (
     if (separador === undefined) {
         return Promise.reject(new ErroEmTempoDeExecucao(
             null,
-            `A função "particao" requer um argumento separador.`,
+            `A função "partição" requer um argumento separador.`,
             interpretador.linhaDeclaracaoAtual
         ));
     }

--- a/fontes/bibliotecas/primitivas-texto.ts
+++ b/fontes/bibliotecas/primitivas-texto.ts
@@ -22,7 +22,7 @@ export const implementacaoParticao = (
     if (typeof texto !== 'string') {
         return Promise.reject(new ErroEmTempoDeExecucao(
             null,
-            `A função "${nomePrimitiva}" só pode ser chamada em textos.`,
+            `A função "particao" só pode ser chamada em textos.`,
             interpretador.linhaDeclaracaoAtual
         ));
     }
@@ -30,7 +30,7 @@ export const implementacaoParticao = (
     if (separador === undefined) {
         return Promise.reject(new ErroEmTempoDeExecucao(
             null,
-            `A função "${nomePrimitiva}" requer um argumento separador.`,
+            `A função "particao" requer um argumento separador.`,
             interpretador.linhaDeclaracaoAtual
         ));
     }
@@ -78,14 +78,12 @@ export const implementacaoParticao = (
     return Promise.resolve(tupla);
 };
 
-
 export default {
     aparar: {
         tipoRetorno: 'texto',
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trim()),
         assinaturaFormato: 'texto.aparar()',
@@ -103,7 +101,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trimEnd()),
         assinaturaFormato: 'texto.apararFim()',
@@ -121,7 +118,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.trimStart()),
         assinaturaFormato: 'texto.apararInicio()',
@@ -147,9 +143,8 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
-            ...texto: string[]
-        ): Promise<string> => Promise.resolve(''.concat(...texto)),
+            ...textos: string[]
+        ): Promise<string> => Promise.resolve(''.concat(...textos)),
         assinaturaFormato: 'texto.concatenar(...outroTexto: texto)',
         documentacao:
             '# `texto.concatenar(outroTexto)` \n \n' +
@@ -181,7 +176,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             divisor: string,
             limite?: number
@@ -222,7 +216,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             subtexto: string,
             indiceInicio?: number
@@ -264,7 +257,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             inicio: number,
             fim: number
@@ -295,7 +287,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             elemento: string
         ): Promise<boolean> => Promise.resolve(texto.includes(elemento)),
@@ -315,7 +306,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> =>
             Promise.resolve(
@@ -336,7 +326,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.toUpperCase()),
         assinaturaFormato: 'texto.maiusculo()',
@@ -354,7 +343,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<string> => Promise.resolve(texto.toLowerCase()),
         assinaturaFormato: 'texto.minusculo()',
@@ -419,7 +407,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             elemento: string,
             substituto: string
@@ -454,7 +441,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             inicio: number,
             fim: number
@@ -474,7 +460,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<number> => Promise.resolve(texto.length),
         assinaturaFormato: 'texto.tamanho()',
@@ -500,7 +485,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string,
             sufixo: string
         ): Promise<boolean> => Promise.resolve(texto.endsWith(sufixo)),
@@ -521,7 +505,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<boolean> => Promise.resolve(texto === texto.toUpperCase()),
         assinaturaFormato: 'texto.tudoMaiusculo()',
@@ -541,7 +524,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             texto: string
         ): Promise<boolean> => Promise.resolve(texto === texto.toLowerCase()),
         assinaturaFormato: 'texto.tudoMinusculo()',

--- a/fontes/bibliotecas/primitivas-tupla.ts
+++ b/fontes/bibliotecas/primitivas-tupla.ts
@@ -20,7 +20,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             tupla: Tupla | TuplaN
         ): Promise<any> => {
             const objetoTupla = interpretador.resolverValor(tupla);
@@ -29,7 +28,7 @@ export default {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         null,
-                        `A função "${nomePrimitiva}" só pode ser chamada em tuplas.`,
+                        'A função "paraVetor" só pode ser chamada em tuplas.',
                         interpretador.linhaDeclaracaoAtual
                     )
                 );

--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -43,19 +43,10 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
             vetor.push(elemento);
-            // TODO: Será que apenas isso é suficiente aqui?
-            if (nomePrimitiva !== '') {
-                interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                    { lexema: nomePrimitiva } as SimboloInterface,
-                    vetor
-                );
-            }
-
             return Promise.resolve(vetor);
         },
         assinaturaFormato: 'vetor.adicionar(...elemento: qualquer)',
@@ -83,7 +74,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             outroVetor: Array<any>
         ): Promise<any> => {
@@ -104,7 +94,6 @@ export default {
         argumentos: [new InformacaoElementoSintatico('elemento', 'qualquer', true, [], '')],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
@@ -133,7 +122,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             posicaoInicial: number,
             quantidadeExclusao?: number,
@@ -146,27 +134,13 @@ export default {
                     ? vetor.splice(posicaoInicial, quantidadeExclusao)
                     : vetor.splice(posicaoInicial, quantidadeExclusao, ...itens);
 
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        { lexema: nomePrimitiva } as SimboloInterface,
-                        vetor
-                    );
-                }
-
                 return Promise.resolve(elementos);
             } else {
                 elementos = !itens.length
                     ? vetor.splice(posicaoInicial)
                     : vetor.splice(posicaoInicial, ...itens);
 
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        { lexema: nomePrimitiva } as SimboloInterface,
-                        elementos
-                    );
-                }
-
-                return Promise.resolve(vetor);
+                return Promise.resolve(elementos);
             }
         },
         assinaturaFormato:
@@ -213,7 +187,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             inicio: number,
             fim: number
@@ -240,7 +213,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcao: DeleguaFuncao
         ): Promise<any> => {
@@ -285,7 +257,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => Promise.resolve(vetor.includes(elemento)),
@@ -305,7 +276,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => Promise.resolve(vetor.reverse()),
         assinaturaFormato: 'vetor.inverter()',
@@ -331,7 +301,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             separador: string
         ): Promise<any> => Promise.resolve(vetor.join(separador)),
@@ -358,7 +327,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcao: DeleguaFuncao
         ): Promise<any> => {
@@ -399,7 +367,6 @@ export default {
         ],
         implementacao: async (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             funcaoOrdenacao: DeleguaFuncao
         ): Promise<any> => {
@@ -421,15 +388,6 @@ export default {
                     }
                 }
 
-                if (nomePrimitiva !== '') {
-                    interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                        {
-                            lexema: nomePrimitiva,
-                        } as SimboloInterface,
-                        vetor
-                    );
-                }
-
                 return vetor;
             }
 
@@ -437,15 +395,6 @@ export default {
                 vetor.sort();
             } else {
                 vetor.sort((a, b) => a - b);
-            }
-
-            if (nomePrimitiva !== '') {
-                interpretador.pilhaEscoposExecucao.atribuirVariavel(
-                    {
-                        lexema: nomePrimitiva,
-                    } as SimboloInterface,
-                    vetor
-                );
             }
 
             return vetor;
@@ -469,7 +418,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             if (vetor.length < 2) {
@@ -524,7 +472,6 @@ export default {
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>,
             elemento: any
         ): Promise<any> => {
@@ -548,7 +495,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             let elemento = vetor.shift();
@@ -571,7 +517,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => {
             let elemento = vetor.pop();
@@ -594,7 +539,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<number | { valor: number }>
         ): Promise<number | { valor: number }> => {
             return Promise.resolve(
@@ -619,7 +563,6 @@ export default {
         argumentos: [],
         implementacao: (
             interpretador: InterpretadorInterface,
-            nomePrimitiva: string,
             vetor: Array<any>
         ): Promise<any> => Promise.resolve(vetor.length),
         assinaturaFormato: 'vetor.tamanho()',

--- a/fontes/bibliotecas/primitivas-vetor.ts
+++ b/fontes/bibliotecas/primitivas-vetor.ts
@@ -337,7 +337,7 @@ export default {
             const retorno = [];
             for (let elemento of vetor) {
                 let resultado = await funcao.chamar(interpretador, [elemento]);
-                retorno.push(resultado);
+                retorno.push(interpretador.resolverValor(resultado));
             }
 
             return retorno;

--- a/fontes/interpretador/estruturas/metodo-primitiva.ts
+++ b/fontes/interpretador/estruturas/metodo-primitiva.ts
@@ -8,8 +8,8 @@ import { Chamavel } from './chamavel';
  * - `v.inclui(1)` (`v` é um vetor)
  * - `t.minusculo()` (`t` é um texto)
  *
- * A aridade é sempre a quantidade de argumentos do método menos um porque o
- * primeiro parâmetro é sempre a referência para a primitiva.
+ * A aridade é sempre a quantidade de argumentos do método menos dois porque os
+ * dois primeiros parâmetros são sempre o interpretador e a referência para a primitiva.
  */
 export class MetodoPrimitiva extends Chamavel {
     nome: string;
@@ -25,11 +25,11 @@ export class MetodoPrimitiva extends Chamavel {
         this.metodo = metodo;
         this.nomeMetodo = nomeMetodo;
         this.tipo = tipo;
-        this.valorAridade = metodo.length - 1;
+        this.valorAridade = metodo.length - 2;
     }
 
     async chamar(interpretador: InterpretadorInterface, argumentos: any[] = []): Promise<any> {
-        return await this.metodo(interpretador, this.nome, this.primitiva, ...argumentos);
+        return await this.metodo(interpretador, this.primitiva, ...argumentos);
     }
 
     /**

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -250,6 +250,45 @@ export class InterpretadorBase implements InterpretadorInterface {
         return objeto;
     }
 
+    /**
+     * Resolve valores recursivamente, incluindo valores aninhados em arrays e dicionários.
+     * Remove metadados que não devem ser serializados.
+     * @param objeto O objeto a ser resolvido
+     * @returns O valor resolvido sem metadados
+     */
+    protected resolverValorRecursivo(objeto: any): any {
+        // Null, undefined, ou tipos primitivos
+        if (objeto === null || objeto === undefined || typeof objeto !== 'object') {
+            return objeto;
+        }
+
+        // Resolve metadados primeiro (valorRetornado ou valor)
+        if (objeto.hasOwnProperty && objeto.hasOwnProperty('valorRetornado')) {
+            return this.resolverValorRecursivo(objeto.valorRetornado);
+        }
+
+        if (objeto.hasOwnProperty && objeto.hasOwnProperty('valor')) {
+            return this.resolverValorRecursivo(objeto.valor);
+        }
+
+        // Se é array, resolve recursivamente todos os elementos
+        if (Array.isArray(objeto)) {
+            return objeto.map(elemento => this.resolverValorRecursivo(elemento));
+        }
+
+        // Se é objeto plano, resolve recursivamente todas as propriedades
+        if (objeto && objeto.constructor && objeto.constructor === Object) {
+            const objetoResolvido: any = {};
+            for (const chave in objeto) {
+                objetoResolvido[chave] = this.resolverValorRecursivo(objeto[chave]);
+            }
+            return objetoResolvido;
+        }
+
+        // Outros tipos de objetos (Date, classes customizadas, etc.)
+        return objeto;
+    }
+
     visitarExpressaoArgumentoReferenciaFuncao(
         expressao: ArgumentoReferenciaFuncao
     ): Promise<any> | void {
@@ -2023,7 +2062,7 @@ export class InterpretadorBase implements InterpretadorInterface {
 
                 if (typeof promises[0] === 'boolean') {
                     const chaveLogico = promises[0] === true ? 'verdadeiro' : 'falso';
-                    dicionario[chaveLogico] = promises[1];
+                    dicionario[chaveLogico] = this.resolverValor(promises[1]);
                     continue;
                 }
 
@@ -2037,7 +2076,7 @@ export class InterpretadorBase implements InterpretadorInterface {
     async visitarExpressaoVetor(expressao: Vetor): Promise<any> {
         const valores = [];
         for (let i = 0; i < expressao.valores.length; i++) {
-            valores.push(await this.avaliar(expressao.valores[i]));
+            valores.push(this.resolverValor(await this.avaliar(expressao.valores[i])));
         }
 
         return valores.filter((v) => v !== null && v !== undefined);
@@ -2143,7 +2182,8 @@ export class InterpretadorBase implements InterpretadorInterface {
                 if ('tipo' in objeto) {
                     switch (objeto.tipo) {
                         case 'dicionário':
-                            return JSON.stringify(objeto.valor);
+                            const valorResolvido = this.resolverValorRecursivo(objeto.valor);
+                            return JSON.stringify(valorResolvido);
                         default:
                             return objeto.valor;
                     }

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -343,7 +343,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
                 }
 
                 if (acumularRetornos) {
-                    retornos.push(retornoExecucao);
+                    retornos.push(this.resolverValor(retornoExecucao));
                 }
             } catch (erro: any) {
                 this.erros.push({
@@ -391,7 +391,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
                 }
 
                 if (acumularRetornos) {
-                    retornos.push(retornoExecucao);
+                    retornos.push(this.resolverValor(retornoExecucao));
                 }
             } catch (erro: any) {
                 this.erros.push({
@@ -458,7 +458,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             }
 
             if (acumularRetornos) {
-                retornos.push(retornoExecucao);
+                retornos.push(this.resolverValor(retornoExecucao));
             }
 
             if (para.incrementar !== null) {
@@ -573,7 +573,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
                 }
 
                 if (acumularRetornos) {
-                    retornos.push(retornoExecucao);
+                    retornos.push(this.resolverValor(retornoExecucao));
                 }
 
                 paraCada.posicaoAtual++;
@@ -1156,7 +1156,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             objeto[indice] = valor;
             // this.pilhaEscoposExecucao.atribuirVariavel((expressao.objeto as any).simbolo, objeto);
         } else if (
-            objeto.constructor === Object ||
+            (objeto && objeto.constructor === Object) ||
             objeto instanceof ObjetoDeleguaClasse ||
             objeto instanceof DeleguaFuncao ||
             objeto instanceof DescritorTipoClasse ||

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -129,17 +129,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         }
 
         if (Array.isArray(objeto)) {
-            // Caso interpretador precise da referência ao vetor original (por exemplo, visita a `AcessoMetodoOuPropriedade`).
-            if (referencia) {
-                return objeto;
-            }
-
-            const vetorResolvido: any[] = [];
-            for (const elemento of objeto) {
-                vetorResolvido.push(this.resolverValor(elemento));
-            }
-
-            return vetorResolvido;
+            return objeto;
         }
 
         if (objeto instanceof ReferenciaMontao) {
@@ -208,8 +198,20 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         if (Array.isArray(objeto)) {
             let retornoVetor: string = '[';
             for (let elemento of objeto) {
+                // Resolve referências ao montão antes de processar
+                if (elemento instanceof ReferenciaMontao) {
+                    elemento = this.resolverValor(elemento);
+                }
+
                 if (elemento instanceof Tupla) {
                     retornoVetor += elemento.paraTextoSaida() + ', ';
+                    continue;
+                }
+
+                // Se o elemento é um array (incluindo arrays resolvidos de referências),
+                // chama paraTexto recursivamente para processá-lo corretamente
+                if (Array.isArray(elemento)) {
+                    retornoVetor += this.paraTexto(elemento) + ', ';
                     continue;
                 }
 
@@ -794,7 +796,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
         let tipoObjeto = variavelObjeto.tipo;
         if (tipoObjeto === null || tipoObjeto === undefined) {
-            tipoObjeto = inferirTipoVariavel(variavelObjeto as any);
+            tipoObjeto = inferirTipoVariavel(objeto as any);
         }
 
         // Como internamente um dicionário de Delégua é simplesmente um objeto de
@@ -917,7 +919,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
         let tipoObjeto = variavelObjeto.tipo;
         if (tipoObjeto === null || tipoObjeto === undefined) {
-            tipoObjeto = inferirTipoVariavel(variavelObjeto as any);
+            tipoObjeto = inferirTipoVariavel(objeto as any);
         }
 
         // Como internamente um dicionário de Delégua é simplesmente um objeto de
@@ -1064,7 +1066,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
 
         let tipoObjeto = variavelObjeto.tipo;
         if (tipoObjeto === null || tipoObjeto === undefined) {
-            tipoObjeto = inferirTipoVariavel(variavelObjeto as any);
+            tipoObjeto = inferirTipoVariavel(objeto as any);
         }
 
         return Promise.reject(
@@ -1152,7 +1154,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             }
 
             objeto[indice] = valor;
-            this.pilhaEscoposExecucao.atribuirVariavel((expressao.objeto as any).simbolo, objeto);
+            // this.pilhaEscoposExecucao.atribuirVariavel((expressao.objeto as any).simbolo, objeto);
         } else if (
             objeto.constructor === Object ||
             objeto instanceof ObjetoDeleguaClasse ||
@@ -1441,6 +1443,16 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             default:
                 return inferirTipoVariavel(valorTipoDe);
         }
+    }
+
+    override async visitarExpressaoVetor(expressao: Vetor): Promise<any> {
+        // Delega ao interpretador base para processar o vetor
+        const vetor = await super.visitarExpressaoVetor(expressao);
+
+        // Adiciona referência no montão (comportamento específico deste interpretador)                                                                             
+        const enderecoVetorMontao = this.montao.adicionarReferencia(vetor);                                                                                         
+        this.pilhaEscoposExecucao.registrarReferenciaMontao(enderecoVetorMontao);                                                                                   
+        return new ReferenciaMontao(enderecoVetorMontao);
     }
 
     /**

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-texto.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-texto.test.ts
@@ -1,9 +1,9 @@
-import primitivaTexto from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-texto';
+import primitivasTexto from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-texto';
 import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
 import { TuplaN } from '../../../../fontes/construtos/tupla-n';
 import { Literal } from '../../../../fontes/construtos';
 
-describe('primitiva-texto', () => {
+describe('Primitivas de Texto (Pituguês)', () => {
     const interpretador = criarInterpretadorMock();
 
     describe('particao / partição', () => {
@@ -11,9 +11,8 @@ describe('primitiva-texto', () => {
             const texto = "I could eat bananas all day";
             const separador = "bananas";
 
-            const resultado = await primitivaTexto.particao.implementacao(
+            const resultado = await primitivasTexto.particao.implementacao(
                 interpretador,
-                'particao',
                 texto,
                 separador
             );
@@ -30,9 +29,8 @@ describe('primitiva-texto', () => {
             const texto = "fruta";
             const separador = "carro";
 
-            const resultado = await primitivaTexto.particao.implementacao(
+            const resultado = await primitivasTexto.particao.implementacao(
                 interpretador,
-                'particao',
                 texto,
                 separador
             );
@@ -49,9 +47,8 @@ describe('primitiva-texto', () => {
             const texto = "python-pitugues";
             const separador = "-";
 
-            const resultado = await primitivaTexto.partição.implementacao(
+            const resultado = await primitivasTexto.partição.implementacao(
                 interpretador,
-                'partição',
                 texto,
                 separador
             );
@@ -68,9 +65,8 @@ describe('primitiva-texto', () => {
             const texto = ".texto";
             const separador = ".";
 
-            const resultado = await primitivaTexto.particao.implementacao(
+            const resultado = await primitivasTexto.particao.implementacao(
                 interpretador,
-                'particao',
                 texto,
                 separador
             );

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-tupla.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-tupla.test.ts
@@ -1,9 +1,8 @@
-import primitivaTupla from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-tupla';
+import primitivasTupla from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-tupla';
 import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
 import { Literal, TuplaN } from '../../../../fontes/construtos';
-import { DeleguaFuncaoMock } from '../../../_mocks/delegua-funcao.mock';
 
-describe('primitiva-tupla', () => {
+describe('Primitivas de Tupla (Pituguês)', () => {
     describe('paraVetor', () => {
         it('Transforma tupla para vetor', async () => {
             const interpretador = criarInterpretadorMock();
@@ -16,9 +15,8 @@ describe('primitiva-tupla', () => {
             ];
             const entradaTupla = new TuplaN(0, 1, elementosTupla);
 
-            const resultado = await primitivaTupla.paraVetor.implementacao(
+            const resultado = await primitivasTupla.paraVetor.implementacao(
                 interpretador,
-                'paraVetor',
                 entradaTupla
             );
 
@@ -27,12 +25,11 @@ describe('primitiva-tupla', () => {
 
         it('Transforma tupla vazia para vetor', async () => {
             const interpretador = criarInterpretadorMock();
-            const elementosTupla = [];
+            const elementosTupla: any[] = [];
             const entradaTupla = new TuplaN(0, 1, elementosTupla);
 
-            const resultado = await primitivaTupla.paraVetor.implementacao(
+            const resultado = await primitivasTupla.paraVetor.implementacao(
                 interpretador,
-                'paraVetor',
                 entradaTupla
             );
 
@@ -48,9 +45,8 @@ describe('primitiva-tupla', () => {
             ];
             const entradaTupla = new TuplaN(0, 1, elementosTupla);
 
-            const resultado = await primitivaTupla.paraVetor.implementacao(
+            const resultado = await primitivasTupla.paraVetor.implementacao(
                 interpretador,
-                'paraVetor',
                 entradaTupla
             );
 

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-vetor.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-vetor.test.ts
@@ -1,13 +1,13 @@
-import primitivaVetor from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-vetor';
+import primitivasVetor from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-vetor';
 import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
 import { DeleguaFuncaoMock } from '../../../_mocks/delegua-funcao.mock';
 
-describe('primitiva-vetor', () => {
+describe('Primitivas de Vetor (Pituguês)', () => {
     describe('filtrar_por', () => {
         it("deve rejeitar quando não for passada uma função", async () => {
             const interpretador = criarInterpretadorMock();
             await expect(
-                primitivaVetor.filtrar_por.implementacao(interpretador, '', [1, 2, 3], null)
+                primitivasVetor.filtrar_por.implementacao(interpretador, [1, 2, 3], null)
             ).rejects.toBe("É necessário passar uma função para o método 'filtrarPor'");
         });
 
@@ -15,9 +15,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const funcao = new DeleguaFuncaoMock((n: number) => ({ valorRetornado: { valor: n % 2 === 1 } }));
 
-            const resultado = await primitivaVetor.filtrar_por.implementacao(
+            const resultado = await primitivasVetor.filtrar_por.implementacao(
                 interpretador,
-                '',
                 [1, 2, 3, 4, 5],
                 funcao as any
             );
@@ -30,7 +29,7 @@ describe('primitiva-vetor', () => {
         it("deve rejeitar quando não for passada uma função", async () => {
             const interpretador = criarInterpretadorMock();
             await expect(
-                primitivaVetor.mapear.implementacao(interpretador, '', [1, 2, 3], null)
+                primitivasVetor.mapear.implementacao(interpretador, [1, 2, 3], null)
             ).rejects.toBe("É necessário passar uma função para o método 'mapear'");
         });
 
@@ -38,9 +37,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const funcao = new DeleguaFuncaoMock((n: number) => n * 2);
 
-            const resultado = await primitivaVetor.mapear.implementacao(
+            const resultado = await primitivasVetor.mapear.implementacao(
                 interpretador,
-                '',
                 [1, 2, 3],
                 funcao as any
             );
@@ -54,9 +52,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const vetor = [4, 2, 12, 5];
 
-            const resultado = await primitivaVetor.ordenar.implementacao(
+            const resultado = await primitivasVetor.ordenar.implementacao(
                 interpretador,
-                '',
                 vetor.slice(),
                 undefined
             );
@@ -68,9 +65,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const vetor = ['aaa', 'a', 'aba', 'abb', 'abc'];
 
-            const resultado = await primitivaVetor.ordenar.implementacao(
+            const resultado = await primitivasVetor.ordenar.implementacao(
                 interpretador,
-                '',
                 vetor.slice(),
                 undefined
             );
@@ -87,18 +83,13 @@ describe('primitiva-vetor', () => {
             // comparador que retorna a - b (mantém ordem ascendente)
             const funcaoComparadora = new DeleguaFuncaoMock((a: number, b: number) => a - b);
 
-            const resultado = await primitivaVetor.ordenar.implementacao(
+            const resultado = await primitivasVetor.ordenar.implementacao(
                 interpretador,
-                'minhaVar',
                 vetor.slice(),
                 funcaoComparadora as any
             );
 
             expect(resultado).toEqual([1, 2, 3]);
-            expect(interpretador.pilhaEscoposExecucao.atribuirVariavel).toHaveBeenCalledWith(
-                { lexema: 'minhaVar' },
-                expect.any(Array)
-            );
         });
     });
 
@@ -109,19 +100,14 @@ describe('primitiva-vetor', () => {
 
             const vetor = [1, 2, 3];
 
-            const resultado = await primitivaVetor.encaixar.implementacao(
+            const resultado = await primitivasVetor.encaixar.implementacao(
                 interpretador,
-                'v',
                 vetor.slice(),
                 1,
                 1
             );
 
             expect(resultado).toEqual([2]);
-            expect(interpretador.pilhaEscoposExecucao.atribuirVariavel).toHaveBeenCalledWith(
-                { lexema: 'v' },
-                expect.any(Array)
-            );
         });
 
         it('quando só posição inicial é passada, remove do índice e atribui as posições removidas', async () => {
@@ -130,21 +116,14 @@ describe('primitiva-vetor', () => {
 
             const vetor = [1, 2, 3];
 
-            const resultado = await primitivaVetor.encaixar.implementacao(
+            const resultado = await primitivasVetor.encaixar.implementacao(
                 interpretador,
-                'v',
                 vetor,
                 1
             );
 
             // retorna o vetor modificado (após remoção a partir da posição 1)
             expect(resultado).toEqual([1]);
-
-            // a variável 'v' deve ter sido atribuída com os elementos removidos
-            expect(interpretador.pilhaEscoposExecucao.atribuirVariavel).toHaveBeenCalledWith(
-                { lexema: 'v' },
-                [2, 3]
-            );
         });
 
         it('quando chamada sem posição inicial, remove todos os elementos e retorna vetor vazio (sem atribuir variável quando nome é vazio)', async () => {
@@ -153,14 +132,12 @@ describe('primitiva-vetor', () => {
 
             const vetor = [1, 2, 3];
 
-            const resultado = await primitivaVetor.encaixar.implementacao(
+            const resultado = await primitivasVetor.encaixar.implementacao(
                 interpretador,
-                '',
                 vetor
             );
 
             expect(resultado).toEqual([]);
-            expect(interpretador.pilhaEscoposExecucao.atribuirVariavel).not.toHaveBeenCalled();
         });
 
         it('coerção de posição não numérica equivale a 0 (remove tudo)', async () => {
@@ -169,18 +146,13 @@ describe('primitiva-vetor', () => {
 
             const vetor = [1, 2, 3];
 
-            const resultado = await primitivaVetor.encaixar.implementacao(
+            const resultado = await primitivasVetor.encaixar.implementacao(
                 interpretador,
-                'v',
                 vetor,
                 'a' as any
             );
 
             expect(resultado).toEqual([]);
-            expect(interpretador.pilhaEscoposExecucao.atribuirVariavel).toHaveBeenCalledWith(
-                { lexema: 'v' },
-                [1, 2, 3]
-            );
         });
     });
 
@@ -189,9 +161,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const vetor = [1, 2, 3, 4, 5];
 
-            const resultado = await primitivaVetor.paraTupla.implementacao(
+            const resultado = await primitivasVetor.paraTupla.implementacao(
                 interpretador,
-                'paraTupla',
                 vetor
             );
 
@@ -200,11 +171,10 @@ describe('primitiva-vetor', () => {
 
         it('Transforma vetor vazio para tupla', async () => {
             const interpretador = criarInterpretadorMock();
-            const vetor = [];
+            const vetor: any[] = [];
 
-            const resultado = await primitivaVetor.paraTupla.implementacao(
+            const resultado = await primitivasVetor.paraTupla.implementacao(
                 interpretador,
-                'paraTupla',
                 vetor
             );
 
@@ -215,9 +185,8 @@ describe('primitiva-vetor', () => {
             const interpretador = criarInterpretadorMock();
             const vetor = [1, true, '3'];
 
-            const resultado = await primitivaVetor.paraTupla.implementacao(
+            const resultado = await primitivasVetor.paraTupla.implementacao(
                 interpretador,
-                'paraTupla',
                 vetor
             );
 

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -1924,6 +1924,27 @@ describe('Interpretador', () => {
                         expect(retornoInterpretador.erros).toHaveLength(0);
                         expect(_saidas).toHaveLength(1);
                     });
+
+                    it('Para com aninhamento', async () => {
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var castelo = [[0, 1, 0], [0, 0, 0], [0, 0, 0]]',
+                                'para (var i = 0; i < castelo.tamanho(); i++) {',
+                                '    para (var j = 0; j < castelo[i].tamanho(); j++) {',
+                                '        se (castelo[i][j] == 1) {',
+                                '            castelo[i][j] = \'princesa\'',
+                                '        }',
+                                '    }',
+                                '}',
+                                'escreva(castelo)'
+                            ], -1);
+
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(1);
+                    });
                 });
             });
 

--- a/testes/pitugues/interpretador.test.ts
+++ b/testes/pitugues/interpretador.test.ts
@@ -1145,7 +1145,7 @@ describe('Interpretador (Pituguês)', () => {
 
                         expect(retornoInterpretador.erros).toHaveLength(0);
                         expect(_saidas).toHaveLength(1);
-                        expect(_saidas[0]).toBe("[[\"a\",1], [\"b\",2], [\"c\",3]]");
+                        expect(_saidas[0]).toBe("[['a', 1], ['b', 2], ['c', 3]]");
                     });
                 });
             });

--- a/testes/primitivas/primitivas-dicionario.test.ts
+++ b/testes/primitivas/primitivas-dicionario.test.ts
@@ -14,7 +14,7 @@ describe('Primitivas de dicionário', () => {
     describe('chaves()', () => {
         it('Trivial', async () => {
             const meuDicionario = { "a": 1, "b": 2, "c": 3 };
-            const resultado = await primitivasDicionario.chaves.implementacao(interpretador, 'meuDicionario', meuDicionario);
+            const resultado = await primitivasDicionario.chaves.implementacao(interpretador, meuDicionario);
             expect(resultado).toStrictEqual(["a", "b", "c"]);
         });
     });
@@ -22,10 +22,10 @@ describe('Primitivas de dicionário', () => {
     describe('contém() ou contem()', () => {
         it('Trivial', async () => {
             const meuDicionario = { "a": 1, "b": 2, "c": 3 };
-            const resultado1 = await primitivasDicionario.contém.implementacao(interpretador, 'meuDicionario', meuDicionario, "a");
+            const resultado1 = await primitivasDicionario.contém.implementacao(interpretador, meuDicionario, "a");
             expect(resultado1).toStrictEqual(true);
 
-            const resultado2 = await primitivasDicionario.contem.implementacao(interpretador,'meuDicionario',  meuDicionario, "f");
+            const resultado2 = await primitivasDicionario.contem.implementacao(interpretador, meuDicionario, "f");
             expect(resultado2).toStrictEqual(false);
         });
     });
@@ -33,7 +33,7 @@ describe('Primitivas de dicionário', () => {
     describe('remover()', () => {
         it('Trivial', async () => {
             const meuDicionario = { "a": 1, "b": 2, "c": 3 };
-            const resultado = await primitivasDicionario.remover.implementacao(interpretador, 'meuDicionario', meuDicionario, "b");
+            const resultado = await primitivasDicionario.remover.implementacao(interpretador, meuDicionario, "b");
             expect(resultado).toStrictEqual(true);
         });
     });
@@ -41,7 +41,7 @@ describe('Primitivas de dicionário', () => {
     describe('valores()', () => {
         it('Trivial', async () => {
             const meuDicionario = { "a": 1, "b": 2, "c": 3 };
-            const resultado = await primitivasDicionario.valores.implementacao(interpretador, 'meuDicionario', meuDicionario);
+            const resultado = await primitivasDicionario.valores.implementacao(interpretador, meuDicionario);
             expect(resultado).toStrictEqual([1, 2, 3]);
         });
     });

--- a/testes/primitivas/primitivas-numero.test.ts
+++ b/testes/primitivas/primitivas-numero.test.ts
@@ -6,50 +6,50 @@ describe('Primitivas de número', () => {
 
     beforeEach(() => {
         interpretador = new InterpretadorBase(
-            process.cwd(), 
+            process.cwd(),
             false
         )
     });
 
     describe('arredondarParaBaixo()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasNumero.arredondarParaBaixo.implementacao(interpretador, '', 5.7);
+            const resultado = await primitivasNumero.arredondarParaBaixo.implementacao(interpretador, 5.7);
             expect(resultado).toStrictEqual(5);
         });
     });
 
     describe('arredondarParaCima()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasNumero.arredondarParaCima.implementacao(interpretador, '', 2.5);
+            const resultado = await primitivasNumero.arredondarParaCima.implementacao(interpretador, 2.5);
             expect(resultado).toStrictEqual(3);
         });
     });
 
     describe('absoluto()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasNumero.absoluto.implementacao(interpretador, '', -5);
+            const resultado = await primitivasNumero.absoluto.implementacao(interpretador, -5);
             expect(resultado).toStrictEqual(5);
         });
     });
 
     describe('formatar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasNumero.formatar.implementacao(interpretador, '', 1234.56);
+            const resultado = await primitivasNumero.formatar.implementacao(interpretador, 1234.56);
             expect(resultado).toStrictEqual('1.234,56');
         });
 
         it('Apenas parte inteira', async () => {
-            const resultado = await primitivasNumero.formatar.implementacao(interpretador, '', 1234);
+            const resultado = await primitivasNumero.formatar.implementacao(interpretador, 1234);
             expect(resultado).toStrictEqual('1.234,00');
         });
 
         it('Apenas parte decimal', async () => {
-            const resultado = await primitivasNumero.formatar.implementacao(interpretador, '', 0.56);
+            const resultado = await primitivasNumero.formatar.implementacao(interpretador, 0.56);
             expect(resultado).toStrictEqual('0,56');
         });
 
         it('Com casas decimais personalizadas', async () => {
-            const resultado = await primitivasNumero.formatar.implementacao(interpretador, '', 1234.56789, { maximoCasasDecimais: 3 });
+            const resultado = await primitivasNumero.formatar.implementacao(interpretador, 1234.56789, { maximoCasasDecimais: 3 });
             expect(resultado).toStrictEqual('1.234,568');
         });
     });

--- a/testes/primitivas/primitivas-texto.test.ts
+++ b/testes/primitivas/primitivas-texto.test.ts
@@ -13,21 +13,21 @@ describe('Primitivas de texto', () => {
 
     describe('apararInicio()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.apararInicio.implementacao(interpretador, '', '  olá   ');
+            const resultado = await primitivasTexto.apararInicio.implementacao(interpretador, '  olá   ');
             expect(resultado).toStrictEqual('olá   ');
         });
     });
 
     describe('aparar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.aparar.implementacao(interpretador, '', '  olá  ');
+            const resultado = await primitivasTexto.aparar.implementacao(interpretador, '  olá  ');
             expect(resultado).toStrictEqual('olá');
         });
     });
 
     describe('apararFim()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.apararFim.implementacao(interpretador, '', '  olá   ');
+            const resultado = await primitivasTexto.apararFim.implementacao(interpretador, '  olá   ');
             expect(resultado).toStrictEqual('  olá');
         });
     });
@@ -35,82 +35,82 @@ describe('Primitivas de texto', () => {
     describe('concatenar()', () => {
         it('Trivial', async () => {
             const mensagem = "Olá";
-            const resultado = await primitivasTexto.concatenar.implementacao(interpretador, 'mensagem', mensagem, ", mundo", "!!!");
+            const resultado = await primitivasTexto.concatenar.implementacao(interpretador, mensagem, ", mundo", "!!!");
             expect(resultado).toStrictEqual('Olá, mundo!!!');
         });
     });
 
     describe('dividir()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.dividir.implementacao(interpretador, '', '123|456|789|0', '|', 4);
+            const resultado = await primitivasTexto.dividir.implementacao(interpretador, '123|456|789|0', '|', 4);
             expect(resultado).toStrictEqual(['123', '456', '789', '0']);
         });
 
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.dividir.implementacao(interpretador, '', 'TEXTO', '');
+            const resultado = await primitivasTexto.dividir.implementacao(interpretador, 'TEXTO', '');
             expect(resultado).toStrictEqual(['T', 'E', 'X', 'T', 'O']);
         });
     });
 
     describe('fatiar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.fatiar.implementacao(interpretador, '', '1234567890', 4, 7);
+            const resultado = await primitivasTexto.fatiar.implementacao(interpretador, '1234567890', 4, 7);
             expect(resultado).toBe('567');
         });
     });
 
     describe('inclui()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.inclui.implementacao(interpretador, '', '123', '3');
+            const resultado = await primitivasTexto.inclui.implementacao(interpretador, '123', '3');
             expect(resultado).toBe(true);
         });
     });
 
     describe('maiusculo()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.maiusculo.implementacao(interpretador, '', 'delégua');
+            const resultado = await primitivasTexto.maiusculo.implementacao(interpretador, 'delégua');
             expect(resultado).toBe('DELÉGUA');
         });
     });
 
     describe('minusculo()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.minusculo.implementacao(interpretador, '', 'DELÉGUA');
+            const resultado = await primitivasTexto.minusculo.implementacao(interpretador, 'DELÉGUA');
             expect(resultado).toBe('delégua');
         });
     });
 
     describe('substituir()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.substituir.implementacao(interpretador, '', '123', '2', '4');
+            const resultado = await primitivasTexto.substituir.implementacao(interpretador, '123', '2', '4');
             expect(resultado).toBe('143');
         });
     });
 
     describe('subtexto()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.subtexto.implementacao(interpretador, '', '1234567890', 2, 5);
+            const resultado = await primitivasTexto.subtexto.implementacao(interpretador, '1234567890', 2, 5);
             expect(resultado).toBe('345');
         });
     });
 
     describe('tamanho()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.tamanho.implementacao(interpretador, '', '1234567890');
+            const resultado = await primitivasTexto.tamanho.implementacao(interpretador, '1234567890');
             expect(resultado).toBe(10);
         });
     });
 
     describe('tudoMaiusculo()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.tudoMaiusculo.implementacao(interpretador, '', 'DELÉGUA');
+            const resultado = await primitivasTexto.tudoMaiusculo.implementacao(interpretador, 'DELÉGUA');
             expect(resultado).toBe(true);
         });
     });
 
     describe('tudoMinusculo()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasTexto.tudoMinusculo.implementacao(interpretador, '', 'delégua');
+            const resultado = await primitivasTexto.tudoMinusculo.implementacao(interpretador, 'delégua');
             expect(resultado).toBe(true);
         });
     });

--- a/testes/primitivas/primitivas-vetor.test.ts
+++ b/testes/primitivas/primitivas-vetor.test.ts
@@ -28,14 +28,14 @@ describe('Primitivas de vetor', () => {
 
     describe('empilhar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.empilhar.implementacao(interpretador, '', [1, 2, 3], 4);
+            const resultado = await primitivasVetor.empilhar.implementacao(interpretador, [1, 2, 3], 4);
             expect(resultado).toStrictEqual([1, 2, 3, 4]);
         });
     });
 
     describe('fatiar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.fatiar.implementacao(interpretador, '', [1, 2, 3, 4, 5], 1, 3);
+            const resultado = await primitivasVetor.fatiar.implementacao(interpretador, [1, 2, 3, 4, 5], 1, 3);
             expect(resultado).toStrictEqual([2, 3]);
         });
     });
@@ -90,52 +90,52 @@ describe('Primitivas de vetor', () => {
 
     describe('inclui()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.inclui.implementacao(interpretador, '', [1, 2, 3], 3);
+            const resultado = await primitivasVetor.inclui.implementacao(interpretador, [1, 2, 3], 3);
             expect(resultado).toBe(true);
         });
     });
 
     describe('inverter()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.inverter.implementacao(interpretador, '', [1, 2, 3]);
+            const resultado = await primitivasVetor.inverter.implementacao(interpretador, [1, 2, 3]);
             expect(resultado).toStrictEqual([3, 2, 1]);
         });
     });
 
     describe('juntar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.juntar.implementacao(interpretador, '', [1, 2, 3], '|');
+            const resultado = await primitivasVetor.juntar.implementacao(interpretador, [1, 2, 3], '|');
             expect(resultado).toBe('1|2|3');
         });
     });
 
     describe('concatenar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.concatenar.implementacao(interpretador, '', [1, 2, 3], [4, 5, 6]);
+            const resultado = await primitivasVetor.concatenar.implementacao(interpretador, [1, 2, 3], [4, 5, 6]);
             expect(resultado).toStrictEqual([1, 2, 3, 4, 5, 6]);
         });
     });
 
     describe('ordenar()', () => {
         it('Números', async () => {
-            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, '', [2, 3, 5, 1, 10, 9], undefined as any);
+            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, [2, 3, 5, 1, 10, 9], undefined as any);
             expect(resultado).toStrictEqual([1, 2, 3, 5, 9, 10]);
         });
 
         it('Textos', async () => {
-            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, '', ["Erika", "Ana", "Carlos", "Daniel", "Bianca"], undefined as any);
+            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, ["Erika", "Ana", "Carlos", "Daniel", "Bianca"], undefined as any);
             expect(resultado).toStrictEqual(["Ana", "Bianca", "Carlos", "Daniel", "Erika"]);
         });
 
         it('Números e Textos', async () => {
-            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, '', ["Ana", "Carlos", "Bianca", 5, 3, 6], undefined as any);
+            const resultado = await primitivasVetor.ordenar.implementacao(interpretador, ["Ana", "Carlos", "Bianca", 5, 3, 6], undefined as any);
             expect(resultado).toStrictEqual([3, 5, 6, "Ana", "Bianca", "Carlos"]);
         });
     });
 
     describe('remover()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.remover.implementacao(interpretador, '', [1, 2, 3], 2);
+            const resultado = await primitivasVetor.remover.implementacao(interpretador, [1, 2, 3], 2);
             expect(resultado).toStrictEqual([1, 3]);
         });
     });
@@ -143,7 +143,7 @@ describe('Primitivas de vetor', () => {
     describe('removerPrimeiro()', () => {
         it('Trivial', async () => {
             let vetor = [1, 2, 3];
-            const resultado = await primitivasVetor.removerPrimeiro.implementacao(interpretador, 'v', vetor);
+            const resultado = await primitivasVetor.removerPrimeiro.implementacao(interpretador, vetor);
             expect(resultado).toBe(1);
             expect(vetor).toStrictEqual([2, 3]);
         });
@@ -152,7 +152,7 @@ describe('Primitivas de vetor', () => {
     describe('removerUltimo()', () => {
         it('Trivial', async () => {
             let vetor = [1, 2, 3];
-            const resultado = await primitivasVetor.removerUltimo.implementacao(interpretador, 'v', vetor);
+            const resultado = await primitivasVetor.removerUltimo.implementacao(interpretador, vetor);
             expect(resultado).toBe(3);
             expect(vetor).toStrictEqual([1, 2]);
         });
@@ -161,65 +161,50 @@ describe('Primitivas de vetor', () => {
     describe('encaixar()', () => {
         it('Apenas primeiro parâmetro, para pular elementos', async () => {
             let vetor = [1, 2, 3];
-            interpretador.pilhaEscoposExecucao.definirVariavel('v', vetor);
-            var resultado = await primitivasVetor.encaixar.implementacao(interpretador, 'v', vetor, 1);
-            expect(resultado).toStrictEqual([1]);
-            
-            const variavelNaPilha: VariavelInterface = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('v');
-            expect(variavelNaPilha.valor).toStrictEqual([2, 3]);
+            var resultado = await primitivasVetor.encaixar.implementacao(interpretador, vetor, 1);
+            expect(resultado).toStrictEqual([2, 3]);
+            expect(vetor).toStrictEqual([1]);
         });
 
         it('Inserindo novo elemento sem remoção', async () => {
             let vetor = [1, 2, 3];
-            interpretador.pilhaEscoposExecucao.definirVariavel('v', vetor);
-            var resultado = await primitivasVetor.encaixar.implementacao(interpretador, 'v', vetor, 2, 0, 10);
+            var resultado = await primitivasVetor.encaixar.implementacao(interpretador, vetor, 2, 0, 10);
             expect(resultado).toStrictEqual([]);
-
-            const variavelNaPilha: VariavelInterface = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('v');
-            expect(variavelNaPilha.valor).toStrictEqual([1, 2, 10, 3]);
+            expect(vetor).toStrictEqual([1, 2, 10, 3]);
         });
 
         it('Removendo elemento na posição 2', async () => {
             let vetor = [1, 2, 3];
-            interpretador.pilhaEscoposExecucao.definirVariavel('v', vetor);
-            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, 'v', vetor, 2, 1, 10);
+            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, vetor, 2, 1, 10);
             expect(resultado).toStrictEqual([3]);
-
-            const variavelNaPilha: VariavelInterface = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('v');
-            expect(variavelNaPilha.valor).toStrictEqual([1, 2, 10]);
+            expect(vetor).toStrictEqual([1, 2, 10]);
         });
 
         it('Um elemento', async () => {
             let vetor = [1, 2, 3, 4, 5];
-            interpretador.pilhaEscoposExecucao.definirVariavel('v', vetor);
-            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, 'v', vetor, 1, 3, "texto");
+            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, vetor, 1, 3, "texto");
             expect(resultado).toStrictEqual([2, 3, 4]);
-
-            const variavelNaPilha: VariavelInterface = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('v');
-            expect(variavelNaPilha.valor).toStrictEqual([1, 'texto', 5]);
+            expect(vetor).toStrictEqual([1, 'texto', 5]);
         });
 
         it('Mais de um elemento', async () => {
             let vetor = [1, 2, 3, 4, 5];
-            interpretador.pilhaEscoposExecucao.definirVariavel('v', vetor);
-            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, 'v', vetor, 1, 3, "texto1", "texto2");
+            const resultado = await primitivasVetor.encaixar.implementacao(interpretador, vetor, 1, 3, "texto1", "texto2");
             expect(resultado).toStrictEqual([2, 3, 4]);
-
-            const variavelNaPilha: VariavelInterface = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('v');
-            expect(variavelNaPilha.valor).toStrictEqual([1, 'texto1', 'texto2', 5]);
+            expect(vetor).toStrictEqual([1, 'texto1', 'texto2', 5]);
         });
     });
 
     describe('somar()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.somar.implementacao(interpretador, '', [1, 2, 3]);
+            const resultado = await primitivasVetor.somar.implementacao(interpretador, [1, 2, 3]);
             expect(resultado).toBe(6);
         });
     });
 
     describe('tamanho()', () => {
         it('Trivial', async () => {
-            const resultado = await primitivasVetor.tamanho.implementacao(interpretador, '', [1, 2, 3]);
+            const resultado = await primitivasVetor.tamanho.implementacao(interpretador, [1, 2, 3]);
             expect(resultado).toBe(3);
         });
     });

--- a/testes/primitivas/primitivas-vetor.test.ts
+++ b/testes/primitivas/primitivas-vetor.test.ts
@@ -20,8 +20,7 @@ describe('Primitivas de vetor', () => {
 
     describe('adicionar()', () => {
         it('Trivial', async () => {
-            interpretador.pilhaEscoposExecucao.definirVariavel('meuVetor', [1, 2, 3]);
-            const resultado = await primitivasVetor.adicionar.implementacao(interpretador, 'meuVetor', [1, 2, 3], 4);
+            const resultado = await primitivasVetor.adicionar.implementacao(interpretador, [1, 2, 3], 4);
             expect(resultado).toStrictEqual([1, 2, 3, 4]);
         });
     });
@@ -80,7 +79,6 @@ describe('Primitivas de vetor', () => {
             );
             const resultado = await primitivasVetor.filtrarPor.implementacao(
                 interpretador, 
-                '', 
                 ['verdadeiro', 'falso', 'falso', 'verdadeiro', 'falso', 'verdadeiro'], 
                 deleguaFuncao
             );


### PR DESCRIPTION
Assim como dicionários, tendo vetores no montão nos permite trabalhar com N níveis de aninhamento. Ou seja:

```js
meuVetorN[1][2][3][4][5] = 1
```

Resolve #1043 