### PR TITLE
[Pituguês] Adiciona suporte ao `para cada` em dicionários

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -1524,19 +1524,46 @@ export class AvaliadorSintaticoPitugues
     }
 
     async declaracaoPara(): Promise<ParaCada> {
-        try {
-            const simboloPara: SimboloInterface = this.simboloAnterior();
-            this.blocos += 1;
+        const simboloPara: SimboloInterface = this.simboloAnterior();
+        this.blocos += 1;
 
+        try {
             this.consumir(
                 tiposDeSimbolos.CADA,
                 `Esperado palavra reservada 'cada' após 'para'. Atual: ${this.simbolos[this.atual].lexema}.`
             );
 
-            const nomeVariavelIteracao = this.consumir(
+            const primeiraVariavel = this.consumir(
                 tiposDeSimbolos.IDENTIFICADOR,
                 "Esperado identificador de variável de iteração para instrução 'para cada'."
             );
+
+            let simboloSegundaVariavel: SimboloInterface = null;
+            if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.VIRGULA)) {
+                simboloSegundaVariavel = this.consumir(
+                    tiposDeSimbolos.IDENTIFICADOR,
+                    'Esperado identificador após a vírgula.'
+                );
+            }
+
+            let variavelIteracao: Variavel<string> | Dupla;
+            const v1 = new Variavel(
+                this.hashArquivo,
+                primeiraVariavel,
+                'qualquer'
+            );
+
+            if (simboloSegundaVariavel) {
+                const v2 = new Variavel(
+                    this.hashArquivo,
+                    simboloSegundaVariavel,
+                    'qualquer'
+                );
+
+                variavelIteracao = new Dupla(v1, v2);
+            } else {
+                variavelIteracao = v1;
+            }
 
             if (!this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.DE, tiposDeSimbolos.EM)) {
                 throw this.erro(
@@ -1545,40 +1572,69 @@ export class AvaliadorSintaticoPitugues
                 );
             }
 
-            const vetor = await this.expressao();
-            if (!vetor.hasOwnProperty('tipo')) {
-                throw this.erro(
-                    simboloPara,
-                    `Variável ou constante em 'para cada' não parece possuir um tipo iterável.`
-                );
-            }
+            const alvoIteracao = await this.expressao();
 
-            const tipoVetor = (vetor as any).tipo as string;
-            if (!tipoVetor.endsWith('[]') && !['qualquer', 'texto', 'vetor'].includes(tipoVetor)) {
-                throw this.erro(
-                    simboloPara,
-                    `Variável ou constante em 'para cada' não é iterável. Tipo resolvido: ${tipoVetor}.`
-                );
-            }
+            this.validarSeAlvoEIteravel(
+                simboloPara,
+                alvoIteracao,
+                !!simboloSegundaVariavel
+            );
 
             this.pilhaEscopos.definirInformacoesVariavel(
-                nomeVariavelIteracao.lexema,
-                new InformacaoElementoSintatico(nomeVariavelIteracao.lexema, tipoVetor.slice(0, -2))
+                primeiraVariavel.lexema,
+                new InformacaoElementoSintatico(primeiraVariavel.lexema, 'qualquer')
             );
+
+            if (simboloSegundaVariavel) {
+                this.pilhaEscopos.definirInformacoesVariavel(
+                    simboloSegundaVariavel.lexema,
+                    new InformacaoElementoSintatico(simboloSegundaVariavel.lexema, 'qualquer')
+                );
+            }
+
             // TODO: Talvez não seja uma ideia melhor chamar o método de `Bloco` aqui?
             const corpo: Bloco = await this.resolverDeclaracao() as Bloco;
 
             return new ParaCada(
                 this.hashArquivo,
                 Number(simboloPara.linha),
-                new Variavel(this.hashArquivo, nomeVariavelIteracao),
-                vetor,
+                variavelIteracao,
+                alvoIteracao,
                 corpo
             );
-        } catch (erro) {
-            throw erro;
         } finally {
             this.blocos -= 1;
+        }
+    }
+
+    /**
+     * Função auxiliar para validar se o alvo pode ser iterado.
+     */
+    private validarSeAlvoEIteravel(
+        simboloPara: SimboloInterface,
+        alvo: any,
+        temDuasVariaveis: boolean
+    ): void {
+        if (!alvo || !alvo.tipo) return;
+
+        const tipo = alvo.tipo;
+        const tiposValidos = ['qualquer', 'vetor', 'dicionário', 'texto'];
+        const eVetor = tipo.endsWith('[]') || tipo === 'vetor';
+
+        if (temDuasVariaveis) {
+            if (!eVetor && tipo !== 'dicionário' && tipo !== 'qualquer') {
+                throw this.erro(
+                    simboloPara,
+                    `Para iterar com duas variáveis, o objeto deve ser um dicionário ou lista. Tipo atual: ${tipo}.`
+                );
+            }
+        } else {
+            if (!eVetor && !tiposValidos.includes(tipo)) {
+                throw this.erro(
+                    simboloPara,
+                    `O objeto do tipo '${tipo}' não é iterável.`
+                );
+            }
         }
     }
 

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -187,7 +187,17 @@ export class InterpretadorPitugues extends Interpretador {
         declaracao.posicaoAtual = 0;
 
         const valorResolvido = await this.avaliar(declaracao.vetorOuDicionario);
-        let listaParaIterar = this.prepararListaParaIteracao(valorResolvido, declaracao);
+        let listaParaIterar: any[];
+        try {
+            listaParaIterar = this.prepararListaParaIteracao(valorResolvido, declaracao);
+        } catch (erro: any) {
+            this.erros.push({
+                erroInterno: erro,
+                linha: declaracao.linha,
+                hashArquivo: declaracao.hashArquivo,
+            });
+            return Promise.reject(erro);
+        }
 
         while (!(retornoExecucao instanceof Quebra) && declaracao.posicaoAtual < listaParaIterar.length) {
             try {

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -7,14 +7,17 @@ import { AcessoMetodo,
     Literal,
     AtribuicaoPorIndice,
     AcessoIndiceVariavel,
-    Unario,
-    Chamada,
-    TipoDe
+    TipoDe,
+    Dupla,
+    Variavel
 } from "../../../construtos";
 import { Interpretador } from "../../interpretador";
 import { ErroEmTempoDeExecucao } from '../../../excecoes';
 
 import * as comum from './comum';
+import { ParaCada } from "../../../declaracoes";
+import { inferirTipoVariavel } from "../../../inferenciador";
+import { ContinuarQuebra, Quebra, SustarQuebra } from "../../../quebras";
 
 export class InterpretadorPitugues extends Interpretador {
     constructor(
@@ -99,5 +102,115 @@ export class InterpretadorPitugues extends Interpretador {
         if (typeof resultado === 'string') return resultado.replace('tipo de', 'tipo');
 
         return resultado;
+    }
+
+    /**
+     * Normaliza o valor resolvido para um array iterável.
+     * Converte dicionários em listas de Duplas e strings em listas de caracteres.
+     */
+    private prepararListaParaIteracao(valor: any, declaracao: ParaCada): any[] {
+        let valorFinal = this.resolverValor(valor);
+
+        const ehDicionario = declaracao.vetorOuDicionario.tipo === 'dicionário';
+        const ehObjetoPuro = valorFinal && typeof valorFinal === 'object' && !Array.isArray(valorFinal);
+
+        if (ehDicionario || ehObjetoPuro) {
+            return Object.entries(valorFinal).map(
+                ([chave, valor]) => new Dupla(
+                    new Literal(
+                        declaracao.hashArquivo,
+                        declaracao.linha,
+                        chave,
+                        'texto'
+                    ),
+                    new Literal(
+                        declaracao.hashArquivo,
+                        declaracao.linha,
+                        valor as any,
+                        inferirTipoVariavel(valor) as any
+                    )
+                )
+            );
+        }
+
+        if (typeof valorFinal === 'string') return valorFinal.split('');
+
+        if (!Array.isArray(valorFinal)) {
+            throw new Error("O objeto provido para 'para cada' não é iterável.");
+        }
+
+        return valorFinal;
+    }
+
+    /**
+     * Resolve a lógica de atribuição das variáveis no escopo.
+     * Suporta variáveis simples ou pares (Dupla).
+     */
+    private definirVariaveisIteracao(variavel: Variavel | Dupla, elemento: any): void {
+        if (variavel instanceof Variavel) {
+            this.pilhaEscoposExecucao.definirVariavel(
+                variavel.simbolo.lexema,
+                this.resolverValor(elemento)
+            );
+
+            return;
+        }
+
+        if (variavel instanceof Dupla) {
+            const var1 = variavel.primeiro as Variavel;
+            const var2 = variavel.segundo as Variavel;
+
+            let v1: any, v2: any;
+
+            if (elemento instanceof Dupla) {
+                v1 = this.resolverValor(elemento.primeiro);
+                v2 = this.resolverValor(elemento.segundo);
+            } else {
+                v1 = elemento[0];
+                v2 = elemento[1];
+            }
+
+            this.pilhaEscoposExecucao.definirVariavel(
+                var1.simbolo.lexema,
+                v1
+            );
+
+            this.pilhaEscoposExecucao.definirVariavel(
+                var2.simbolo.lexema,
+                v2
+            );
+        }
+    }
+
+    async visitarDeclaracaoParaCada(declaracao: ParaCada): Promise<any> {
+        let retornoExecucao: any;
+        declaracao.posicaoAtual = 0;
+
+        const valorResolvido = await this.avaliar(declaracao.vetorOuDicionario);
+        let listaParaIterar = this.prepararListaParaIteracao(valorResolvido, declaracao);
+
+        while (!(retornoExecucao instanceof Quebra) && declaracao.posicaoAtual < listaParaIterar.length) {
+            try {
+                const elementoAtual = listaParaIterar[declaracao.posicaoAtual];
+
+                this.definirVariaveisIteracao(declaracao.variavelIteracao, elementoAtual);
+
+                retornoExecucao = await this.executar(declaracao.corpo);
+
+                if (retornoExecucao instanceof SustarQuebra) return null;
+                if (retornoExecucao instanceof ContinuarQuebra) retornoExecucao = null;
+
+                declaracao.posicaoAtual++;
+            } catch (erro: any) {
+                this.erros.push({
+                    erroInterno: erro,
+                    linha: declaracao.linha,
+                    hashArquivo: declaracao.hashArquivo,
+                });
+                return Promise.reject(erro);
+            }
+        }
+
+        return retornoExecucao;
     }
 }

--- a/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
@@ -140,6 +140,59 @@ describe('Avaliador sintático (Pituguês)', () => {
                     expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
                     expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
                 });
+
+                describe('Iterando dicionários', () => {
+                    it('Iterando dicionários com método itens()', async () => {
+                        const retornoLexador = lexador.mapear([
+                            'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                            'para cada chave, valor em dicionarioLegal.itens():',
+                            '    imprima(chave, valor)'
+                        ], -1);
+
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                        expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                    });
+
+                    it('Iterando dicionários com duas variáveis', async () => {
+                        const retornoLexador = lexador.mapear([
+                            'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                            'para cada chave, valor em dicionarioLegal:',
+                            '    imprima(chave, valor)'
+                        ], -1);
+
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                        expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                    });
+
+                    it('Iterando dicionários com uma variável', async () => {
+                        const retornoLexador = lexador.mapear([
+                            'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                            'para cada chaveValor em dicionarioLegal:',
+                            '    imprima(chaveValor)'
+                        ], -1);
+
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                            retornoLexador,
+                            -1
+                        );
+
+                        expect(retornoAvaliadorSintatico).toBeTruthy();
+                        expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                        expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(2);
+                    });
+                });
             });
 
             it('Lista de Compreensão', async () => {

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -1100,6 +1100,89 @@ describe('Interpretador (Pituguês)', () => {
                         expect(_saidas[1]).toBe('2');
                         expect(_saidas[2]).toBe('3');
                     });
+
+                    describe('Dicionários', () => {
+                        it('Iterando dicionários com duas variáveis usando o método itens()', async () => {
+                            const retornoLexador = lexador.mapear(
+                                [
+                                    'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                                    'para cada chave, valor em dicionarioLegal.itens():',
+                                    '    escreva(chave, valor)'
+                                ],
+                                -1
+                            );
+
+                            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                                retornoLexador,
+                                -1
+                            );
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            expect(_saidas).toHaveLength(3);
+                            expect(_saidas[0]).toBe('a 1');
+                            expect(_saidas[1]).toBe('b 2');
+                            expect(_saidas[2]).toBe('c 3');
+                        });
+
+                        it('Iterando dicionários com duas variáveis', async () => {
+                            const retornoLexador = lexador.mapear(
+                                [
+                                    'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                                    'para cada chave, valor em dicionarioLegal:',
+                                    '    escreva(chave, valor)'
+                                ],
+                                -1
+                            );
+
+                            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                                retornoLexador,
+                                -1
+                            );
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            expect(_saidas).toHaveLength(3);
+                            expect(_saidas[0]).toBe('a 1');
+                            expect(_saidas[1]).toBe('b 2');
+                            expect(_saidas[2]).toBe('c 3');
+                        });
+
+                        it('Iterando dicionários com uma variável', async () => {
+                            const retornoLexador = lexador.mapear(
+                                [
+                                    'dicionarioLegal = { "a": 1, "b": 2, "c": 3 }',
+                                    'para cada chaveValor em dicionarioLegal:',
+                                    '    escreva(chaveValor)'
+                                ],
+                                -1
+                            );
+
+                            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                                retornoLexador,
+                                -1
+                            );
+
+                            const retornoInterpretador = await interpretador.interpretar(
+                                retornoAvaliadorSintatico.declaracoes,
+                                true
+                            );
+
+                            expect(retornoInterpretador.erros).toHaveLength(0);
+                            expect(_saidas).toHaveLength(3);
+                            expect(_saidas[0]).toBe('("a", 1)');
+                            expect(_saidas[1]).toBe('("b", 2)');
+                            expect(_saidas[2]).toBe('("c", 3)');
+                        });
+                    });
                 });
 
                 it('Iterando texto', async () => {


### PR DESCRIPTION
Este PR resolve a issue #890, que solicita a implementação da possibilidade de dicionários serem iterados em um laço de repetição no Pituguês.

## Alterações Realizadas

- **Iteração com e sem `.itens()`:** Agora o Pituguês permite iterar diretamente sobre um dicionário usando a sintaxe `para cada chave, valor em dicionario:` ou até mesmo `para cada chave, valor em dicionario.itens():`. O interpretador converte automaticamente o objeto em uma lista de `Duplas`.
- **Testes:** Foram feitos testes no `avaliador-sintatico.test.ts` e no `interpretador-pitugues.test.ts` para que fosse verificado se a implementação dessa feature foi feita corretamente.

Closes #890