### PR TITLE
Implementação de formatação de pontos flutuantes em f-string e usando o método formatar()

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -779,13 +779,18 @@ export class AvaliadorSintaticoPitugues
                 const simboloInterpolacao = this.avancarEDevolverAnterior();
                 const conteudoOriginal = simboloInterpolacao.literal as string;
 
-                // Transforma "Olá {nome}" em '"Olá " + (nome) + ""'
-                // Adicionado parênteses em volta das variáveis para garantir precedência na soma
-                const codigoTransformado = '"' +
-                    conteudoOriginal
-                        .replace(/\{/g, '" + (')
-                        .replace(/\}/g, ') + "') +
-                    '"';
+                const codigoTransformado = '"' + conteudoOriginal.replace(/\{(.*?)\}/g, (_, miolo) => {
+                    // 'miolo' é o texto que estava dentro das chaves. Ex: "valor" ou "valor:.2f"
+                    if (miolo.includes(':')) {
+                        const [variavel, formato] = miolo.split(':').map(s => s.trim());
+
+                        if (variavel !== "") {
+                            // Transforma {valor:.2f} em "{:.2f}".formatar(valor)
+                            return '" + "{:' + formato + '}".formatar(' + variavel + ') + "';
+                        }
+                    }
+                    return '" + (' + miolo.trim() + ') + "';
+                }) + '"';
 
                 const microLexador = new MicroLexadorPitugues();
                 const retornoMicroLexador = microLexador.mapear(codigoTransformado);

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
@@ -2,6 +2,7 @@ import { InterpretadorInterface } from '../../../interfaces';
 import { PrimitivaInterface } from '../../../interfaces/primitiva-interface';
 import { InformacaoElementoSintatico } from '../../../informacao-elemento-sintatico';
 import { implementacaoParticao } from '../../primitivas-texto';
+import { ErroEmTempoDeExecucao } from '../../../excecoes';
 
 export default {
     aparar: {
@@ -253,6 +254,51 @@ export default {
             't.fatiar(8) // "três quatro", ou seja, seleciona tudo da posição 8 até o final do texto.\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.fatiar(início, final)\n' + 'texto.fatiar(aPartirDaPosicao)',
+    },
+    formatar: {
+        tipoRetorno: 'texto',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'elemento',
+                'qualquer',
+                true,
+                [],
+                'O elemento a ser formatado.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            mascara: string,
+            elemento: any,
+        ): Promise<string> => {
+            const valor = interpretador.resolverValor(elemento);
+            const matchMascara = mascara.match(/\{:(.*?)\}/);
+
+            if (matchMascara) {
+                const configuracao = matchMascara[1];
+
+                if (configuracao.includes('f') && typeof valor !== 'number') {
+                    return Promise.reject(
+                        new ErroEmTempoDeExecucao(
+                            null,
+                            `Erro: Código de formato 'f' desconhecido para objeto do tipo '${typeof valor === 'string' ? 'texto' : typeof valor}'`,
+                            interpretador.linhaDeclaracaoAtual
+                        )
+                    );
+                }
+
+                if (typeof valor === 'number') {
+                    const matchCasas = configuracao.match(/\.(\d+)f/);
+                    const casas = matchCasas ? parseInt(matchCasas[1]) : 2;
+                    return Promise.resolve(mascara.replace(matchMascara[0], valor.toFixed(casas)));
+                }
+            }
+
+            return Promise.resolve(mascara.replace(/\{.*?\}/, String(valor)));
+        },
+        assinaturaFormato: 'texto.formatar(elemento: qualquer)',
+        documentacao: '# `texto.formatar(valor)` \n\n Formata um valor com base na máscara de texto.',
+        exemploCodigo: '"{:.2f}".formatar(1.2345)',
     },
     inclui: {
         tipoRetorno: 'lógico',

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -2380,6 +2380,45 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('Valor: 10');
                 });
+
+                it('Formatação de pontos flutuantes', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        valor = 1234.56789
+                        escreva(f"Duas casas decimais: {valor:.2f}")
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes,
+                        true
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('Duas casas decimais: 1234.57')
+                });
+            });
+
+            it('Formatação de ponto flutuante usando formatar()', async () => {
+                const retornoLexador = lexador.mapear([`
+                    valor = 1234.56789
+                    escreva("Duas casas decimais: {:.2f}".formatar(valor))
+                `], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoInterpretador = await interpretador.interpretar(
+                    retornoAvaliadorSintatico.declaracoes
+                );
+
+                expect(retornoInterpretador.erros).toHaveLength(0);
+                expect(_saidas).toHaveLength(1);
+                expect(_saidas[0]).toBe('Duas casas decimais: 1234.57')
             });
 
             describe('Tuplas', () => {
@@ -3339,6 +3378,46 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoLexador.erros).toHaveLength(1);
                     expect(retornoLexador.erros[0].mensagem).toContain('Texto não finalizado');
                 });
+
+                it('Tentativa de formatar uma string como ponto flutuante', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        valor = "estudante"
+                        escreva(f"{valor:.2f}")
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+
+                it('Variável não definida dentro da f-string', async () => {
+                    const retornoLexador = lexador.mapear([`
+                        escreva(f"O resultado é: {resultado_fantasma:.2f}")
+                    `], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                });
+            });
+
+            it('Tentativa de formatação de ponto flutuante usando formatar() com valor string', async () => {
+                const retornoLexador = lexador.mapear([`
+                    valor = "1234.56789"
+                    escreva("Duas casas decimais: {:.2f}".formatar(valor))
+                `], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoInterpretador = await interpretador.interpretar(
+                    retornoAvaliadorSintatico.declaracoes
+                );
+
+                expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
             });
 
             it('Deve dar erro ao tentar alterar valor de uma tupla (Imutabilidade)', async () => {


### PR DESCRIPTION
Esta implementação introduz o suporte ao método de formatação `formatar()` nas **primitivas de texto** no dialeto Pituguês. O objetivo é permitir que o usuário tenha controle preciso sobre a exibição de casas decimais de pontos flutuantes em f-string, seguindo a sintaxe e o comportamento semântico do Python.

# O que foi feito

- **Avaliador Sintático:** Foi implementada uma lógica de transformação no `avaliador-sintatico-pitugues.ts` que identifica padrões de interpolação e os transpila para chamadas do método `formatar()` diretamente nas strings.
- **Primitivas de Texto:** Adicionado o método `formatar()`.

# Exemplos de Uso

```
valor = 1234.56789
escreva(f"Resultado: {valor:.2f}") 
# Saída: Resultado: 1234.57
```

```
escreva("Pi: {:.4f}".formatar(3.14159))
# Saída: Pi: 3.1416
```

Closes #1024