### PR TITLE
Implementação de correções nas funções nativas `todos()` e `todosEmCondicao()`

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -3672,9 +3672,15 @@ export class AvaliadorSintatico
             ])
         );
         this.pilhaEscopos.definirInformacoesVariavel(
+            'todos',
+            new InformacaoElementoSintatico('todos', 'lógico', true, [
+                new InformacaoElementoSintatico('iteravel', 'qualquer')
+            ])
+        );
+        this.pilhaEscopos.definirInformacoesVariavel(
             'todosEmCondicao',
             new InformacaoElementoSintatico('todosEmCondicao', 'lógico', true, [
-                new InformacaoElementoSintatico('vetor', 'qualquer[]'),
+                new InformacaoElementoSintatico('iteravel', 'qualquer'),
                 new InformacaoElementoSintatico('funcaoCondicional', 'função'),
             ])
         );

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -2396,9 +2396,15 @@ export class AvaliadorSintaticoPitugues
             ])
         );
         this.pilhaEscopos.definirInformacoesVariavel(
+            'todos',
+            new InformacaoElementoSintatico('todos', 'lógico', true, [
+                new InformacaoElementoSintatico('iteravel', 'qualquer')
+            ])
+        );
+        this.pilhaEscopos.definirInformacoesVariavel(
             'todosEmCondicao',
             new InformacaoElementoSintatico('todosEmCondicao', 'lógico', true, [
-                new InformacaoElementoSintatico('vetor', 'qualquer[]'),
+                new InformacaoElementoSintatico('iteravel', 'qualquer'),
                 new InformacaoElementoSintatico('funcaoCondicional', 'função'),
             ])
         );

--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -1614,9 +1614,12 @@ export async function todosEmCondicao(
     }
 
     const valorFuncao = interpretador.resolverValor(funcaoCondicional);
-    const naoEhUmaFuncao = !['DeleguaFuncao', 'FuncaoPadrao'].includes(valorFuncao.constructor.name);
 
-    if (!valorFuncao || naoEhUmaFuncao) {
+    const ehFuncaoValida =
+        valorFuncao instanceof DeleguaFuncao ||
+        valorFuncao instanceof FuncaoPadrao;
+
+    if (!ehFuncaoValida) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {

--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -1534,62 +1534,95 @@ export async function texto(
 }
 
 /**
+ * Retorna verdadeiro se todos os elementos do iterável forem truly.
+ * @param {InterpretadorInterface} interpretador A instância do interpretador.
+ * @param {VariavelInterface | any} iteravel O primeiro parâmetro, qualquer dado que seja iterável (vetores, tuplas, dicionários etc.).
+ * @returns {Promise<boolean>} Verdadeiro, se todos os valores do iterável forem Truly.
+ */
+export async function todos(
+    interpretador: InterpretadorInterface,
+    iteravel: VariavelInterface | any
+): Promise<boolean> {
+    const valorIteravel = interpretador.resolverValor(iteravel);
+    const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
+    const ehIteravelNativo = valorIteravel && typeof valorIteravel[Symbol.iterator] === 'function';
+
+    if (!ehIteravelNativo && !ehObjetoOuDicionario) {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                {
+                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                    linha: interpretador.linhaDeclaracaoAtual,
+                } as SimboloInterface,
+                'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
+            )
+        );
+    }
+
+    const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
+
+    for (const valor of itens) {
+        const valorResolvido = interpretador.resolverValor(valor);
+        if (!interpretador.eVerdadeiro(valorResolvido)) return false;
+    }
+
+    return true;
+}
+
+/**
  * Retorna verdadeiro se todos os elementos do primeiro parâmetro retornam verdadeiro ao
  * serem aplicados como argumentos da função passada como segundo parâmetro.
  * @param {InterpretadorInterface} interpretador A instância do interpretador.
- * @param {VariavelInterface | any} vetor O primeiro parâmetro, um vetor.
+ * @param {VariavelInterface | any} iteravel O primeiro parâmetro, qualquer dado que seja iterável (vetores, tuplas, dicionários etc.).
  * @param {VariavelInterface | any} funcaoCondicional A função que será executada com cada
- *                                  valor do vetor passado como primeiro parâmetro.
- * @returns {Promise<boolean>} Verdadeiro, se todos os valores do vetor fazem a função passada
+ *                                  valor do iterável passado como primeiro parâmetro.
+ * @returns {Promise<boolean>} Verdadeiro, se todos os valores do iterável fazem a função passada
  *                             por parâmetro devolver verdadeiro, ou falso em caso contrário.
  */
 export async function todosEmCondicao(
     interpretador: InterpretadorInterface,
-    vetor: VariavelInterface | any,
+    iteravel: VariavelInterface | any,
     funcaoCondicional: VariavelInterface | any
 ): Promise<boolean> {
-    if (vetor === null || vetor === undefined)
-        return Promise.reject(
-            new ErroEmTempoDeExecucao(
-                {
-                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
-                    linha: interpretador.linhaDeclaracaoAtual,
-                } as SimboloInterface,
-                'Parâmetro inválido. O primeiro parâmetro da função todosEmCondicao() não pode ser nulo.'
-            )
-        );
+    const valorIteravel = interpretador.resolverValor(iteravel);
 
-    const valorVetor = vetor.hasOwnProperty('valor') ? vetor.valor : vetor;
-    const valorFuncaoCondicional = funcaoCondicional.hasOwnProperty('valor')
-        ? funcaoCondicional.valor
-        : funcaoCondicional;
-    if (!Array.isArray(valorVetor)) {
+    const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
+    const ehIteravelNativo = valorIteravel && typeof valorIteravel[Symbol.iterator] === 'function';
+
+    if (!ehIteravelNativo && !ehObjetoOuDicionario) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {
                     hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
                     linha: interpretador.linhaDeclaracaoAtual,
                 } as SimboloInterface,
-                'Parâmetro inválido. O primeiro parâmetro da função todosEmCondicao() deve ser um vetor.'
+                'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
             )
         );
     }
 
-    if (valorFuncaoCondicional.constructor !== DeleguaFuncao) {
+    const valorFuncao = interpretador.resolverValor(funcaoCondicional);
+    const naoEhUmaFuncao = !['DeleguaFuncao', 'FuncaoPadrao'].includes(valorFuncao.constructor.name);
+
+    if (!valorFuncao || naoEhUmaFuncao) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {
                     hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
                     linha: interpretador.linhaDeclaracaoAtual,
                 } as SimboloInterface,
-                'Parâmetro inválido. O segundo parâmetro da função todosEmCondicao() deve ser uma função.'
+                'Parâmetro inválido. O segundo parâmetro deve ser uma função.'
             )
         );
     }
 
-    for (let indice = 0; indice < valorVetor.length; ++indice) {
-        if (!(await valorFuncaoCondicional.chamar(interpretador, [valorVetor[indice]])))
-            return false;
+    const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
+
+    for (const valor of itens) {
+        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor]);
+        const resultadoResolvido = interpretador.resolverValor(resultadoChamada);
+
+        if (!interpretador.eVerdadeiro(resultadoResolvido)) return false;
     }
 
     return true;

--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -1596,6 +1596,11 @@ export async function todosEmCondicao(
     iteravel: VariavelInterface | any,
     funcaoCondicional: VariavelInterface | any
 ): Promise<boolean> {
+    const simboloChamada = {
+        linha: interpretador.linhaDeclaracaoAtual,
+        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+    } as SimboloInterface;
+
     const valorIteravel = interpretador.resolverValor(iteravel);
 
     const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
@@ -1634,7 +1639,7 @@ export async function todosEmCondicao(
     const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
 
     for (const valor of itens) {
-        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor]);
+        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor], simboloChamada);
         const resultadoResolvido = interpretador.resolverValor(resultadoChamada);
 
         if (!interpretador.eVerdadeiro(resultadoResolvido)) return false;

--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -1378,6 +1378,11 @@ export async function todos_em_condicao(
     iteravel: VariavelInterface | any,
     funcaoCondicional: VariavelInterface | any
 ): Promise<boolean> {
+    const simboloChamada = {
+        linha: interpretador.linhaDeclaracaoAtual,
+        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+    } as SimboloInterface;
+
     const valorIteravel = interpretador.resolverValor(iteravel);
 
     const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
@@ -1413,7 +1418,7 @@ export async function todos_em_condicao(
     const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
 
     for (const valor of itens) {
-        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor]);
+        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor], simboloChamada);
         const resultadoResolvido = interpretador.resolverValor(resultadoChamada);
 
         if (!interpretador.eVerdadeiro(resultadoResolvido)) return false;

--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -1396,7 +1396,7 @@ export async function todos_em_condicao(
     }
 
     const valorFuncao = interpretador.resolverValor(funcaoCondicional);
-    const naoEhUmaFuncao = !['DeleguaFuncao', 'FuncaoPadrao'].includes(valorFuncao.constructor.name);
+    const naoEhUmaFuncao = !(valorFuncao instanceof DeleguaFuncao || valorFuncao instanceof FuncaoPadrao);
 
     if (!valorFuncao || naoEhUmaFuncao) {
         return Promise.reject(

--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -1327,62 +1327,95 @@ export async function texto(
 }
 
 /**
+ * Retorna verdadeiro se todos os elementos do iterável forem truly.
+ * @param {InterpretadorInterface} interpretador A instância do interpretador.
+ * @param {VariavelInterface | any} iteravel O primeiro parâmetro, qualquer dado que seja iterável (vetores, tuplas, dicionários etc.).
+ * @returns {Promise<boolean>} Verdadeiro, se todos os valores do iterável forem Truly.
+ */
+export async function todos(
+    interpretador: InterpretadorInterface,
+    iteravel: VariavelInterface | any
+): Promise<boolean> {
+    const valorIteravel = interpretador.resolverValor(iteravel);
+    const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
+    const ehIteravelNativo = valorIteravel && typeof valorIteravel[Symbol.iterator] === 'function';
+
+    if (!ehIteravelNativo && !ehObjetoOuDicionario) {
+        return Promise.reject(
+            new ErroEmTempoDeExecucao(
+                {
+                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+                    linha: interpretador.linhaDeclaracaoAtual,
+                } as SimboloInterface,
+                'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
+            )
+        );
+    }
+
+    const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
+
+    for (const valor of itens) {
+        const valorResolvido = interpretador.resolverValor(valor);
+        if (!interpretador.eVerdadeiro(valorResolvido)) return false;
+    }
+
+    return true;
+}
+
+/**
  * Retorna verdadeiro se todos os elementos do primeiro parâmetro retornam verdadeiro ao
  * serem aplicados como argumentos da função passada como segundo parâmetro.
  * @param {InterpretadorInterface} interpretador A instância do interpretador.
- * @param {VariavelInterface | any} vetor O primeiro parâmetro, um vetor.
+ * @param {VariavelInterface | any} iteravel O primeiro parâmetro, qualquer dado que seja iterável (vetores, tuplas, dicionários etc.).
  * @param {VariavelInterface | any} funcaoCondicional A função que será executada com cada
  *                                  valor do vetor passado como primeiro parâmetro.
- * @returns {Promise<boolean>} Verdadeiro, se todos os valores do vetor fazem a função passada
+ * @returns {Promise<boolean>} Verdadeiro, se todos os valores do iterável fazem a função passada
  *                             por parâmetro devolver verdadeiro, ou falso em caso contrário.
  */
 export async function todos_em_condicao(
     interpretador: InterpretadorInterface,
-    vetor: VariavelInterface | any,
+    iteravel: VariavelInterface | any,
     funcaoCondicional: VariavelInterface | any
 ): Promise<boolean> {
-    if (vetor === null || vetor === undefined)
-        return Promise.reject(
-            new ErroEmTempoDeExecucao(
-                {
-                    hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
-                    linha: interpretador.linhaDeclaracaoAtual,
-                } as SimboloInterface,
-                'Parâmetro inválido. O primeiro parâmetro da função todosEmCondicao() não pode ser nulo.'
-            )
-        );
+    const valorIteravel = interpretador.resolverValor(iteravel);
 
-    const valorVetor = vetor.hasOwnProperty('valor') ? vetor.valor : vetor;
-    const valorFuncaoCondicional = funcaoCondicional.hasOwnProperty('valor')
-        ? funcaoCondicional.valor
-        : funcaoCondicional;
-    if (!Array.isArray(valorVetor)) {
+    const ehObjetoOuDicionario = valorIteravel && typeof valorIteravel === 'object' && !Array.isArray(valorIteravel);
+    const ehIteravelNativo = valorIteravel && typeof valorIteravel[Symbol.iterator] === 'function';
+
+    if (!ehIteravelNativo && !ehObjetoOuDicionario) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {
                     hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
                     linha: interpretador.linhaDeclaracaoAtual,
                 } as SimboloInterface,
-                'Parâmetro inválido. O primeiro parâmetro da função todosEmCondicao() deve ser um vetor.'
+                'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
             )
         );
     }
 
-    if (valorFuncaoCondicional.constructor.name !== 'DeleguaFuncao') {
+    const valorFuncao = interpretador.resolverValor(funcaoCondicional);
+    const naoEhUmaFuncao = !['DeleguaFuncao', 'FuncaoPadrao'].includes(valorFuncao.constructor.name);
+
+    if (!valorFuncao || naoEhUmaFuncao) {
         return Promise.reject(
             new ErroEmTempoDeExecucao(
                 {
                     hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
                     linha: interpretador.linhaDeclaracaoAtual,
                 } as SimboloInterface,
-                'Parâmetro inválido. O segundo parâmetro da função todosEmCondicao() deve ser uma função.'
+                'Parâmetro inválido. O segundo parâmetro deve ser uma função.'
             )
         );
     }
 
-    for (let indice = 0; indice < valorVetor.length; ++indice) {
-        if (!(await valorFuncaoCondicional.chamar(interpretador, [valorVetor[indice]])))
-            return false;
+    const itens = ehIteravelNativo ? valorIteravel : Object.values(valorIteravel);
+
+    for (const valor of itens) {
+        const resultadoChamada = await valorFuncao.chamar(interpretador, [valor]);
+        const resultadoResolvido = interpretador.resolverValor(resultadoChamada);
+
+        if (!interpretador.eVerdadeiro(resultadoResolvido)) return false;
     }
 
     return true;

--- a/fontes/interpretador/comum.ts
+++ b/fontes/interpretador/comum.ts
@@ -91,7 +91,7 @@ export function carregarBibliotecasGlobais(pilhaEscoposExecucao: PilhaEscoposExe
 
     pilhaEscoposExecucao.definirVariavel(
         'todos',
-        new FuncaoPadrao(2, bibliotecaGlobal.todosEmCondicao)
+        new FuncaoPadrao(2, bibliotecaGlobal.todos)
     );
 
     pilhaEscoposExecucao.definirVariavel(

--- a/fontes/interpretador/comum.ts
+++ b/fontes/interpretador/comum.ts
@@ -91,7 +91,7 @@ export function carregarBibliotecasGlobais(pilhaEscoposExecucao: PilhaEscoposExe
 
     pilhaEscoposExecucao.definirVariavel(
         'todos',
-        new FuncaoPadrao(2, bibliotecaGlobal.todos)
+        new FuncaoPadrao(1, bibliotecaGlobal.todos)
     );
 
     pilhaEscoposExecucao.definirVariavel(

--- a/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
@@ -140,14 +140,14 @@ describe('biblioteca-global (pituguês)', () => {
         it('rejeita quando primeiro parâmetro for nulo', async () => {
             const interpretador = criarInterpretadorMock();
             await expect(todos_em_condicao(interpretador, null as any, {} as any)).rejects.toMatchObject({
-                mensagem: 'Parâmetro inválido. O primeiro parâmetro da função todosEmCondicao() não pode ser nulo.',
+                mensagem: 'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.',
             });
         });
 
         it('rejeita quando segundo parâmetro não for função DeleguaFuncao', async () => {
             const interpretador = criarInterpretadorMock();
             await expect(todos_em_condicao(interpretador, [1, 2], {} as any)).rejects.toMatchObject({
-                mensagem: 'Parâmetro inválido. O segundo parâmetro da função todosEmCondicao() deve ser uma função.',
+                mensagem: 'Parâmetro inválido. O segundo parâmetro deve ser uma função.',
             });
         });
 

--- a/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
@@ -154,36 +154,24 @@ describe('biblioteca-global (pituguês)', () => {
         it('retorna verdadeiro quando todos satisfazem condição', async () => {
             const interpretador = criarInterpretadorMock();
 
-            class DeleguaFuncao {
-                private fn: (...args: any[]) => any;
-                constructor(fn: (...args: any[]) => any) {
-                    this.fn = fn;
-                }
-                async chamar(_interpretador: any, argumentos: any[]) {
-                    return this.fn(...argumentos);
-                }
-            }
+            interpretador.resolverValor = jest.fn(v => v);
+            interpretador.eVerdadeiro = jest.fn(v => !!v);
 
-            const func = new DeleguaFuncao((n: number) => n % 2 === 0);
-            const resultado = await todos_em_condicao(interpretador, [2, 4, 6], func as any);
+            const func = new FuncaoPadrao(1, (_interpretador: any, n: number) => n % 2 === 0);
+
+            const resultado = await todos_em_condicao(interpretador, [2, 4, 6], func);
             expect(resultado).toBe(true);
         });
 
         it('retorna falso quando pelo menos um elemento não satisfaz condição', async () => {
             const interpretador = criarInterpretadorMock();
 
-            class DeleguaFuncao {
-                private fn: (...args: any[]) => any;
-                constructor(fn: (...args: any[]) => any) {
-                    this.fn = fn;
-                }
-                async chamar(_interpretador: any, argumentos: any[]) {
-                    return this.fn(...argumentos);
-                }
-            }
+            interpretador.resolverValor = jest.fn(v => v);
+            interpretador.eVerdadeiro = jest.fn(v => !!v);
 
-            const func = new DeleguaFuncao((n: number) => n % 2 === 0);
-            const resultado = await todos_em_condicao(interpretador, [2, 3, 4], func as any);
+            const func = new FuncaoPadrao(1, (_interpretador: any, n: number) => n % 2 === 0);
+
+            const resultado = await todos_em_condicao(interpretador, [2, 3, 4], func);
             expect(resultado).toBe(false);
         });
     });

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -3129,6 +3129,145 @@ describe('Interpretador (Pituguês)', () => {
                 expect(_saidas[2]).toBe('vetor');
                 expect(_saidas[3]).toBe('dicionário');
             });
+
+            describe('todos()', () => {
+                it('Chama a função nativa "todos()" com iterável de dados Truly', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNumeros = [1, "Pituguês", verdadeiro]',
+                            'escreva(todos(listaDeNumeros))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe('verdadeiro');
+                });
+
+                it('Chama a função nativa "todos()" com um objeto', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
+                            'escreva(todos(objetoLegal))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe('verdadeiro');
+                });
+
+                it('Chama a função nativa "todos()" com um dicionário', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
+                            'escreva(todos(objetoLegal))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe('verdadeiro');
+                });
+
+                it('Chama a função nativa "todos()" com iterável de dados Falsy', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNumeros = [0, "", nulo, falso]',
+                            'escreva(todos(listaDeNumeros))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe('falso');
+                });
+            });
+
+            describe('todosEmCondicao()', () => {
+                it('Chama a função nativa "todosEmCondicao()" para verificar se os elementos do array são par.', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNumeros = [1, 2, 3, 4, 5]',
+                            'funcao eh_par(valor):',
+                            '    retorna valor % 2 == 0',
+                            'escreva(todosEmCondicao(listaDeNumeros, eh_par))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBe('falso');
+                });
+
+                it('Chama a função nativa "todosEmCondicao()" para verificar se todos os nomes começam com "V"', async () => {
+                    let _saida: string = '';
+
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNomes = ["Victor", "Verônica", "Vanessa"]',
+                            'funcao verificar_nomes(nome):',
+                            '    retorna nome[0] == "V"',
+                            'escreva(todosEmCondicao(listaDeNomes, verificar_nomes))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: any) => {
+                        _saida = saida;
+                    };
+
+                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(_saida).toBeTruthy();
+                    expect(_saida).toBe('verdadeiro');
+                });
+            });
         });
 
         it('termina_com - sufixo encontrado no final', async () => {
@@ -4131,6 +4270,46 @@ describe('Interpretador (Pituguês)', () => {
 
                 expect(retornoInterpretador.erros).toHaveLength(1);
                 expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('Divisão por zero não é permitida.');
+            });
+
+            describe('todos()', () => {
+                it('Chama a função nativa "todos()" passando dados que não são iteráveis', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNumeros = 67',
+                            'escreva(todos(listaDeNumeros))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain(
+                        'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
+                    );
+                });
+            });
+
+            describe('todosEmCondicao()', () => {
+                it('Chama a função nativa "todosEmCondicao()" passando dados que não são iteráveis', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'listaDeNumeros = 67',
+                            'funcao eh_par(valor):',
+                            '    retorna valor % 2 == 0',
+                            'escreva(todosEmCondicao(listaDeNumeros, eh_par))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain(
+                        'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
+                    );
+                });
             });
         });
 

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -1047,6 +1047,125 @@ describe('Interpretador', () => {
                     expect(_saida).toBeTruthy();
                     expect(_saida).toBe('[0, 2, 4, 6, 8]');
                 });
+
+                describe('todos()', () => {
+                    it('Chama a função nativa "todos()" com iterável de dados Truly', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var listaDeNumeros = [1, "Delégua", verdadeiro]',
+                                'escreva(todos(listaDeNumeros))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+
+                    it('Chama a função nativa "todos()" com um objeto', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var objetoLegal = { 1: "a", 2: "b", 3: "c" }',
+                                'escreva(todos(objetoLegal))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+
+                    it('Chama a função nativa "todos()" com iterável de dados Falsy', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var listaDeNumeros = [0, "", nulo, falso]',
+                                'escreva(todos(listaDeNumeros))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('falso');
+                    });
+                });
+
+                describe('todosEmCondicao()', () => {
+                    it('Chama a função nativa "todosEmCondicao()" para verificar se os elementos do array são par.', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var listaDeNumeros = [1, 2, 3, 4, 5]',
+                                'funcao ehPar(valor) {',
+                                '    retorna valor % 2 == 0',
+                                '}',
+                                'escreva(todosEmCondicao(listaDeNumeros, ehPar))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBe('falso');
+                    });
+
+                    it('Chama a função nativa "todosEmCondicao()" para verificar se todos os nomes começam com V', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var listaDeNomes = ["Victor", "Verônica", "Vanessa"]',
+                                'funcao verificar_nomes(nome) {',
+                                '    retorna nome[0] == "V"',
+                                '}',
+                                'escreva(todosEmCondicao(listaDeNomes, verificar_nomes))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+                });
             });
 
             describe('Conversões entre tipos', () => {
@@ -3928,6 +4047,47 @@ describe('Interpretador', () => {
                     expect(retornoInterpretador.erros).toHaveLength(1);
                     expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe(
                         'Não é possível modificar uma tupla. As tuplas são estruturas de dados imutáveis.'
+                    );
+                });
+            });
+
+            describe('todos()', () => {
+                it('Chama a função nativa "todos()" passando dados que não são iteráveis', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'var listaDeNumeros = 67',
+                            'escreva(todos(listaDeNumeros))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe(
+                        'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
+                    );
+                });
+            });
+
+            describe('todosEmCondicao()', () => {
+                it('Chama a função nativa "todosEmCondicao()" passando dados que não são iteráveis', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'var listaDeNumeros = 67',
+                            'funcao ehPar(valor) {',
+                            '    retorna valor % 2 == 0',
+                            '}',
+                            'escreva(todosEmCondicao(listaDeNumeros, ehPar))'
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain(
+                        'Parâmetro inválido. O primeiro parâmetro deve ser um iterável.'
                     );
                 });
             });


### PR DESCRIPTION
Este PR implementa as funções globais `todos()` e correções em `todosEmCondicao()`, atendendo à necessidade de verificação lógica de elementos em objetos iteráveis (vetores, tuplas e dicionários). Conforme discutido na issue #1097, as responsabilidades foram separadas para garantir clareza e consistência com o dialeto.

## Alterações Realizadas

- **Função `todos()`:** Agora responsável apenas por validar se todos os elementos de um iterável são Truly (equivalente ao `all()` do Python).
- **Função `todosEmCondicao()`:** Destinada a validar elementos com base em uma função de predicado (segundo parâmetro) obrigatoriamente fornecida.
- **Suporte a Dicionários:** Ambas as funções foram atualizadas para suportar objetos/dicionários, iterando sobre seus valores via `Object.values()`.

## Testes Unitários

Foram adicionados cenários de teste para:

- Verificação Truly/Falsy no iterável.
- Validação de funções condicionais.
- Tratamento de erros para parâmetros inválidos.

## Exemplo de Uso no Pituguês

```
# todos()
lista = [1, 2, 3]
escreva(todos(lista)) # verdadeiro

# todosEmCondicao()
funcao ehPar(valor):
    retorna valor % 2 == 0

escreva(todosEmCondicao([2, 4, 6], ehPar)) # verdadeiro
```

Closes #1097