### PR TITLE
[Delégua] Simplifica a sintaxe de exibição de Tuplas de [()] para ()

### DIFF
--- a/fontes/construtos/tuplas/deceto.ts
+++ b/fontes/construtos/tuplas/deceto.ts
@@ -72,6 +72,6 @@ export class Deceto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()}, ${this.nono.paraTextoSaida()}, ${this.decimo.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()}, ${this.nono.paraTextoSaida()}, ${this.decimo.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/dupla.ts
+++ b/fontes/construtos/tuplas/dupla.ts
@@ -20,6 +20,6 @@ export class Dupla extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/noneto.ts
+++ b/fontes/construtos/tuplas/noneto.ts
@@ -59,6 +59,6 @@ export class Noneto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()}, ${this.nono.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()}, ${this.nono.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/octeto.ts
+++ b/fontes/construtos/tuplas/octeto.ts
@@ -55,6 +55,6 @@ export class Octeto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()}, ${this.oitavo.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/quarteto.ts
+++ b/fontes/construtos/tuplas/quarteto.ts
@@ -26,6 +26,6 @@ export class Quarteto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/quinteto.ts
+++ b/fontes/construtos/tuplas/quinteto.ts
@@ -35,6 +35,6 @@ export class Quinteto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, , ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, , ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/septeto.ts
+++ b/fontes/construtos/tuplas/septeto.ts
@@ -51,6 +51,6 @@ export class Septeto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()}, ${this.setimo.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/sexteto.ts
+++ b/fontes/construtos/tuplas/sexteto.ts
@@ -39,6 +39,6 @@ export class Sexteto extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()}, ${this.quarto.paraTextoSaida()}, ${this.quinto.paraTextoSaida()}, ${this.sexto.paraTextoSaida()})`;
     }
 }

--- a/fontes/construtos/tuplas/trio.ts
+++ b/fontes/construtos/tuplas/trio.ts
@@ -23,6 +23,6 @@ export class Trio extends Tupla {
     }
 
     paraTextoSaida(): string {
-        return `[(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()})]`;
+        return `(${this.primeiro.paraTextoSaida()}, ${this.segundo.paraTextoSaida()}, ${this.terceiro.paraTextoSaida()})`;
     }
 }

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -239,7 +239,7 @@ describe('Interpretador', () => {
                     const retornoInterpretador = await interpretador.interpretar(
                         retornoAvaliadorSintatico.declaracoes
                     );
-                    
+
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('Olá, Maria! Você tem 25 anos.');
@@ -1928,9 +1928,9 @@ describe('Interpretador', () => {
 
                         expect(retornoInterpretador.erros).toHaveLength(0);
                         expect(_saidas).toHaveLength(3);
-                        expect(_saidas[0]).toContain('[(\"a\", 1)]');
-                        expect(_saidas[1]).toContain('[(\"b\", 2)]');
-                        expect(_saidas[2]).toContain('[(\"c\", 3)]');
+                        expect(_saidas[0]).toContain('(\"a\", 1)');
+                        expect(_saidas[1]).toContain('(\"b\", 2)');
+                        expect(_saidas[2]).toContain('(\"c\", 3)');
                     });
 
                     it('para cada - texto', async () => {
@@ -2897,7 +2897,7 @@ describe('Interpretador', () => {
                         expect(_saidas).toHaveLength(5);
                         expect(_saidas[0]).toEqual('[\'a\', \'b\', \'c\']');
                         expect(_saidas[1]).toEqual('[1, 2, 3]');
-                        expect(_saidas[2]).toEqual('[[(\"a\", 1)], [(\"b\", 2)], [(\"c\", 3)]]');
+                        expect(_saidas[2]).toEqual('[(\"a\", 1), (\"b\", 2), (\"c\", 3)]');
                         expect(_saidas[3]).toEqual('falso');
                         expect(_saidas[4]).toEqual('verdadeiro');
                     });


### PR DESCRIPTION
### O que foi feito

Este PR realiza a refatoração da representação textual das tuplas em todo o ecossistema Delégua. Foi modificado o método `paraTextoSaida()` de todos os construtos de tuplas (do Dupla ao Deceto) para remover os colchetes externos, mantendo apenas os parênteses.

### Por que foi feito

A alteração visa simplificar a sintaxe da linguagem para a sua próxima versão, tornando a exibição de dados mais limpa e intuitiva. Além disso, a mudança garante a consistência visual entre o núcleo do Delégua e o dialeto Pituguês, que já utiliza a convenção de parênteses para tuplas.

Closes #1053