### PR TITLE
Evita falha silenciosa em declarações incompletas no final do arquivo

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -668,9 +668,17 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         }
     }
 
-    erro(simbolo: SimboloInterface, mensagemDeErro: string): ErroAvaliadorSintatico {
-        const excecao = new ErroAvaliadorSintatico(simbolo, mensagemDeErro);
+    erro(
+        simbolo: SimboloInterface,
+        mensagemDeErro: string
+    ): ErroAvaliadorSintatico {
+        const simboloParaErro = simbolo || this.simboloAnterior();
+        const excecao = new ErroAvaliadorSintatico(
+            simboloParaErro,
+            mensagemDeErro
+        );
         this.erros.push(excecao);
+
         return excecao;
     }
 
@@ -685,7 +693,7 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
     }
 
     verificarTipoProximoSimbolo(tipo: string): boolean {
-        if (this.estaNoFinal()) return false;
+        if (this.atual + 1 >= this.simbolos.length) return false;
         return this.simbolos[this.atual + 1].tipo === tipo;
     }
 
@@ -1440,60 +1448,48 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         let simboloAtual = this.simboloAtual();
         const simboloAnterior = this.simboloAnterior();
 
-        // Situação 1: não tem bloco de escopo.
-        //
-        // Exemplo: `se verdadeiro: escreva('Alguma coisa')`.
-        // Neste caso, linha do símbolo atual é igual à linha do símbolo anterior.
+        if (!simboloAtual) {
+            throw this.erro(
+                simboloAnterior,
+                'Esperado corpo do escopo após a declaração.'
+            );
+        }
 
+        // Declaração na mesma linha (ex: 'se verdadeiro: escreva("Oi")')
         if (simboloAtual.linha === simboloAnterior.linha) {
-            const declaracoesBloco = await this.resolverDeclaracaoForaDeBloco();
-            if (declaracoesBloco !== null) {
-                if (Array.isArray(declaracoesBloco)) {
-                    declaracoes = declaracoes.concat(declaracoesBloco);
-                } else {
-                    declaracoes.push(declaracoesBloco as Declaracao);
-                }
-            }
+            const retorno = await this.resolverDeclaracaoForaDeBloco();
+            if (retorno !== null) declaracoes = declaracoes.concat(retorno);
         } else {
-            // Situação 2: símbolo atual fica na próxima linha.
-            //
-            // Verifica-se o número de espaços à esquerda da linha através dos pragmas.
-            // Se número de espaços da linha do símbolo atual é menor ou igual ao número de espaços
-            // da linha anterior, e bloco ainda não começou, é uma situação de erro.
-            let espacosIndentacaoLinhaAtual =
-                this.localizacoes[simboloAtual.linha].espacosIndentacao;
-            const espacosIndentacaoLinhaAnterior =
-                this.localizacoes[simboloAnterior.linha].espacosIndentacao;
+            // Bloco de múltiplas linhas baseado em indentação
+            let espacosAtual = this
+                .localizacoes[simboloAtual.linha]
+                .espacosIndentacao;
+            const espacosAnterior = this
+                .localizacoes[simboloAnterior.linha]
+                .espacosIndentacao;
 
-            if (espacosIndentacaoLinhaAtual <= espacosIndentacaoLinhaAnterior) {
+            if (espacosAtual <= espacosAnterior) {
                 throw this.erro(
                     simboloAtual,
                     `Indentação inconsistente na linha ${simboloAtual.linha}. ` +
-                        `Esperado: >= ${espacosIndentacaoLinhaAnterior}. ` +
-                        `Atual: ${espacosIndentacaoLinhaAtual}`
+                        `Esperado: >= ${espacosAnterior}. ` +
+                        `Atual: ${espacosAtual}`
                 );
             }
 
-            // Indentação ok, é um bloco de escopo.
-            // Inclui todas as declarações cujas linhas tenham o mesmo número de espaços
-            // de indentação do bloco.
-            // Se `simboloAtual` for definido em algum momento como indefinido,
-            // Significa que o código acabou, então o bloco também acabou.
-            const espacosIndentacaoBloco = espacosIndentacaoLinhaAtual;
-            while (espacosIndentacaoLinhaAtual === espacosIndentacaoBloco) {
-                const retornoDeclaracao = await this.resolverDeclaracaoForaDeBloco();
-                if (retornoDeclaracao !== null) {
-                    if (Array.isArray(retornoDeclaracao)) {
-                        declaracoes = declaracoes.concat(retornoDeclaracao);
-                    } else {
-                        declaracoes.push(retornoDeclaracao as Declaracao);
-                    }
-                }
+            const indentacaoBloco = espacosAtual;
+
+            // Consome as declarações enquanto a indentação for estritamente igual à do bloco
+            while (simboloAtual && espacosAtual === indentacaoBloco) {
+                const retorno = await this.resolverDeclaracaoForaDeBloco();
+                if (retorno !== null) declaracoes = declaracoes.concat(retorno);
 
                 simboloAtual = this.simboloAtual();
-                if (!simboloAtual) break;
-                espacosIndentacaoLinhaAtual =
-                    this.localizacoes[simboloAtual.linha].espacosIndentacao;
+                if (simboloAtual) {
+                    espacosAtual = this
+                        .localizacoes[simboloAtual.linha]
+                        .espacosIndentacao;
+                }
             }
         }
 
@@ -2337,12 +2333,11 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
     async resolverDeclaracaoForaDeBloco(): Promise<Declaracao | Declaracao[]> {
         try {
             if (
-                (this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNCAO) ||
-                    this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNÇÃO)) &&
-                this.verificarTipoProximoSimbolo(tiposDeSimbolos.IDENTIFICADOR)
+                this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNCAO) ||
+                this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNÇÃO)
             ) {
                 this.avancarEDevolverAnterior();
-                return await this.funcao('funcao');
+                return await this.funcao('da função');
             }
 
             if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.CLASSE))

--- a/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
@@ -756,6 +756,32 @@ describe('Avaliador sintático (Pituguês)', () => {
                     expect(declaracao.elementosImportacao[1].lexema).toBe('potencia');
                 });
             });
+
+            it('Deve exigir o corpo do escopo e lançar erro se o fim de arquivo for alcançado', async () => {
+                const codigo = [`
+                    se verdadeiro:
+                `];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliador = await avaliadorSintatico.analisar(
+                    retornoLexador, -1
+                );
+
+                expect(retornoAvaliador.erros).toHaveLength(1);
+                expect(retornoAvaliador.erros[0].message).toBe('Esperado corpo do escopo após a declaração.');
+            });
+
+            it('Deve exigir o identificador da função e barrar falha silenciosa no final do arquivo', async () => {
+                const codigo = [`
+                    funcao
+                `];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliador = await avaliadorSintatico.analisar(
+                    retornoLexador, -1
+                );
+
+                expect(retornoAvaliador.erros).toHaveLength(1);
+                expect(retornoAvaliador.erros[0].message).toBe('Esperado nome da função.');
+            });
         });
     });
 });


### PR DESCRIPTION
Este PR corrige os bugs no `avaliador-sintatico-pitugues.ts` que foram mencionados na issue #1126, ajudando o usuário a encontrar erros na sintaxe do código Pituguês.

Arquivos de código que antes terminavam de forma abrupta e não exibiam nenhum erro no terminal, agora lançam erro e dizem exatamente o que precisa ser corrigido.

## Código Pituguês

### Antes das alterações

```bash
se verdadeiro:

# Nenhum erro exibido no terminal
```

```bash
funcao

# Nenhum erro exibido no terminal
```

### Após as alterações

```bash
se verdadeiro:

# Erro: Esperado corpo do escopo após a declaração.
```

```bash
funcao

# Erro: Esperado nome da função.
```

Closes #1126