### PR TITLE
[Pituguês] Implementa métodos de primitiva limpar, contar, estender, inserir e indice para vetores

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -142,42 +142,53 @@ export default {
                 'qualquer[]',
                 true,
                 [],
-                'Um ou mais vetores cujos elementos serão adicionados ao final deste vetor.'
+                'Um ou mais vetores (ou dicionários) cujos elementos serão adicionados ao final deste vetor.'
             ),
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
             vetor: Array<any>,
-            ...outrosVetores: any[]
+            ...iteraveis: any[]
         ): Promise<any[]> => {
-            if (outrosVetores.length === 0) {
+            if (iteraveis.length === 0) {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         null,
-                        'A função "estender" espera pelo menos um vetor como argumento.',
+                        'A função "estender" espera pelo menos um argumento (vetor ou dicionário).',
                         interpretador.linhaDeclaracaoAtual
                     )
                 );
             }
 
-            for (const argumento of outrosVetores) {
-                const listaAdicional = interpretador.resolverValor(argumento);
-                if (!Array.isArray(listaAdicional)) {
-                    return Promise.reject(
-                        new ErroEmTempoDeExecucao(
-                            null,
-                            'O argumento da função "estender" deve ser um vetor.',
-                            interpretador.linhaDeclaracaoAtual,
-                        )
-                    );
+            for (const argumento of iteraveis) {
+                const itemResolvido = interpretador.resolverValor(argumento);
+
+                // É um vetor
+                if (Array.isArray(itemResolvido)) {
+                    vetor.push(...itemResolvido);
+                    continue;
                 }
-                vetor.push(...listaAdicional);
+
+                // É um dicionário
+                if (typeof itemResolvido === 'object' && itemResolvido !== null) {
+                    vetor.push(...Object.keys(itemResolvido));
+                    continue;
+                }
+
+                // Não é iterável
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        'O argumento da função "estender" deve ser um vetor ou um dicionário.',
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
             }
             return Promise.resolve(vetor);
         },
-        assinaturaFormato: 'vetor.estender(...outroVetor: qualquer[])',
-        documentacao: '# `vetor.estender(outroVetor)`\n\nAdiciona todos os elementos de outro vetor ao final do vetor atual.',
-        exemploCodigo: 'vetor.estender(...argumentos)',
+        assinaturaFormato: 'vetor.estender(...iteravel: qualquer[])',
+        documentacao: '# `vetor.estender(iteravel)`\n\nAdiciona elementos de um vetor ou chaves de um dicionário ao final do vetor atual.',
+        exemploCodigo: 'vetor.estender([1, 2])',
     },
     fatiar: {
         tipoRetorno: 'qualquer[]',

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -3,6 +3,7 @@ import { InterpretadorInterface, PrimitivaInterface } from '../../../interfaces'
 import { InformacaoElementoSintatico } from '../../../informacao-elemento-sintatico';
 import { inferirTipoVariavel } from '../../../inferenciador';
 import { Literal, TuplaN } from '../../../construtos';
+import { ErroEmTempoDeExecucao } from '../../../excecoes';
 
 export default {
     adicionar: {
@@ -64,6 +65,51 @@ export default {
             '\n\n ### Formas de uso  \n',
         exemploCodigo: 'vetor.concatenar(...argumentos)',
     },
+    contar: {
+        tipoRetorno: 'numero',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'elemento',
+                'qualquer',
+                true,
+                [],
+                'O elemento a ser contado no vetor.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            vetor: Array<any>,
+            ...args: any[]
+        ): Promise<any> => {
+            if (args.length === 0) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `A função "contar" espera um argumento.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            if (args.length > 1) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `A função "contar" espera apenas um argumento.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            const elemento = args[0];
+            const valorProcurado = interpretador.resolverValor(elemento);
+            const total = vetor.filter(item => interpretador.resolverValor(item) === valorProcurado).length;
+            return Promise.resolve(total);
+        },
+        assinaturaFormato: 'vetor.contar(elemento)',
+        documentacao: '# `vetor.contar(elemento)`\n\nRetorna quantas vezes o elemento aparece no vetor.',
+        exemploCodigo: 'vetor.contar(elemento)',
+    },
     empilhar: {
         tipoRetorno: 'qualquer[]',
         argumentos: [new InformacaoElementoSintatico('elemento', 'qualquer', true, [], '')],
@@ -88,56 +134,50 @@ export default {
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.empilhar(elemento)',
     },
-    encaixar: {
+    estender: {
         tipoRetorno: 'qualquer[]',
         argumentos: [
-            new InformacaoElementoSintatico('inicio', 'inteiro'),
-            new InformacaoElementoSintatico('excluirQuantidade', 'número'),
-            new InformacaoElementoSintatico('itens', 'qualquer[]'),
+            new InformacaoElementoSintatico(
+                'outrosVetores',
+                'qualquer[]',
+                true,
+                [],
+                'Um ou mais vetores cujos elementos serão adicionados ao final deste vetor.'
+            ),
         ],
         implementacao: (
             interpretador: InterpretadorInterface,
             vetor: Array<any>,
-            posicaoInicial: number,
-            quantidadeExclusao?: number,
-            ...itens: any[]
-        ): Promise<any> => {
-            let elementos = [];
-
-            if (quantidadeExclusao || quantidadeExclusao === 0) {
-                elementos = !itens.length
-                    ? vetor.splice(posicaoInicial, quantidadeExclusao)
-                    : vetor.splice(posicaoInicial, quantidadeExclusao, ...itens);
-
-                return Promise.resolve(elementos);
-            } else {
-                elementos = !itens.length ? vetor.splice(posicaoInicial) : vetor.splice(posicaoInicial, ...itens);
-
-                return Promise.resolve(vetor);
+            ...outrosVetores: any[]
+        ): Promise<any[]> => {
+            if (outrosVetores.length === 0) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        'A função "estender" espera pelo menos um vetor como argumento.',
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
             }
+
+            for (const argumento of outrosVetores) {
+                const listaAdicional = interpretador.resolverValor(argumento);
+                if (!Array.isArray(listaAdicional)) {
+                    return Promise.reject(
+                        new ErroEmTempoDeExecucao(
+                            null,
+                            'O argumento da função "estender" deve ser um vetor.',
+                            interpretador.linhaDeclaracaoAtual,
+                        )
+                    );
+                }
+                vetor.push(...listaAdicional);
+            }
+            return Promise.resolve(vetor);
         },
-        assinaturaFormato: 'vetor.encaixar(posicaoInicial?: número, quantidadeExclusao?: número, itens?: qualquer[])',
-        documentacao:
-            '# `vetor.encaixar(posicaoInicial, quantidadeExclusao, itens)` \n \n' +
-            'Encaixa um vetor em outro, dadas posições de início e quantidade de ítens a serem excluídos do vetor original. \n' +
-            '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar v = [1, 2, 3, 4, 5]\n' +
-            'escreva(v.encaixar()) // "[1, 2, 3, 4, 5]", ou seja, não faz coisa alguma.\n' +
-            `var v1 = v.encaixar(2)\n` +
-            'escreva(v) // "[3, 4, 5]", ou seja, a posição 2, onde fica o 3, passa a ser a nova posição inicial do vetor.\n' +
-            'escreva(v1) // "[1, 2]", ou seja, o retorno de `encaixar()` são as posições removidas do vetor original.\n' +
-            'var v2 = [1, 2, 3, 4, 5]\n' +
-            'escreva(v2.encaixar(2, 1)) // "[3]"\n' +
-            'escreva(v2) // "[1, 2, 4, 5]"\n```' +
-            'var v3 = [1, 2, 3, 4, 5]\n' +
-            'escreva(v3.encaixar(2, 1, "teste")) // "[3]"\n' +
-            'escreva(v3) // "[1, 2, "teste", 4, 5]"\n```' +
-            '\n\n ### Formas de uso \n' +
-            '`encaixar` suporta sobrecarga do método.\n\n',
-        exemploCodigo:
-            'vetor.encaixar(<nova posição inicial>)\n' +
-            'vetor.encaixar(<a partir desta posição>, <exclua esta quantidade de elementos>)\n' +
-            'vetor.encaixar(<a partir desta posição>, <exclua esta quantidade de elementos>, <adicione estes elementos>)',
+        assinaturaFormato: 'vetor.estender(...outroVetor: qualquer[])',
+        documentacao: '# `vetor.estender(outroVetor)`\n\nAdiciona todos os elementos de outro vetor ao final do vetor atual.',
+        exemploCodigo: 'vetor.estender(...argumentos)',
     },
     fatiar: {
         tipoRetorno: 'qualquer[]',
@@ -249,6 +289,122 @@ export default {
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.inclui(elemento)'
     },
+    indice: {
+        tipoRetorno: 'numero',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'elemento',
+                'qualquer',
+                true,
+                [],
+                'O elemento cuja posição (índice) será buscada no vetor.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            vetor: Array<any>,
+            elemento: any
+        ): Promise<any> => {
+            if (elemento === undefined) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        '',
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            if (elemento === 'nulo') return Promise.reject(-1);
+
+            const valorProcurado = interpretador.resolverValor(elemento);
+            const index = vetor.findIndex(item => interpretador.resolverValor(item) === valorProcurado);
+            return Promise.resolve(index);
+        },
+        assinaturaFormato: 'vetor.indice(elemento: qualquer)',
+        documentacao:
+            '# `vetor.indice(elemento)` \n \n' +
+            'Retorna a posição (índice) da primeira ocorrência do elemento no vetor. \n' +
+            'Caso o elemento não seja encontrado, devolve `-1`.\n' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```pitugues\n' +
+            'var v = ["maçã", "banana", "uva"]\n' +
+            'escreva(v.indice("banana")) // 1\n' +
+            'escreva(v.indice("abacaxi")) // -1\n' +
+            '```',
+        exemploCodigo: 'vetor.indice(elemento)'
+    },
+    inserir: {
+        tipoRetorno: 'qualquer[]',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'índice',
+                'inteiro',
+                true,
+                [],
+                'O índice onde o elemento será inserido.'
+            ),
+            new InformacaoElementoSintatico(
+                'elemento',
+                'qualquer',
+                true,
+                [],
+                'O elemento a ser inserido.'
+            )
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            vetor: Array<any>,
+            ...args: any[]
+        ): Promise<any> => {
+            if (args.length !== 2) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `A função "inserir" espera exatamente 2 argumentos (índice e elemento), mas recebeu ${args.length}.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            const idx = interpretador.resolverValor(args[0]);
+            const item = interpretador.resolverValor(args[1]);
+
+            if (typeof idx !== 'number') {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        'O primeiro argumento da função "inserir" (índice) deve ser um número.',
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            if (idx < 0 || idx > vetor.length) {
+                return Promise.reject(
+                    new ErroEmTempoDeExecucao(
+                        null,
+                        `Índice ${idx} fora dos limites do vetor. O tamanho atual é ${vetor.length}.`,
+                        interpretador.linhaDeclaracaoAtual
+                    )
+                );
+            }
+
+            vetor.splice(idx, 0, item);
+            return Promise.resolve(vetor);
+        },
+        assinaturaFormato: 'vetor.inserir(indice: numero, elemento: qualquer)',
+        documentacao:
+            '# `vetor.inserir(indice, elemento)` \n \n' +
+            'Insere um elemento em uma posição específica do vetor, deslocando os elementos existentes para a direita. \n' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```pitugues\n' +
+            'v = [1, 2, 4, 5]\n' +
+            'v.inserir(2, 3) \n' +
+            'escreva(v) // "[1, 2, 3, 4, 5]"\n' +
+            '```',
+        exemploCodigo: 'vetor.inserir(indice, elemento)'
+    },
     inverter: {
         tipoRetorno: 'qualquer[]',
         argumentos: [],
@@ -292,6 +448,20 @@ export default {
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.juntar()\n' +
             'vetor.juntar(<separador>)',
+    },
+    limpar: {
+        tipoRetorno: 'qualquer[]',
+        argumentos: [],
+        implementacao: async (
+            interpretador: InterpretadorInterface,
+            vetor: Array<any>
+        ): Promise<any> => {
+            vetor.splice(0, vetor.length);
+            return Promise.resolve();
+        },
+        assinaturaFormato: 'vetor.limpar()',
+        documentacao: '# `vetor.limpar()`\n\nRemove todos os elementos do vetor original, deixando-o vazio.',
+        exemploCodigo: 'vetor.limpar()',
     },
     mapear: {
         tipoRetorno: 'qualquer[]',

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-vetor.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-vetor.test.ts
@@ -3,6 +3,34 @@ import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
 import { DeleguaFuncaoMock } from '../../../_mocks/delegua-funcao.mock';
 
 describe('Primitivas de Vetor (Pituguês)', () => {
+    describe('contar', () => {
+        it('deve contar quantas vezes um elemento aparece no vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, 2, 2, 3, 2];
+
+            const resultado = await primitivasVetor.contar.implementacao(
+                interpretador,
+                vetor,
+                2
+            );
+
+            expect(resultado).toBe(3);
+        });
+
+        it('deve retornar 0 se o elemento não existir no vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, 2, 3];
+
+            const resultado = await primitivasVetor.contar.implementacao(
+                interpretador,
+                vetor,
+                99
+            );
+
+            expect(resultado).toBe(0);
+        });
+    });
+
     describe('filtrar_por', () => {
         it("deve rejeitar quando não for passada uma função", async () => {
             const interpretador = criarInterpretadorMock();
@@ -22,6 +50,32 @@ describe('Primitivas de Vetor (Pituguês)', () => {
             );
 
             expect(resultado).toEqual([1, 3, 5]);
+        });
+    });
+
+    describe('limpar', () => {
+        it('deve remover todos os elementos do vetor', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, 2, 3];
+
+            await primitivasVetor.limpar.implementacao(
+                interpretador,
+                vetor
+            );
+
+            expect(vetor).toEqual([]);
+        });
+
+        it('não deve quebrar se o vetor já estiver vazio', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor: any[] = [];
+
+            await primitivasVetor.limpar.implementacao(
+                interpretador,
+                vetor
+            );
+
+            expect(vetor).toEqual([]);
         });
     });
 
@@ -93,66 +147,62 @@ describe('Primitivas de Vetor (Pituguês)', () => {
         });
     });
 
-    describe('encaixar', () => {
-        it('remove elementos quando quantidadeExclusao é fornecida e atribui variável', async () => {
-            const interpretador: any = criarInterpretadorMock();
-            interpretador.pilhaEscoposExecucao.atribuirVariavel = jest.fn();
+    describe('indice', () => {
+        it('deve retornar o índice do elemento se ele existir', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = ['a', 'b', 'c'];
 
+            const resultado = await primitivasVetor.indice.implementacao(
+                interpretador,
+                vetor,
+                'b'
+            );
+
+            expect(resultado).toBe(1);
+        });
+
+        it('deve retornar -1 se o elemento não existir', async () => {
+            const interpretador = criarInterpretadorMock();
             const vetor = [1, 2, 3];
 
-            const resultado = await primitivasVetor.encaixar.implementacao(
+            const resultado = await primitivasVetor.indice.implementacao(
                 interpretador,
-                vetor.slice(),
-                1,
+                vetor,
+                99
+            );
+
+            expect(resultado).toBe(-1);
+        });
+    });
+
+    describe('inserir', () => {
+        it('deve inserir elemento na posição indicada e deslocar os demais', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [1, 2, 4];
+
+            const resultado = await primitivasVetor.inserir.implementacao(
+                interpretador,
+                vetor,
+                2,
+                3
+            );
+
+            expect(resultado).toEqual([1, 2, 3, 4]);
+            expect(vetor).toEqual([1, 2, 3, 4]);
+        });
+
+        it('deve inserir no início do vetor (índice 0)', async () => {
+            const interpretador = criarInterpretadorMock();
+            const vetor = [2, 3];
+
+            await primitivasVetor.inserir.implementacao(
+                interpretador,
+                vetor,
+                0,
                 1
             );
 
-            expect(resultado).toEqual([2]);
-        });
-
-        it('quando só posição inicial é passada, remove do índice e atribui as posições removidas', async () => {
-            const interpretador: any = criarInterpretadorMock();
-            interpretador.pilhaEscoposExecucao.atribuirVariavel = jest.fn();
-
-            const vetor = [1, 2, 3];
-
-            const resultado = await primitivasVetor.encaixar.implementacao(
-                interpretador,
-                vetor,
-                1
-            );
-
-            // retorna o vetor modificado (após remoção a partir da posição 1)
-            expect(resultado).toEqual([1]);
-        });
-
-        it('quando chamada sem posição inicial, remove todos os elementos e retorna vetor vazio (sem atribuir variável quando nome é vazio)', async () => {
-            const interpretador: any = criarInterpretadorMock();
-            interpretador.pilhaEscoposExecucao.atribuirVariavel = jest.fn();
-
-            const vetor = [1, 2, 3];
-
-            const resultado = await primitivasVetor.encaixar.implementacao(
-                interpretador,
-                vetor
-            );
-
-            expect(resultado).toEqual([]);
-        });
-
-        it('coerção de posição não numérica equivale a 0 (remove tudo)', async () => {
-            const interpretador: any = criarInterpretadorMock();
-            interpretador.pilhaEscoposExecucao.atribuirVariavel = jest.fn();
-
-            const vetor = [1, 2, 3];
-
-            const resultado = await primitivasVetor.encaixar.implementacao(
-                interpretador,
-                vetor,
-                'a' as any
-            );
-
-            expect(resultado).toEqual([]);
+            expect(vetor).toEqual([1, 2, 3]);
         });
     });
 

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -2916,6 +2916,20 @@ describe('Interpretador (Pituguês)', () => {
 
                     expect(_saidas[0]).toBe('[1, 2]');
                 });
+
+                it('Estender com um objeto literal', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1]
+                        v.estender({ 'a': 1 })
+                        v.estender({ 'b': 2 })
+                        escreva(v)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe("[1, 'a', 'b']");
+                });
             });
 
             describe('vetor.inserir()', () => {
@@ -3825,21 +3839,6 @@ describe('Interpretador (Pituguês)', () => {
             });
 
             describe('vetor.estender()', () => {
-                // VERIFICAR ISSO
-                it('Falha - Tentar estender com um objeto literal em vez de vetor', async () => {
-                    const retornoLexador = lexador.mapear([`
-                        v = [1]
-                        v.estender({ 'a': 1 })
-                        escreva(v)
-                    `], -1);
-
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
-
-                    // O código não deve quebrar, mas o vetor original não deve ser alterado
-                    expect(_saidas[0]).toBe('[1]');
-                });
-
                 it('Falha - Tentar estender com um valor booleano', async () => {
                     const retornoLexador = lexador.mapear([`
                         v = [1]

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -2788,6 +2788,216 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas[0]).toBe('0');
                 });
             });
+
+            describe('vetor.limpar()', () => {
+                it('Limpar vetor usando o método vetor.limpar()', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        vetor = [1, 2, 3]
+                        vetor.limpar()
+                        escreva(vetor);
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('[]');
+                });
+
+                it('Limpar um vetor que já está vazio', async () => {
+                    const código = [
+                        "vetor = []",
+                        "vetor.limpar()",
+                        "escreva(vetor)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[]');
+                });
+
+                it('Verificar se o vetor limpo pode receber novos itens após a limpeza', async () => {
+                    const código = [
+                        "vetor = [1, 2]",
+                        "vetor.limpar()",
+                        "vetor.adicionar(10)",
+                        "escreva(vetor)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[10]');
+                });
+            });
+
+            describe('vetor.contar()', () => {
+                it('Contar ocorrências de elementos repetidos', async () => {
+                    const retornoLexador = lexador.mapear([
+                        "v = [1, 'a', 1, 'b', 1, 'a']",
+                        "escreva(v.contar(1))",
+                        "escreva(v.contar('a'))",
+                        "escreva(v.contar('z'))"
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('3');
+                    expect(_saidas[1]).toBe('2');
+                    expect(_saidas[2]).toBe('0');
+                });
+
+                it('Contar elemento que não existe no vetor', async () => {
+                    const código = [
+                        "v = [1, 2, 3]",
+                        "escreva(v.contar(99))"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('0');
+                });
+
+                it('Contar em um vetor vazio', async () => {
+                    const código = [
+                        "v = []",
+                        "escreva(v.contar(1))"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('0');
+                });
+            });
+
+            describe('vetor.estender()', () => {
+                it('Estender vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v1 = [1, 2]
+                        v2 = [3, 4]
+                        v1.estender(v2)
+                        escreva(v1)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('[1, 2, 3, 4]');
+                });
+
+                it('Estender usando múltiplos vetores (variádico)', async () => {
+                    const código = [
+                        "v1 = [1]",
+                        "v1.estender([2], [3], [4])",
+                        "escreva(v1)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[1, 2, 3, 4]');
+                });
+
+                it('Estender um vetor vazio com outro vetor', async () => {
+                    const código = [
+                        "v1 = []",
+                        "v1.estender([1, 2])",
+                        "escreva(v1)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[1, 2]');
+                });
+            });
+
+            describe('vetor.inserir()', () => {
+                it('Inserir elemento no vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        vetor = [10, 30, 40]
+                        vetor.inserir(1, 20)
+                        escreva(vetor)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('[10, 20, 30, 40]');
+                });
+
+                it('Inserir elemento no início (índice 0)', async () => {
+                    const código = [
+                        "vetor = [2, 3]",
+                        "vetor.inserir(0, 1)",
+                        "escreva(vetor)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[1, 2, 3]');
+                });
+
+                it('Inserir elemento no final do vetor usando o tamanho atual como índice', async () => {
+                    const código = [
+                        "vetor = [1, 2]",
+                        "vetor.inserir(2, 3)",
+                        "escreva(vetor)"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('[1, 2, 3]');
+                });
+            });
+
+            describe('vetor.indice()', () => {
+                it('Verificar índice de elemento', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        vetor = [1, 2, 3, 4, 5]
+                        escreva(vetor.indice(3))
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('2');
+                });
+
+                it('Retornar -1 para elemento inexistente', async () => {
+                    const código = [
+                        "vetor = [1, 2, 3]",
+                        "escreva(vetor.indice(50))"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('-1');
+                });
+
+                it('Retornar o índice da primeira ocorrência quando há duplicatas', async () => {
+                    const código = [
+                        "vetor = ['a', 'b', 'a', 'c']",
+                        "escreva(vetor.indice('a'))"
+                    ];
+                    const retornoLexador = lexador.mapear(código, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('0');
+                });
+            });
         });
 
         it('termina_com - sufixo encontrado no final', async () => {
@@ -3558,6 +3768,167 @@ describe('Interpretador (Pituguês)', () => {
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
                     expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain('aceita apenas vetores contendo números');
+                });
+            });
+
+            describe('vetor.limpar()', () => {
+                it('Falha - Tentar limpar uma variável que não é um vetor (ex: número)', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        numero = 10
+                        numero.limpar()
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    expect(retornoInterpretador.erros[0].erroInterno.message).toContain("não encontrado");
+                });
+
+                it('Falha - Tentar limpar um vetor nulo', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = nulo
+                        v.limpar()
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('vetor.contar()', () => {
+                it('Falha - Chamar contar() sem passar o argumento do elemento', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1, 2]
+                        escreva(v.contar())
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Passar mais argumentos do que o esperado (deve ignorar ou falhar)', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1, 2]
+                        escreva(v.contar(1, 2, 3))
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('vetor.estender()', () => {
+                // VERIFICAR ISSO
+                it('Falha - Tentar estender com um objeto literal em vez de vetor', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1]
+                        v.estender({ 'a': 1 })
+                        escreva(v)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    // O código não deve quebrar, mas o vetor original não deve ser alterado
+                    expect(_saidas[0]).toBe('[1]');
+                });
+
+                it('Falha - Tentar estender com um valor booleano', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1]
+                        v.estender(verdadeiro)
+                        escreva(v)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Estender com nulo', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1]
+                        v.estender(nulo)
+                        escreva(v)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('vetor.inserir()', () => {
+                it('Falha - Inserir passando texto no lugar do índice', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1, 2]
+                        v.inserir('texto', 10)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Passar apenas um argumento (faltando o elemento)', async () => {
+                    const codigo = ["v = [1, 2]", "v.inserir(0)"];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Índice muito negativo (fora da realidade do vetor)', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        v = [1, 2]
+                        v.inserir(-999, 0)
+                        escreva(v)
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            describe('vetor.indice()', () => {
+                it('Falha - Chamar sem argumentos', async () => {
+                    const codigo = ["v = [1, 2]", "v.indice()"];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Chamar em um dicionário (objeto)', async () => {
+                    const codigo = ["d = { 'chave': 'valor' }", "d.indice('valor')"];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Falha - Argumento nulo para busca', async () => {
+                    const codigo = ["v = [1, 2]", "escreva(v.indice(nulo))"];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                    expect(_saidas[0]).toBe('-1');
                 });
             });
         });

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -239,7 +239,7 @@ describe('Interpretador', () => {
                     const retornoInterpretador = await interpretador.interpretar(
                         retornoAvaliadorSintatico.declaracoes
                     );
-                    
+
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('Olá, Maria! Você tem 25 anos.');


### PR DESCRIPTION
# O que foi feito

Este PR implementa cinco novos métodos nativos para a primitiva de vetores no dialeto Pituguês, visando a paridade funcional com as listas de Python. Além da implementação core, foram adicionadas validações rigorosas de argumentos e tipos para garantir a estabilidade do interpretador.

Métodos adicionados:
- `limpar()`: Remove todos os elementos do vetor.
- `contar(elemento)`: Retorna a quantidade de ocorrências de um valor.
- `estender(...vetores)`: Adiciona elementos de um ou mais vetores ao final do original.
- `inserir(indice, elemento)`: Insere um item em uma posição específica, com validação de limites de índice.
- `indice(elemento)`: Retorna a posição da primeira ocorrência ou -1 caso não encontre.

# Por que foi feito

Para reduzir a verbosidade do código no Pituguês e permitir que desenvolvedores vindos do Python tenham uma experiência de aprendizado e transição mais fluida. Anteriormente, algumas dessas operações exigiam manipulações manuais.

Closes #1052