### PR TITLE
[Pituguês] Implementação do parâmetro de passo (step) em fatiamento

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -908,22 +908,26 @@ export class AvaliadorSintaticoPitugues
 
                 expressao = new AcessoMetodoOuPropriedade(this.hashArquivo, expressao, nome);
             } else if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.COLCHETE_ESQUERDO)) {
-                let ehFatiamento = false;
-                let indiceInicio: Construto | null = null;
-                let indiceFim: Construto | null = null;
+                const inicio = !this.verificarTipoSimboloAtual(tiposDeSimbolos.DOIS_PONTOS)
+                    ? await this.expressao()
+                    : null;
 
-                if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.DOIS_PONTOS)) {
-                    indiceInicio = await this.expressao();
-                }
+                let ehFatiamento = false;
+                let fim: Construto | null = null;
+                let passo: Construto | null = null;
 
                 if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)) {
                     ehFatiamento = true;
 
-                    // Se o próximo não é ':', nem ']', então é o índice fim
-                    if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.DOIS_PONTOS) &&
-                        !this.verificarTipoSimboloAtual(tiposDeSimbolos.COLCHETE_DIREITO)) {
-                        indiceFim = await this.expressao();
-                    }
+                    if (
+                        !this.verificarTipoSimboloAtual(tiposDeSimbolos.DOIS_PONTOS)
+                        && !this.verificarTipoSimboloAtual(tiposDeSimbolos.COLCHETE_DIREITO)
+                    ) fim = await this.expressao();
+
+                    if (
+                        this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DOIS_PONTOS)
+                        && !this.verificarTipoSimboloAtual(tiposDeSimbolos.COLCHETE_DIREITO)
+                    ) passo = await this.expressao();
                 }
 
                 const simboloFechamento = this.consumir(
@@ -935,15 +939,16 @@ export class AvaliadorSintaticoPitugues
                     expressao = new AcessoIntervaloVariavel(
                         this.hashArquivo,
                         expressao,
-                        indiceInicio,
-                        indiceFim,
+                        inicio,
+                        fim,
+                        passo,
                         simboloFechamento
                     )
                 } else {
                     expressao = new AcessoIndiceVariavel(
                         this.hashArquivo,
                         expressao,
-                        indiceInicio,
+                        inicio,
                         simboloFechamento
                     );
                 }

--- a/fontes/construtos/acesso-intervalo-variavel.ts
+++ b/fontes/construtos/acesso-intervalo-variavel.ts
@@ -3,7 +3,7 @@ import { Construto } from './construto';
 
 /**
  * Construto para acesso de intervalos (fatiamento/slicing) em vetores.
- * Ex: vetor[1:4], vetor[1:], vetor[:3] ou vetor[:]
+ * Ex: vetor[1:4], vetor[1:4:2], vetor[1:], vetor[:3] ou vetor[:]
  */
 export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> implements Construto {
     linha: number;
@@ -13,6 +13,7 @@ export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> imple
     simboloFechamento: SimboloInterface<TTipoSimbolo>;
     indiceInicio: Construto | null;
     indiceFim: Construto | null;
+    indicePasso: Construto | null;
     tipo: string = 'qualquer';
 
     constructor(
@@ -20,6 +21,7 @@ export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> imple
         entidadeChamada: Construto,
         indiceInicio: Construto | null,
         indiceFim: Construto | null,
+        indicePasso: Construto | null,
         simboloFechamento: SimboloInterface<TTipoSimbolo>,
         tipo: string = 'qualquer'
     ) {
@@ -29,6 +31,7 @@ export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> imple
         this.entidadeChamada = entidadeChamada;
         this.indiceInicio = indiceInicio;
         this.indiceFim = indiceFim;
+        this.indicePasso = indicePasso;
         this.simboloFechamento = simboloFechamento;
         this.tipo = tipo;
     }
@@ -40,11 +43,13 @@ export class AcessoIntervaloVariavel<TTipoSimbolo extends string = string> imple
     paraTexto(): string {
         const inicio = this.indiceInicio ? this.indiceInicio.paraTexto() : 'sem-início';
         const fim = this.indiceFim ? this.indiceFim.paraTexto() : 'sem-fim';
+        const passo = this.indicePasso ? this.indicePasso.paraTexto() : 'sem-passo';
 
         return (
             `<acesso-índice-variável entidadeChamada=${this.entidadeChamada.paraTexto()} ` +
             `inicio=${inicio} ` +
             `fim=${fim}` +
+            `passo=${passo}` +
             `/>`
         );
     }

--- a/fontes/interpretador/dialetos/pitugues/comum.ts
+++ b/fontes/interpretador/dialetos/pitugues/comum.ts
@@ -431,9 +431,14 @@ export async function visitarExpressaoAcessoIntervaloVariavel(
     const objeto = interpretador.resolverValor(resultadoEntidade);
 
     let tamanho = 0;
+    let itens: any;
+    const ehTexto = typeof objeto === 'string';
+
     if (objeto instanceof TuplaN) {
+        itens = objeto.elementos;
         tamanho = objeto.elementos.length;
-    } else if (Array.isArray(objeto) || typeof objeto === 'string') {
+    } else if (Array.isArray(objeto) || ehTexto) {
+        itens = objeto;
         tamanho = objeto.length;
     } else {
         throw new ErroEmTempoDeExecucao(
@@ -443,26 +448,58 @@ export async function visitarExpressaoAcessoIntervaloVariavel(
         );
     }
 
-    let inicio = 0;
+    let passo = 1;
+    if (expressao.indicePasso) {
+        const resPasso = await interpretador.avaliar(expressao.indicePasso);
+        passo = interpretador.resolverValor(resPasso);
+    }
+
+    if (passo === 0) {
+        throw new ErroEmTempoDeExecucao(
+            expressao.simboloFechamento,
+            'O passo do fatiamento não pode ser zero.',
+            expressao.linha
+        );
+    }
+
+    let inicio = passo > 0 ? 0 : tamanho - 1;
     if (expressao.indiceInicio) {
         const resInicio = await interpretador.avaliar(expressao.indiceInicio);
         inicio = interpretador.resolverValor(resInicio);
         if (inicio < 0) inicio = tamanho + inicio;
     }
 
-    let fim = tamanho;
+    let fim = passo > 0 ? tamanho : -1;
     if (expressao.indiceFim) {
         const resFim = await interpretador.avaliar(expressao.indiceFim);
         fim = interpretador.resolverValor(resFim);
         if (fim < 0) fim = tamanho + fim;
     }
 
-    if (objeto instanceof TuplaN) {
-        const novosElementos = objeto.elementos.slice(inicio, fim);
-        return new TuplaN(objeto.hashArquivo, objeto.linha, novosElementos);
+    // Lógica de fatiamento para suportar "passo", pois o TypeScript não suporta nativamente
+    const resultadoFatiado: any[] = [];
+
+    if (passo > 0) {
+        for (let i = inicio; i < fim; i += passo) {
+            if (i >= 0 && i < tamanho) {
+                resultadoFatiado.push(itens[i]);
+            }
+        }
+    } else {
+        for (let i = inicio; i > fim; i += passo) {
+            if (i >= 0 && i < tamanho) {
+                resultadoFatiado.push(itens[i]);
+            }
+        }
     }
 
-    return objeto.slice(inicio, fim);
+    if (objeto instanceof TuplaN) {
+        return new TuplaN(objeto.hashArquivo, objeto.linha, resultadoFatiado);
+    }
+
+    if (ehTexto) return resultadoFatiado.join('');
+
+    return resultadoFatiado;
 }
 
 export async function visitarExpressaoTuplaN(

--- a/testes/interpretador/dialetos/pitugues/comum.test.ts
+++ b/testes/interpretador/dialetos/pitugues/comum.test.ts
@@ -43,9 +43,16 @@ describe('comum (dialeto pitugues)', () => {
   it('visitarExpressaoAcessoIntervaloVariavel lança ErroEmTempoDeExecucao quando não é vetor nem texto', async () => {
     const literal = new Literal(1, 1, 10, 'número');
     const simboloFechamento: any = { linha: 5 };
-    const expressao = new AcessoIntervaloVariavel(1, literal, null, null, simboloFechamento);
+    const expressao = new AcessoIntervaloVariavel(
+        1,
+        literal,
+        null,
+        null,
+        null,
+        simboloFechamento
+    );
 
-    const interpretador: any = {
+      const interpretador: any = {
       avaliar: jest.fn().mockResolvedValue({ valor: 10 }),
       resolverValor: jest.fn().mockReturnValue(10),
     };

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues-com-depuracao.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues-com-depuracao.test.ts
@@ -61,7 +61,7 @@ describe('Interpretador Pituguês com Depuração', () => {
 
         const entidade = { linha: 4, paraTexto: () => '<e>' } as any;
         const simb = { lexema: ']' } as any;
-        const expressao = new AcessoIntervaloVariavel(4, entidade, null, null, simb);
+        const expressao = new AcessoIntervaloVariavel(4, entidade, null, null, null, simb);
 
         await expect(interpretador.visitarExpressaoAcessoIntervaloVariavel(expressao)).resolves.toBe(
             'ok-intervalo'

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -261,6 +261,29 @@ describe('Interpretador (Pituguês)', () => {
                             expect(variavelFatia.valor).toEqual([1, 2, 3]);
                         });
 
+                        it('Fatiamento com início, fim e passo definidos [início:fim:passo]', async () => {
+                            const retornoLexador = lexador.mapear([`
+                                numeros = [0, 1, 2, 3, 4, 5]
+                                fatia = numeros[1::2]
+                            `], -1);
+
+                            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                                retornoLexador,
+                                -1
+                            );
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+
+                            const variavelFatia = interpretador.pilhaEscoposExecucao.obterVariavelPorNome('fatia');
+
+                            expect(variavelFatia.valor).toEqual([1, 3, 5]);
+                        });
+
                         it('Fatiamento sem fim definido [início:]', async () => {
                             const retornoLexador = lexador.mapear([`
                                 numeros = [0, 1, 2, 3]


### PR DESCRIPTION
Esta alteração implementa o suporte ao terceiro argumento no fatiamento de variáveis (o "passo" ou step), permitindo sintaxes como `lista[inicio:fim:passo]`.

Este parâmetro deveria ter sido adicionado originalmente no PR #1012, mas acabou sendo omitido durante a implementação inicial da lógica de fatiamento. Este ajuste garante que o avaliador sintático consuma corretamente o segundo símbolo de dois-pontos (`:`) e processe a expressão de passo, quando presente.

## Alterações Realizadas

- **Avaliador Sintático:** Atualizada a lógica dentro da verificação de fatiamento para identificar a presença de um segundo símbolo de `DOIS_PONTOS`.
- **Consumo de Símbolos:** Adicionado o consumo efetivo do símbolo para evitar que o interpretador tente processar o `:` como parte de uma expressão ou falhe ao procurar o fechamento do colchete `]`.

## Por que isso é necessário?

Sem essa alteração, o fatiamento ficava restrito apenas a `[inicio:fim]`. Caso o usuário tentasse definir um passo, o analisador sintático ignorava a lógica ou lançava um erro de símbolo inesperado, impossibilitando iterações customizadas (ex: `vetor[::2]`).