### PR TITLE
Validação de divisão por zero para o Pituguês

### DIFF
--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -17,6 +17,16 @@ import { ErroEmTempoDeExecucao } from '../../../excecoes';
 import * as comum from './comum';
 
 export class InterpretadorPitugues extends Interpretador {
+    constructor(
+        diretorioBase: string,
+        performance = false,
+        funcaoDeRetorno: Function = null,
+        funcaoDeRetornoMesmaLinha: Function = null
+    ) {
+        super(diretorioBase, performance, funcaoDeRetorno, funcaoDeRetornoMesmaLinha);
+        this.lancarErroPorDivisaoPorZero = true;
+    }
+
     override async visitarExpressaoAcessoMetodo(expressao: AcessoMetodo): Promise<any> {
         return comum.visitarExpressaoAcessoMetodo(this, expressao);
     }

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -155,6 +155,8 @@ export class InterpretadorBase implements InterpretadorInterface {
         tipoDeDadosDelegua.REAL,
     ];
 
+    lancarErroPorDivisaoPorZero = false;
+
     constructor(
         diretorioBase: string,
         performance = false,
@@ -836,6 +838,15 @@ export class InterpretadorBase implements InterpretadorInterface {
             case tiposDeSimbolos.DIVISAO:
             case tiposDeSimbolos.DIVISAO_IGUAL:
                 this.verificarOperandosNumeros(expressao.operador, esquerda, direita);
+
+                if (this.lancarErroPorDivisaoPorZero && Number(valorDireito) === 0) {
+                    throw new ErroEmTempoDeExecucao(
+                        expressao.operador,
+                        'Divisão por zero não é permitida.',
+                        expressao.operador.linha
+                    );
+                }
+
                 // SEMPRE retorna Number para precisão decimal (preferência do usuário)
                 // Mesmo se operandos forem BigInt, converte para Number
                 return Number(valorEsquerdo) / Number(valorDireito);
@@ -843,6 +854,15 @@ export class InterpretadorBase implements InterpretadorInterface {
             case tiposDeSimbolos.DIVISAO_INTEIRA:
             case tiposDeSimbolos.DIVISAO_INTEIRA_IGUAL:
                 this.verificarOperandosNumeros(expressao.operador, esquerda, direita);
+
+                if (this.lancarErroPorDivisaoPorZero && valorDireito === 0) {
+                    throw new ErroEmTempoDeExecucao(
+                        expressao.operador,
+                        'Divisão por zero não é permitida.',
+                        expressao.operador.linha
+                    );
+                }
+
                 // Retorna BigInt se qualquer operando for BigInt
                 if (typeof valorEsquerdo === 'bigint' || typeof valorDireito === 'bigint') {
                     const esq = typeof valorEsquerdo === 'bigint' ? valorEsquerdo : BigInt(Math.floor(Number(valorEsquerdo)));

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -4112,6 +4112,26 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoAvaliadorSintatico.erros.length).toBeGreaterThan(0);
                 });
             });
+
+            it('Lançando erro quando a divisão de um número é por zero', async () => {
+                const codigo = ["escreva(10 / 0)"];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                expect(retornoInterpretador.erros).toHaveLength(1);
+                expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('Divisão por zero não é permitida.');
+            });
+
+            it('Lançando erro quando a divisão inteira de um número é por zero', async () => {
+                const codigo = ["escreva(10 // 0)"];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
+
+                expect(retornoInterpretador.erros).toHaveLength(1);
+                expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('Divisão por zero não é permitida.');
+            });
         });
 
         describe('Métodos de primitivas com dependência no interpretador', () => {


### PR DESCRIPTION
## O que foi feito

Este PR implementa a validação para impedir operações de divisão por zero no dialeto Pituguês.

As principais alterações incluem:
- **InterpretadorBase:** Adição da propriedade `lancarErroPorDivisaoPorZero` (booleana) para controlar o comportamento global de operações matemáticas.
- **Lógica de Divisão:** Atualização do método `visitarExpressaoBinaria` para verificar se o divisor é zero nos casos de `DIVISAO`, `DIVISAO_IGUAL`, `DIVISAO_INTEIRA` e `DIVISAO_INTEIRA_IGUAL`. O erro só é lançado se a flag estiver ativa.
- **InterpretadorPitugues:** Sobrescrita do construtor da classe para ativar a flag de validação, garantindo que apenas este dialeto seja afetado.
- **Testes:** Adição de cenários de falha no arquivo `interpretador-pitugues.test.ts` para validar o lançamento do erro e a precisão da mensagem retornada.

## Por que foi feito

A alteração foi realizada para resolver a issue #1082, que identificou a necessidade de um tratamento mais rigoroso para divisões por zero no Pituguês.

Closes #1082