### PR TITLE
Adiciona suporte ao uso de Decoradores no Pituguês.

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -11,6 +11,7 @@ import {
     Chamada,
     DefinirValor,
     Construto,
+    Decorador,
     Dicionario,
     FuncaoConstruto,
     Isto,
@@ -132,6 +133,7 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
     performance: boolean;
     superclasseAtual: string | undefined;
     intuirTipoQualquerParaIdentificadores: boolean;
+    pilhaDecoradores: Decorador[];
 
     constructor(performance = false) {
         this.atual = 0;
@@ -139,6 +141,7 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         this.performance = performance;
         this.intuirTipoQualquerParaIdentificadores = false;
         this.escopos = [];
+        this.pilhaDecoradores = [];
         this.pilhaEscopos = new PilhaEscopos();
         this.primitivasConhecidas = {};
         this.tiposDefinidosEmCodigo = {};
@@ -1753,6 +1756,56 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         return new Sustar(this.simboloAtual());
     }
 
+    protected async resolverDecoradores(): Promise<void> {
+        while (this.verificarTipoSimboloAtual(tiposDeSimbolos.ARROBA)) {
+            this.avancarEDevolverAnterior();
+            let nomeDecorador = '@';
+            let linha: number;
+            let parametros: Array<Partial<ParametroInterface>> = [];
+            const atributos: { [key: string]: any } = {};
+
+            const primeiraParteNomeDecorador = this.consumir(
+                tiposDeSimbolos.IDENTIFICADOR,
+                'Esperado nome de decorador após "@".'
+            );
+            linha = Number(primeiraParteNomeDecorador.linha);
+            nomeDecorador += primeiraParteNomeDecorador.lexema;
+
+            while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PONTO)) {
+                const parteNomeDecorador = this.consumir(
+                    tiposDeSimbolos.IDENTIFICADOR,
+                    'Esperado nome de decorador após "."'
+                );
+                nomeDecorador += '.' + parteNomeDecorador.lexema;
+            }
+
+            if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.PARENTESE_ESQUERDO)) {
+                if (!this.verificarTipoSimboloAtual(tiposDeSimbolos.PARENTESE_DIREITO)) {
+                    parametros = await this.logicaComumParametros();
+                }
+
+                for (const parametro of parametros) {
+                    if (parametro.nome.lexema in atributos) {
+                        throw this.erro(
+                            parametro.nome,
+                            `Atributo de decorador declarado duas ou mais vezes: ${parametro.nome.lexema}`
+                        );
+                    }
+                    atributos[parametro.nome.lexema] = parametro.valorPadrao;
+                }
+
+                this.consumir(
+                    tiposDeSimbolos.PARENTESE_DIREITO,
+                    'Esperado ")" após argumentos do decorador.'
+                );
+            }
+
+            this.pilhaDecoradores.push(
+                new Decorador(this.hashArquivo, linha, nomeDecorador, atributos)
+            );
+        }
+    }
+
     declaracaoComentario(): Comentario {
         const simboloComentario = this.avancarEDevolverAnterior();
         return new Comentario(
@@ -1958,6 +2011,9 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
             ? this.consumir(tiposDeSimbolos.IDENTIFICADOR, `Esperado nome ${tipo}.`)
             : new Simbolo(tiposDeSimbolos.CONSTRUTOR, 'construtor', null, -1, -1);
 
+        const decoradores = Array.from(this.pilhaDecoradores);
+        this.pilhaDecoradores = [];
+
         // Se houver chamadas recursivas à função, precisamos definir um tipo
         // para ela. Vai ser atualizado após avaliação do corpo da função.
         this.pilhaEscopos.definirInformacoesVariavel(
@@ -1971,8 +2027,17 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
             simbolo.lexema,
             new InformacaoElementoSintatico(simbolo.lexema, tipoDaFuncao)
         );
-        const funcaoDeclaracao = new FuncaoDeclaracao(simbolo, corpoDaFuncao, tipoDaFuncao);
-        this.pilhaEscopos.registrarReferenciaFuncao(simbolo.lexema, funcaoDeclaracao);
+        const funcaoDeclaracao = new FuncaoDeclaracao(
+            simbolo,
+            corpoDaFuncao,
+            tipoDaFuncao,
+            decoradores
+        );
+        this.pilhaEscopos.registrarReferenciaFuncao(
+            simbolo.lexema,
+            funcaoDeclaracao
+        );
+
         return funcaoDeclaracao;
     }
 
@@ -2103,6 +2168,24 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
     }
 
     protected verificarDefinicaoTipoAtual(): string {
+        if (
+            this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNCAO) ||
+            this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNÇÃO)
+        ) {
+            if (this.verificarTipoProximoSimbolo(tiposDeSimbolos.MENOR)) {
+                this.avancarEDevolverAnterior();
+                this.avancarEDevolverAnterior();
+
+                const tipoRetorno = this.simboloAtual().lexema;
+
+                this.avancarEDevolverAnterior();
+
+                return `função<${tipoRetorno}>`;
+            }
+
+            return 'função<qualquer>';
+        }
+
         const tipos = [...Object.values(tiposDeDadosPitugues)];
 
         if (this.simbolos[this.atual].lexema in this.tiposDefinidosEmCodigo) {
@@ -2332,11 +2415,24 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
      */
     async resolverDeclaracaoForaDeBloco(): Promise<Declaracao | Declaracao[]> {
         try {
+            if (this.verificarTipoSimboloAtual(tiposDeSimbolos.ARROBA)) {
+                await this.resolverDecoradores();
+            }
+
             if (
                 this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNCAO) ||
                 this.verificarTipoSimboloAtual(tiposDeSimbolos.FUNÇÃO)
             ) {
                 this.avancarEDevolverAnterior();
+
+                if (
+                    this.verificarTipoSimboloAtual(tiposDeSimbolos.DE) &&
+                    this.simboloNaPosicao(1)?.lexema === 'decorador'
+                ) {
+                    this.avancarEDevolverAnterior();
+                    this.avancarEDevolverAnterior();
+                }
+
                 return await this.funcao('da função');
             }
 
@@ -2685,6 +2781,7 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         this.atual = 0;
         this.blocos = 0;
         this.escopos = [];
+        this.pilhaDecoradores = [];
         this.inicializarPilhaEscopos();
         this.tiposDefinidosEmCodigo = {};
 

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -16,9 +16,9 @@ import { Interpretador } from '../../interpretador';
 import { ErroEmTempoDeExecucao } from '../../../excecoes';
 
 import * as comum from './comum';
-import { ParaCada } from '../../../declaracoes';
+import { ParaCada, Retorna } from '../../../declaracoes';
 import { inferirTipoVariavel } from '../../../inferenciador';
-import { ContinuarQuebra, Quebra, SustarQuebra } from '../../../quebras';
+import { ContinuarQuebra, Quebra, SustarQuebra, RetornoQuebra } from '../../../quebras';
 
 export class InterpretadorPitugues extends Interpretador {
     constructor(
@@ -251,5 +251,24 @@ export class InterpretadorPitugues extends Interpretador {
         }
 
         return retornoExecucao;
+    }
+
+    override async visitarExpressaoRetornar(
+        declaracao: Retorna
+    ): Promise<RetornoQuebra> {
+        let valor = null;
+        if (declaracao.valor !== null && declaracao.valor !== undefined) {
+            valor = await this.avaliar(declaracao.valor);
+        }
+
+        const retornoQuebra = new RetornoQuebra(valor, declaracao.tipo);
+
+        if (retornoQuebra.valor) {
+            const valorResolvido = this.resolverValor(retornoQuebra.valor);
+            const construtorRetorno = valorResolvido?.constructor?.name?.replaceAll('_', '') ?? '';
+            if (['DeleguaFuncao', 'ReferenciaMontao'].includes(construtorRetorno)) retornoQuebra.preservarEscopo = true;
+        }
+
+        return retornoQuebra;
     }
 }

--- a/fontes/lexador/dialetos/lexador-pitugues.ts
+++ b/fontes/lexador/dialetos/lexador-pitugues.ts
@@ -398,6 +398,11 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
                 this.avancar();
                 break;
 
+            case '@':
+                this.adicionarSimbolo(tiposDeSimbolos.ARROBA);
+                this.avancar();
+                break;
+
             case '=':
                 this.avancar();
                 if (this.simboloAtual() === '=') {

--- a/fontes/tipos-de-simbolos/pitugues.ts
+++ b/fontes/tipos-de-simbolos/pitugues.ts
@@ -1,5 +1,6 @@
 export default {
     ADICAO: 'ADICAO',
+    ARROBA: 'ARROBA',
     BIT_AND: 'BIT_AND',
     BIT_OR: 'BIT_OR',
     BIT_XOR: 'BIT_XOR',

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -3801,13 +3801,42 @@ describe('Interpretador (Pituguês)', () => {
                 });
             });
 
-            it('Suporta o uso de Decoradores', async () => {
+            it('Suporta o uso de Decoradores utilizando função anônima', async () => {
                 const codigo = [
                     'função de decorador meu_decorador(decorado):',
                     '   retorna funcao():',
                     '       escreva("Antes")',
                     '       decorado()',
                     '       escreva("Depois")',
+                    '',
+                    '@meu_decorador',
+                    'função ola_mundo():',
+                    '   escreva("Olá, Mundo!")',
+                    '',
+                    'ola_mundo()'
+                ];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliador = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoInterpretador = await interpretador.interpretar(
+                    retornoAvaliador.declaracoes
+                );
+
+                expect(retornoInterpretador.erros).toHaveLength(0);
+                expect(_saidas).toEqual(['Antes', 'Olá, Mundo!', 'Depois']);
+            });
+
+            it('Suporta o uso de Decoradores usando função nomeada', async () => {
+                const codigo = [
+                    'função de decorador meu_decorador(decorado):',
+                    '   funcao envelope():',
+                    '       escreva("Antes")',
+                    '       decorado()',
+                    '       escreva("Depois")',
+                    '',
+                    '   retorna envelope',
                     '',
                     '@meu_decorador',
                     'função ola_mundo():',

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -37,7 +37,7 @@ describe('Interpretador (Pituguês)', () => {
                         retornoAvaliadorSintatico.declaracoes
                     );
 
-                     expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Teste do exemplo de código presente no artigo sobre o Interpretador', async () => {
@@ -58,7 +58,7 @@ describe('Interpretador (Pituguês)', () => {
                         retornoAvaliadorSintatico.declaracoes
                     );
 
-                     expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
                 it('Atribuição com anotação de tipo texto[]', async () => {
@@ -1629,7 +1629,7 @@ describe('Interpretador (Pituguês)', () => {
                         expect(_saidas[0]).toBe('falso');
                     });
                 });
-                });
+            });
 
             describe('Desempacotamento de dicionários com **', () => {
                 describe('Casos de sucesso', () => {
@@ -3661,143 +3661,171 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas[0]).toBe('1.234,5');
                 });
-            describe('todos()', () => {
-                it('Chama a função nativa "todos()" com iterável de dados Truly', async () => {
-                    let _saida: string = '';
+                describe('todos()', () => {
+                    it('Chama a função nativa "todos()" com iterável de dados Truly', async () => {
+                        let _saida: string = '';
 
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'listaDeNumeros = [1, "Pituguês", verdadeiro]',
-                            'escreva(todos(listaDeNumeros))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'listaDeNumeros = [1, "Pituguês", verdadeiro]',
+                                'escreva(todos(listaDeNumeros))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
 
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
-                    expect(_saida).toBeTruthy();
-                    expect(_saida).toBe('verdadeiro');
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+
+                    it('Chama a função nativa "todos()" com um objeto', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
+                                'escreva(todos(objetoLegal))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+
+                    it('Chama a função nativa "todos()" com um dicionário', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
+                                'escreva(todos(objetoLegal))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
+
+                    it('Chama a função nativa "todos()" com iterável de dados Falsy', async () => {
+                        let _saida: string = '';
+
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'listaDeNumeros = [0, "", nulo, falso]',
+                                'escreva(todos(listaDeNumeros))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
+
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('falso');
+                    });
                 });
 
-                it('Chama a função nativa "todos()" com um objeto', async () => {
-                    let _saida: string = '';
+                describe('todosEmCondicao()', () => {
+                    it('Chama a função nativa "todosEmCondicao()" para verificar se os elementos do array são par.', async () => {
+                        let _saida: string = '';
 
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
-                            'escreva(todos(objetoLegal))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'listaDeNumeros = [1, 2, 3, 4, 5]',
+                                'funcao eh_par(valor):',
+                                '    retorna valor % 2 == 0',
+                                'escreva(todosEmCondicao(listaDeNumeros, eh_par))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
 
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
-                    expect(_saida).toBeTruthy();
-                    expect(_saida).toBe('verdadeiro');
-                });
+                        expect(_saida).toBe('falso');
+                    });
 
-                it('Chama a função nativa "todos()" com um dicionário', async () => {
-                    let _saida: string = '';
+                    it('Chama a função nativa "todosEmCondicao()" para verificar se todos os nomes começam com "V"', async () => {
+                        let _saida: string = '';
 
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'objetoLegal = { 1: "a", 2: "b", 3: "c" }',
-                            'escreva(todos(objetoLegal))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'listaDeNomes = ["Victor", "Verônica", "Vanessa"]',
+                                'funcao verificar_nomes(nome):',
+                                '    retorna nome[0] == "V"',
+                                'escreva(todosEmCondicao(listaDeNomes, verificar_nomes))'
+                            ],
+                            -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
+                        interpretador.funcaoDeRetorno = (saida: any) => {
+                            _saida = saida;
+                        };
 
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+                        await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
 
-                    expect(_saida).toBeTruthy();
-                    expect(_saida).toBe('verdadeiro');
-                });
-
-                it('Chama a função nativa "todos()" com iterável de dados Falsy', async () => {
-                    let _saida: string = '';
-
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'listaDeNumeros = [0, "", nulo, falso]',
-                            'escreva(todos(listaDeNumeros))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
-
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
-
-                    expect(_saida).toBeTruthy();
-                    expect(_saida).toBe('falso');
+                        expect(_saida).toBeTruthy();
+                        expect(_saida).toBe('verdadeiro');
+                    });
                 });
             });
 
-            describe('todosEmCondicao()', () => {
-                it('Chama a função nativa "todosEmCondicao()" para verificar se os elementos do array são par.', async () => {
-                    let _saida: string = '';
+            it('Suporta o uso de Decoradores', async () => {
+                const codigo = [
+                    'função de decorador meu_decorador(decorado):',
+                    '   retorna funcao():',
+                    '       escreva("Antes")',
+                    '       decorado()',
+                    '       escreva("Depois")',
+                    '',
+                    '@meu_decorador',
+                    'função ola_mundo():',
+                    '   escreva("Olá, Mundo!")',
+                    '',
+                    'ola_mundo()'
+                ];
+                const retornoLexador = lexador.mapear(codigo, -1);
+                const retornoAvaliador = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoInterpretador = await interpretador.interpretar(
+                    retornoAvaliador.declaracoes
+                );
 
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'listaDeNumeros = [1, 2, 3, 4, 5]',
-                            'funcao eh_par(valor):',
-                            '    retorna valor % 2 == 0',
-                            'escreva(todosEmCondicao(listaDeNumeros, eh_par))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
-
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
-
-                    expect(_saida).toBe('falso');
-                });
-
-                it('Chama a função nativa "todosEmCondicao()" para verificar se todos os nomes começam com "V"', async () => {
-                    let _saida: string = '';
-
-                    const retornoLexador = lexador.mapear(
-                        [
-                            'listaDeNomes = ["Victor", "Verônica", "Vanessa"]',
-                            'funcao verificar_nomes(nome):',
-                            '    retorna nome[0] == "V"',
-                            'escreva(todosEmCondicao(listaDeNomes, verificar_nomes))'
-                        ],
-                        -1
-                    );
-                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-
-                    interpretador.funcaoDeRetorno = (saida: any) => {
-                        _saida = saida;
-                    };
-
-                    await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
-
-                    expect(_saida).toBeTruthy();
-                    expect(_saida).toBe('verdadeiro');
-                });
+                expect(retornoInterpretador.erros).toHaveLength(0);
+                expect(_saidas).toEqual(['Antes', 'Olá, Mundo!', 'Depois']);
             });
         });
 
@@ -3996,9 +4024,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Acesso a elementos negativos fora do tamanho do vetor', async () => {
                     const retornoLexador = lexador.mapear([`
-                        a = [1, 2, 3]
-                        escreva(a[-4])
-                    `], -1);
+                    a = [1, 2, 3]
+                    escreva(a[-4])
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4013,9 +4041,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Acesso a elementos negativos fora do tamanho da tupla', async () => {
                     const retornoLexador = lexador.mapear([`
-                        a = (1, 2, 3)
-                        escreva(a[-4])
-                    `], -1);
+                    a = (1, 2, 3)
+                    escreva(a[-4])
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4088,9 +4116,9 @@ describe('Interpretador (Pituguês)', () => {
             describe('Fatiamento (Slicing)', () => {
                 it('Tentar fatiar número', async () => {
                     const retornoLexador = lexador.mapear([`
-                        numero = 123
-                        fatia = numero[0:1]
-                    `], -1);
+                    numero = 123
+                    fatia = numero[0:1]
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(
@@ -4106,9 +4134,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Tentar fatiar booleano', async () => {
                     const retornoLexador = lexador.mapear([`
-                        logico = verdadeiro
-                        fatia = logico[0:1]
-                    `], -1);
+                    logico = verdadeiro
+                    fatia = logico[0:1]
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(
@@ -4121,9 +4149,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Tentar fatiar dicionário (não suportado como intervalo)', async () => {
                     const retornoLexador = lexador.mapear([`
-                        dic = {'a': 1, 'b': 2}
-                        fatia = dic[0:1]
-                    `], -1);
+                    dic = {'a': 1, 'b': 2}
+                    fatia = dic[0:1]
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                     const retornoInterpretador = await interpretador.interpretar(
@@ -4179,9 +4207,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Tentativa de formatar uma string como ponto flutuante', async () => {
                     const retornoLexador = lexador.mapear([`
-                        valor = "estudante"
-                        escreva(f"{valor:.2f}")
-                    `], -1);
+                    valor = "estudante"
+                    escreva(f"{valor:.2f}")
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
@@ -4191,8 +4219,8 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Variável não definida dentro da f-string', async () => {
                     const retornoLexador = lexador.mapear([`
-                        escreva(f"O resultado é: {resultado_fantasma:.2f}")
-                    `], -1);
+                    escreva(f"O resultado é: {resultado_fantasma:.2f}")
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
@@ -4203,9 +4231,9 @@ describe('Interpretador (Pituguês)', () => {
 
             it('Tentativa de formatação de ponto flutuante usando formatar() com valor string', async () => {
                 const retornoLexador = lexador.mapear([`
-                    valor = "1234.56789"
-                    escreva("Duas casas decimais: {:.2f}".formatar(valor))
-                `], -1);
+                valor = "1234.56789"
+                escreva("Duas casas decimais: {:.2f}".formatar(valor))
+            `], -1);
 
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                     retornoLexador,
@@ -4220,9 +4248,9 @@ describe('Interpretador (Pituguês)', () => {
 
             it('Deve dar erro ao tentar alterar valor de uma tupla (Imutabilidade)', async () => {
                 const retornoLexador = lexador.mapear([`
-                    t = (1, 2, 3)
-                    t[0] = 999
-                `], -1);
+                t = (1, 2, 3)
+                t[0] = 999
+            `], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
 
                 const retornoInterpretador = await interpretador.interpretar(
@@ -4390,10 +4418,10 @@ describe('Interpretador (Pituguês)', () => {
             describe('tupla() e vetor()', () => {
                 it('Erro em transformar vetor para vetor', async () => {
                     const retornoLexador = lexador.mapear([`
-                        vetor_muito_legal = [1, 2, 3]
-                        vetor = vetor(vetor_muito_legal)
-                        escreva(vetor);
-                    `], -1);
+                    vetor_muito_legal = [1, 2, 3]
+                    vetor = vetor(vetor_muito_legal)
+                    escreva(vetor);
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4409,10 +4437,10 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Erro em transformar tupla para tupla', async () => {
                     const retornoLexador = lexador.mapear([`
-                        tupla_muito_legal = (1, 2, 3)
-                        tupla = tupla(tupla_muito_legal)
-                        escreva(tupla);
-                    `], -1);
+                    tupla_muito_legal = (1, 2, 3)
+                    tupla = tupla(tupla_muito_legal)
+                    escreva(tupla);
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4430,10 +4458,10 @@ describe('Interpretador (Pituguês)', () => {
             describe('paraTupla() e paraVetor()', () => {
                 it('Erro em transformar vetor para vetor usando paraVetor()', async () => {
                     const retornoLexador = lexador.mapear([`
-                        vetor_muito_legal = [1, 2, 3]
-                        vetor = vetor_muito_legal.paraVetor()
-                        escreva(vetor);
-                    `], -1);
+                    vetor_muito_legal = [1, 2, 3]
+                    vetor = vetor_muito_legal.paraVetor()
+                    escreva(vetor);
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4449,10 +4477,10 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Erro em transformar tupla para tupla usando paraTupla()', async () => {
                     const retornoLexador = lexador.mapear([`
-                        tupla_muito_legal = (1, 2, 3)
-                        tupla = tupla_muito_legal.paraTupla()
-                        escreva(tupla);
-                    `], -1);
+                    tupla_muito_legal = (1, 2, 3)
+                    tupla = tupla_muito_legal.paraTupla()
+                    escreva(tupla);
+                `], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
                         retornoLexador,
                         -1
@@ -4548,8 +4576,8 @@ describe('Interpretador (Pituguês)', () => {
 
             it('Deve falhar ao tentar usar atribuição composta em um literal (Syntax Error)', async () => {
                 const retornoLexador = lexador.mapear([`
-                    10 += 5
-                `], -1);
+                10 += 5
+            `], -1);
 
                 const retornoAvaliador = await avaliadorSintatico.analisar(retornoLexador, -1);
 
@@ -4559,8 +4587,8 @@ describe('Interpretador (Pituguês)', () => {
 
             it('Deve falhar ao tentar atualizar variável não definida (Runtime Error)', async () => {
                 const retornoLexador = lexador.mapear([`
-                    x += 10
-                `], -1);
+                x += 10
+            `], -1);
 
                 const retornoAvaliador = await avaliadorSintatico.analisar(retornoLexador, -1);
 
@@ -4665,9 +4693,9 @@ describe('Interpretador (Pituguês)', () => {
             describe('vetor.limpar()', () => {
                 it('Falha - Tentar limpar uma variável que não é um vetor (ex: número)', async () => {
                     const retornoLexador = lexador.mapear([`
-                        numero = 10
-                        numero.limpar()
-                    `], -1);
+                    numero = 10
+                    numero.limpar()
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4678,9 +4706,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Falha - Tentar limpar um vetor nulo', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = nulo
-                        v.limpar()
-                    `], -1);
+                    v = nulo
+                    v.limpar()
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4692,9 +4720,9 @@ describe('Interpretador (Pituguês)', () => {
             describe('vetor.contar()', () => {
                 it('Falha - Chamar contar() sem passar o argumento do elemento', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1, 2]
-                        escreva(v.contar())
-                    `], -1);
+                    v = [1, 2]
+                    escreva(v.contar())
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4704,9 +4732,9 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Falha - Passar mais argumentos do que o esperado (deve ignorar ou falhar)', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1, 2]
-                        escreva(v.contar(1, 2, 3))
-                    `], -1);
+                    v = [1, 2]
+                    escreva(v.contar(1, 2, 3))
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4718,10 +4746,10 @@ describe('Interpretador (Pituguês)', () => {
             describe('vetor.estender()', () => {
                 it('Falha - Tentar estender com um valor booleano', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1]
-                        v.estender(verdadeiro)
-                        escreva(v)
-                    `], -1);
+                    v = [1]
+                    v.estender(verdadeiro)
+                    escreva(v)
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4731,10 +4759,10 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Falha - Estender com nulo', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1]
-                        v.estender(nulo)
-                        escreva(v)
-                    `], -1);
+                    v = [1]
+                    v.estender(nulo)
+                    escreva(v)
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4746,9 +4774,9 @@ describe('Interpretador (Pituguês)', () => {
             describe('vetor.inserir()', () => {
                 it('Falha - Inserir passando texto no lugar do índice', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1, 2]
-                        v.inserir('texto', 10)
-                    `], -1);
+                    v = [1, 2]
+                    v.inserir('texto', 10)
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4767,10 +4795,10 @@ describe('Interpretador (Pituguês)', () => {
 
                 it('Falha - Índice muito negativo (fora da realidade do vetor)', async () => {
                     const retornoLexador = lexador.mapear([`
-                        v = [1, 2]
-                        v.inserir(-999, 0)
-                        escreva(v)
-                    `], -1);
+                    v = [1, 2]
+                    v.inserir(-999, 0)
+                    escreva(v)
+                `], -1);
 
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
@@ -4926,4 +4954,3 @@ describe('Interpretador (Pituguês)', () => {
         });
     });
 });
-})


### PR DESCRIPTION
Este PR diz respeito a issue #1095.

No momento, só é possível utilizar os Decoradores quando há uma **função anônima** dentro da `função de decorador`.

Exemplo usando função anônima (funcionando):
```bash
função de decorador meu_decorador(decorado: função<qualquer>):
    retorna função():
        escreva("Executando algo antes da função...")
        decorado()
        escreva("Executando algo depois da função...")

@meu_decorador
função ola_mundo():
    escreva("Olá, Mundo!")

ola_mundo()
```

Exemplo usando função nomeada (não funcionando):
```bash
função de decorador meu_decorador(decorado: função<qualquer>):
    função envelope():
        escreva("Executando algo antes da função...")
        decorado()
        escreva("Executando algo depois da função...")
    
    retorna envelope

@meu_decorador
função ola_mundo():
    escreva("Olá, Mundo!")

ola_mundo()
```

Além de ser feita essa implementação dos Decoradores, também foi corrigido um erro de escopo no arquivo `interpretador-pitugues.test.ts`, em que os testes de `Cenário de Falha` estavam dentro do escopo dos testes de `Cenário de Sucesso`.