### PR TITLE
Tipagem explícita em Pituguês.

### DIFF
--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -1026,50 +1026,25 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
                                 );
                             }
 
-                            // Valida todos os retornos do corpo da função, não apenas o primeiro.
-                            const retornosFuncao = buscarRetornos(funcaoConstruto.corpo) as Retorna[];
+                            const funcaoContemRetorno = funcaoConstruto.corpo.find(
+                                (c) => c instanceof Retorna
+                            ) as Retorna;
 
-                            for (const retorno of retornosFuncao) {
-                                if (!retorno || !retorno.valor) {
-                                    continue;
-                                }
-
-                                // Tenta obter o tipo da expressão de retorno de forma semântica.
-                                let tipoValor: string | undefined;
-                                if (typeof (this as any).obterTipoExpressao === 'function') {
-                                    tipoValor = (this as any).obterTipoExpressao(retorno.valor);
-                                } else {
-                                    // Fallback para comportamento anterior quando não houver suporte semântico,
-                                    // tomando cuidado com expressões que não possuem a propriedade `valor`.
-                                    const expressao: any = retorno.valor as any;
-                                    if (expressao && Object.prototype.hasOwnProperty.call(expressao, 'valor')) {
-                                        tipoValor = typeof expressao.valor;
+                            if (funcaoContemRetorno && funcaoContemRetorno.valor) {
+                                const tipoValor = typeof funcaoContemRetorno.valor.valor;
+                                if (!['qualquer'].includes(tipoRetornoFuncao)) {
+                                    if (tipoValor === 'string' && tipoRetornoFuncao !== 'texto') {
+                                        this.erro(
+                                            declaracao.simbolo,
+                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                        );
                                     }
-                                }
-
-                                if (!tipoValor || ['qualquer'].includes(tipoRetornoFuncao)) {
-                                    continue;
-                                }
-
-                                // Normaliza tipos possíveis (tanto de JS quanto do dialeto) para a checagem.
-                                const tipoTexto = ['texto', 'string'];
-                                const tiposNumero = ['inteiro', 'real', 'número', 'number'];
-
-                                if (tipoTexto.includes(tipoValor) && tipoRetornoFuncao !== 'texto') {
-                                    this.erro(
-                                        declaracao.simbolo,
-                                        `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
-                                    );
-                                }
-
-                                if (
-                                    tiposNumero.includes(tipoValor) &&
-                                    !['inteiro', 'real', 'número'].includes(tipoRetornoFuncao)
-                                ) {
-                                    this.erro(
-                                        declaracao.simbolo,
-                                        `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
-                                    );
+                                    if (tipoValor === 'number' && !['inteiro', 'real', 'número'].includes(tipoRetornoFuncao)) {
+                                        this.erro(
+                                            declaracao.simbolo,
+                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -1026,25 +1026,50 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
                                 );
                             }
 
-                            const funcaoContemRetorno = funcaoConstruto.corpo.find(
-                                (c) => c instanceof Retorna
-                            ) as Retorna;
+                            // Valida todos os retornos do corpo da função, não apenas o primeiro.
+                            const retornosFuncao = buscarRetornos(funcaoConstruto.corpo) as Retorna[];
 
-                            if (funcaoContemRetorno && funcaoContemRetorno.valor) {
-                                const tipoValor = typeof funcaoContemRetorno.valor.valor;
-                                if (!['qualquer'].includes(tipoRetornoFuncao)) {
-                                    if (tipoValor === 'string' && tipoRetornoFuncao !== 'texto') {
-                                        this.erro(
-                                            declaracao.simbolo,
-                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
-                                        );
+                            for (const retorno of retornosFuncao) {
+                                if (!retorno || !retorno.valor) {
+                                    continue;
+                                }
+
+                                // Tenta obter o tipo da expressão de retorno de forma semântica.
+                                let tipoValor: string | undefined;
+                                if (typeof (this as any).obterTipoExpressao === 'function') {
+                                    tipoValor = (this as any).obterTipoExpressao(retorno.valor);
+                                } else {
+                                    // Fallback para comportamento anterior quando não houver suporte semântico,
+                                    // tomando cuidado com expressões que não possuem a propriedade `valor`.
+                                    const expressao: any = retorno.valor as any;
+                                    if (expressao && Object.prototype.hasOwnProperty.call(expressao, 'valor')) {
+                                        tipoValor = typeof expressao.valor;
                                     }
-                                    if (tipoValor === 'number' && !['inteiro', 'real', 'número'].includes(tipoRetornoFuncao)) {
-                                        this.erro(
-                                            declaracao.simbolo,
-                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
-                                        );
-                                    }
+                                }
+
+                                if (!tipoValor || ['qualquer'].includes(tipoRetornoFuncao)) {
+                                    continue;
+                                }
+
+                                // Normaliza tipos possíveis (tanto de JS quanto do dialeto) para a checagem.
+                                const tipoTexto = ['texto', 'string'];
+                                const tiposNumero = ['inteiro', 'real', 'número', 'number'];
+
+                                if (tipoTexto.includes(tipoValor) && tipoRetornoFuncao !== 'texto') {
+                                    this.erro(
+                                        declaracao.simbolo,
+                                        `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                    );
+                                }
+
+                                if (
+                                    tiposNumero.includes(tipoValor) &&
+                                    !['inteiro', 'real', 'número'].includes(tipoRetornoFuncao)
+                                ) {
+                                    this.erro(
+                                        declaracao.simbolo,
+                                        `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                    );
                                 }
                             }
                         }

--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -601,6 +601,11 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
             this.verificarChamada(expressao);
             return;
         }
+
+        if (expressao instanceof Variavel) {
+            this.verificarVariavel(expressao);
+            return;
+        }
     }
 
     private verificarBinario(binario: Binario): Promise<void> {

--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -1088,7 +1088,9 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
         }
 
         let tipoInferido = declaracao.tipo;
-        if (!tipoInferido && declaracao.inicializador) {
+        // Se o tipo é o padrão implícito 'qualquer', tenta inferir um tipo mais específico
+        // a partir do inicializador. Para 'qualquer' explícito, apenas sugerimos mais abaixo.
+        if (tipoInferido === 'qualquer' && !declaracao.tipoExplicito && declaracao.inicializador) {
             tipoInferido = this.obterTipoExpressao(declaracao.inicializador);
         }
 

--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -581,6 +581,28 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
         return Promise.resolve();
     }
 
+    private verificarExpressao(expressao: Construto): void {
+        if (expressao instanceof Agrupamento) {
+            this.verificarExpressao(expressao.expressao);
+            return;
+        }
+
+        if (expressao instanceof Binario) {
+            this.verificarBinario(expressao);
+            return;
+        }
+
+        if (expressao instanceof Logico) {
+            this.verificarLogico(expressao);
+            return;
+        }
+
+        if (expressao instanceof Chamada) {
+            this.verificarChamada(expressao);
+            return;
+        }
+    }
+
     private verificarBinario(binario: Binario): Promise<void> {
         this.verificarExistenciaConstruto(binario.direita);
         this.verificarExistenciaConstruto(binario.esquerda);
@@ -813,10 +835,19 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
         switch (chamada.entidadeChamada.constructor) {
             case Variavel:
                 let entidadeChamadaVariavel = chamada.entidadeChamada as Variavel;
-                if (!this.funcoes[entidadeChamadaVariavel.simbolo.lexema]) {
+                const nomeFuncao = entidadeChamadaVariavel.simbolo.lexema;
+
+                const funcoesBuiltIn = ['inteiro', 'real', 'número', 'texto', 'leia', 'escreva', 'tipo'];
+
+                const pareceSerClasse = nomeFuncao[0] === nomeFuncao[0].toUpperCase();
+
+                if (!funcoesBuiltIn.includes(nomeFuncao) &&
+                    !pareceSerClasse &&
+                    !this.funcoes[nomeFuncao] &&
+                    !this.gerenciadorEscopos.buscar(nomeFuncao)) {
                     this.erro(
                         entidadeChamadaVariavel.simbolo,
-                        `Chamada da função '${entidadeChamadaVariavel.simbolo.lexema}' não existe.`
+                        `Chamada da função '${nomeFuncao}' não existe.`
                     );
                 }
                 break;
@@ -929,6 +960,7 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
 
         if (declaracao.inicializador) {
             this.marcarVariaveisUsadasEmExpressao(declaracao.inicializador);
+            this.verificarExpressao(declaracao.inicializador);
         }
 
         const constanteCorrespondente = this.gerenciadorEscopos.buscarNoEscopoAtual(
@@ -961,11 +993,63 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
 
     override visitarDeclaracaoVar(declaracao: Var): Promise<any> {
         this.verificarTipoAtribuido(declaracao);
-        let valorInicializador: any = undefined;
 
         if (declaracao.inicializador) {
             this.marcarVariaveisUsadasEmExpressao(declaracao.inicializador);
+            this.verificarExpressao(declaracao.inicializador);
 
+            switch (declaracao.inicializador.constructor) {
+                case FuncaoConstruto:
+                    const funcaoConstruto = declaracao.inicializador as FuncaoConstruto;
+                    if (funcaoConstruto.parametros.length >= 255) {
+                        this.erro(
+                            declaracao.simbolo,
+                            'Função não pode ter mais de 255 parâmetros.'
+                        );
+                    }
+                    if (funcaoConstruto.tipo) {
+                        const tipoRetornoFuncao = funcaoConstruto.tipo;
+                        if (!['vazio', 'qualquer'].includes(tipoRetornoFuncao)) {
+                            const todosOsCaminhosRetornam = this.todosOsCaminhosRetornam(
+                                funcaoConstruto.corpo
+                            );
+
+                            if (!todosOsCaminhosRetornam) {
+                                this.erro(
+                                    declaracao.simbolo,
+                                    `Função '${declaracao.simbolo.lexema}' deve retornar '${tipoRetornoFuncao}' em todos os caminhos de execução.`
+                                );
+                            }
+
+                            const funcaoContemRetorno = funcaoConstruto.corpo.find(
+                                (c) => c instanceof Retorna
+                            ) as Retorna;
+
+                            if (funcaoContemRetorno && funcaoContemRetorno.valor) {
+                                const tipoValor = typeof funcaoContemRetorno.valor.valor;
+                                if (!['qualquer'].includes(tipoRetornoFuncao)) {
+                                    if (tipoValor === 'string' && tipoRetornoFuncao !== 'texto') {
+                                        this.erro(
+                                            declaracao.simbolo,
+                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                        );
+                                    }
+                                    if (tipoValor === 'number' && !['inteiro', 'real', 'número'].includes(tipoRetornoFuncao)) {
+                                        this.erro(
+                                            declaracao.simbolo,
+                                            `Esperado retorno do tipo '${tipoRetornoFuncao}' dentro da função.`
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        let valorInicializador: any = undefined;
+        if (declaracao.inicializador) {
             if (declaracao.inicializador.hasOwnProperty('valor')) {
                 valorInicializador = (declaracao.inicializador as any).valor;
             } else {
@@ -973,9 +1057,32 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
             }
         }
 
+        let tipoInferido = declaracao.tipo;
+        if (!tipoInferido && declaracao.inicializador) {
+            tipoInferido = this.obterTipoExpressao(declaracao.inicializador);
+        }
+
+        if (declaracao.tipoExplicito && declaracao.tipoOriginal === 'qualquer' && declaracao.inicializador) {
+            const tipoMelhor = this.obterTipoExpressao(declaracao.inicializador);
+            if (tipoMelhor && tipoMelhor !== 'qualquer') {
+                this.sugestao(
+                    declaracao.simbolo,
+                    'Um tipo melhor pode ser inferido.',
+                    [{
+                        titulo: `Alterar tipo para '${tipoMelhor}'`,
+                        textoOriginal: 'qualquer',
+                        textoSubstituto: tipoMelhor,
+                        linha: declaracao.simbolo.linha,
+                        colunaInicio: declaracao.simbolo.colunaInicio,
+                        colunaFim: declaracao.simbolo.colunaFim,
+                    }]
+                );
+            }
+        }
+
         const variavel: EscopoVariavel = {
             nome: declaracao.simbolo.lexema,
-            tipo: declaracao.tipo || 'qualquer',
+            tipo: tipoInferido || 'qualquer',
             imutavel: false,
             valor: valorInicializador,
             inicializada: declaracao.inicializador !== null && declaracao.inicializador !== undefined,

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -291,6 +291,14 @@ export class AvaliadorSintaticoPitugues
             'Esperado nome de variável.'
         );
 
+        let tipo: string = 'qualquer';
+        let tipoExplicito: boolean = false;
+        if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
+            tipo = this.verificarDefinicaoTipoAtual();
+            tipoExplicito = true;
+            this.avancarEDevolverAnterior();
+        }
+
         this.consumir(tiposDeSimbolos.IGUAL, "Esperado '=' após identificador.");
 
         if (this.estaNoFinal()) {
@@ -301,14 +309,16 @@ export class AvaliadorSintaticoPitugues
         }
 
         const valor = await this.expressao();
-        const tipo = this.logicaComumInferenciaTiposVariaveisEConstantes(valor, 'qualquer');
+        if (!tipoExplicito) {
+            tipo = this.logicaComumInferenciaTiposVariaveisEConstantes(valor, 'qualquer');
+        }
 
         this.pilhaEscopos.definirInformacoesVariavel(
             identificador.lexema,
             new InformacaoElementoSintatico(identificador.lexema, tipo)
         );
 
-        return new Var(identificador, valor, tipo);
+        return new Var(identificador, valor, tipo, tipoExplicito);
     }
 
     private temPadraoMultiplaAtribuicao(): boolean {
@@ -2152,6 +2162,10 @@ export class AvaliadorSintaticoPitugues
             const proximoSimbolo = this.simbolos[this.atual + 1];
             if (proximoSimbolo && proximoSimbolo.tipo === tiposDeSimbolos.IGUAL) {
                 if (!this.variavelJaDeclarada(simboloAtual.lexema)) return this.declaracaoImplicitaVariaveis();
+            }
+
+            if (proximoSimbolo && proximoSimbolo.tipo === tiposDeSimbolos.DOIS_PONTOS) {
+                return this.declaracaoImplicitaVariaveis();
             }
         }
 

--- a/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
@@ -498,7 +498,13 @@ describe('Analisador semântico', () => {
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
 
                     expect(retornoAnalisadorSemantico).toBeTruthy();
-                    expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+                    expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
+                    expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain(
+                        'Operação entre tipos diferentes'
+                    );
+                    expect(retornoAnalisadorSemantico.diagnosticos[1].mensagem).toContain(
+                        'foi declarada mas nunca usada'
+                    );
                 });
             });
         });

--- a/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
@@ -499,11 +499,12 @@ describe('Analisador semântico', () => {
 
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
-                    expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain(
-                        'Operação entre tipos diferentes'
-                    );
-                    expect(retornoAnalisadorSemantico.diagnosticos[1].mensagem).toContain(
-                        'foi declarada mas nunca usada'
+                    const mensagens = retornoAnalisadorSemantico.diagnosticos.map((d: any) => d.mensagem);
+                    expect(mensagens).toEqual(
+                        expect.arrayContaining([
+                            expect.stringContaining('Operação entre tipos diferentes'),
+                            expect.stringContaining('foi declarada mas nunca usada'),
+                        ])
                     );
                 });
             });

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -40,6 +40,105 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
+                it('Atribuição com anotação de tipo texto[]', async () => {
+                    const retornoLexador = lexador.mapear([
+                        "t: texto[] = ['gggg', 'vvv']",
+                        'escreva(t)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe("['gggg', 'vvv']");
+                });
+
+                it('Atribuição com anotação de tipo inteiro', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'n: inteiro = 42',
+                        'escreva(n)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('42');
+                });
+
+                it('Variável sem tipo explícito aceita qualquer valor', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'y = "hello"',
+                        'y = 10',
+                        'escreva(y)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('10');
+                });
+
+                it('Reatribuição com mesmo tipo funciona normalmente', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'z: inteiro = 5',
+                        'z = 42',
+                        'escreva(z)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('42');
+                });
+
+                it('Tipos numéricos são compatíveis entre si', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'n: número = 10',
+                        'n = 3.14',
+                        'escreva(n)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                });
+
                 describe('Compreensão de listas', () => {
                     it('Trivial', async () => {
                         const retornoLexador = lexador.mapear(
@@ -3259,6 +3358,36 @@ describe('Interpretador (Pituguês)', () => {
         });
 
         describe('Cenários de falha', () => {
+            describe('Tipagem explícita', () => {
+                it('Erro ao atribuir número a variável do tipo texto', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'nome: texto = "Fernando"',
+                        'nome = 10',
+                    ], -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe(
+                        "Variável 'nome' é do tipo 'texto' e não pode receber um valor do tipo 'número'."
+                    );
+                });
+
+                it('Erro ao atribuir texto a variável do tipo inteiro', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'idade: inteiro = 25',
+                        'idade = "vinte"',
+                    ], -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe(
+                        "Variável 'idade' é do tipo 'inteiro' e não pode receber um valor do tipo 'texto'."
+                    );
+                });
+            });
+
             describe('Acesso a variáveis e objetos', () => {
                 it('Acesso a elementos de vetor', async () => {
                     const retornoLexador = lexador.mapear(['a = [1, 2, 3]\nescreva(a[4])'], -1);


### PR DESCRIPTION
Pituguês passa a aceitar tipagem explícita. Por exemplo:

```py
t: texto[] = ['gggg', 'vvv']
escreva(t)
```