### PR TITLE
Montão para classes.

### DIFF
--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -175,6 +175,10 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
             return objeto ? 'verdadeiro' : 'falso';
         }
 
+        if (objeto instanceof ReferenciaMontao) {
+            objeto = this.resolverReferenciaMontao(objeto);
+        }
+
         if (objeto.valor instanceof ObjetoPadrao) return objeto.valor.paraTexto();
         if (objeto instanceof Literal || objeto instanceof Tupla) return objeto.paraTextoSaida();
         if (objeto instanceof ObjetoDeleguaClasse || objeto instanceof DeleguaFuncao)
@@ -608,7 +612,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         );
         await this.executar(declaracao.corpo);
 
-        if (retornoInicializacao instanceof ObjetoDeleguaClasse) {
+        if (retornoInicializacaoResolvido instanceof ObjetoDeleguaClasse) {
             const metodoFinalizar = retornoInicializacaoResolvido.classe.metodos['finalizar'];
             if (metodoFinalizar) {
                 const chamavel = metodoFinalizar.funcaoPorMetodoDeClasse(
@@ -1276,6 +1280,20 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         if (objeto.constructor === Object) {
             objeto[expressao.nome.lexema] = valorResolvido;
         }
+    }
+
+    /**
+     * Instâncias de classes em Delégua são passadas por referência, portanto, são
+     * armazenadas no montão.
+     */
+    override async visitarExpressaoDeChamada(expressao: Chamada): Promise<any> {
+        const resultado = await super.visitarExpressaoDeChamada(expressao);
+        if (resultado instanceof ObjetoDeleguaClasse) {
+            const enderecoMontao = this.montao.adicionarReferencia(resultado);
+            this.pilhaEscoposExecucao.registrarReferenciaMontao(enderecoMontao);
+            return new ReferenciaMontao(enderecoMontao);
+        }
+        return resultado;
     }
 
     /**

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -2597,6 +2597,60 @@ describe('Interpretador', () => {
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(1);
                 });
+
+                it('Semântica de referência - duas variáveis apontam para a mesma instância', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'classe Contador {',
+                            '  valor: numero',
+                            '  construtor() {',
+                            '    isto.valor = 0',
+                            '  }',
+                            '  incrementar() {',
+                            '    isto.valor += 1',
+                            '  }',
+                            '}',
+                            'var a = Contador()',
+                            'var b = a',
+                            'b.incrementar()',
+                            'escreva(a.valor)',
+                        ],
+                        -1
+                    );
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('1');
+                });
+
+                it('Instância retornada de função preserva referência no montão', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'classe Pessoa {',
+                            '  nome: texto',
+                            '  construtor(nome) {',
+                            '    isto.nome = nome',
+                            '  }',
+                            '}',
+                            'funcao criarPessoa(nome) {',
+                            '  retorna Pessoa(nome)',
+                            '}',
+                            'var p = criarPessoa("Maria")',
+                            'escreva(p.nome)',
+                        ],
+                        -1
+                    );
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('Maria');
+                });
             });
 
             describe('Declaração e chamada de funções', () => {


### PR DESCRIPTION
Para o correto funcionamento por referências, classes precisam ser instanciadas no montão, ao invés de valores na pilha de escopos de execução.