### PR TITLE
Aviso comparação tipos diferentes

### DIFF
--- a/fontes/analisador-semantico/analisador-semantico.ts
+++ b/fontes/analisador-semantico/analisador-semantico.ts
@@ -344,6 +344,14 @@ export class AnalisadorSemantico extends AnalisadorSemanticoBase {
         // Marca como inicializada após atribuição
         this.gerenciadorEscopos.marcarComoInicializada(simboloAlvo.lexema, expressao.valor);
 
+        // Atualiza tipo se a variável não foi tipada explicitamente
+        if (variavel.tipo === 'qualquer') {
+            const tipoInferido = this.obterTipoExpressao(expressao.valor);
+            if (tipoInferido && tipoInferido !== 'qualquer') {
+                variavel.tipo = tipoInferido;
+            }
+        }
+
         // TODO: Readaptar para trabalhar com `expressao.alvo` sendo um construto.
         switch (expressao.alvo.constructor) {
             case Variavel:
@@ -614,9 +622,14 @@ export class AnalisadorSemantico extends AnalisadorSemanticoBase {
         }
 
         const operadoresMatematicos = ['ADICAO', 'SUBTRACAO', 'MULTIPLICACAO', 'DIVISAO', 'MODULO'];
+        const operadoresComparacao = ['MAIOR', 'MAIOR_IGUAL', 'MENOR', 'MENOR_IGUAL', 'IGUAL', 'DIFERENTE'];
 
         if (operadoresMatematicos.includes(binario.operador.tipo)) {
             this.verificarTiposOperandos(binario);
+        }
+
+        if (operadoresComparacao.includes(binario.operador.tipo)) {
+            this.verificarTiposComparacao(binario);
         }
 
         if (binario.operador.tipo === 'DIVISAO') {
@@ -679,6 +692,25 @@ export class AnalisadorSemantico extends AnalisadorSemanticoBase {
                     `Operação entre tipos diferentes: tipo esquerdo '${tipoEsquerda}' e tipo direito '${tipoDireita}'. O resultado será resolvido implicitamente.`
                 );
             }
+        }
+    }
+
+    /**
+     * Verifica se os tipos dos operandos em uma comparação são compatíveis
+     */
+    private verificarTiposComparacao(binario: Binario): void {
+        const tipoEsquerda = this.obterTipoExpressao(binario.esquerda);
+        const tipoDireita = this.obterTipoExpressao(binario.direita);
+        const tiposNumericos = ['inteiro', 'número', 'real'];
+
+        if (
+            (tipoEsquerda === 'texto' && tiposNumericos.includes(tipoDireita)) ||
+            (tiposNumericos.includes(tipoEsquerda) && tipoDireita === 'texto')
+        ) {
+            this.aviso(
+                binario.operador,
+                `Esta comparação ocorre entre tipos texto e inteiro, e o resultado pode não ser o desejado.`
+            );
         }
     }
 

--- a/fontes/analisador-semantico/analisador-semantico.ts
+++ b/fontes/analisador-semantico/analisador-semantico.ts
@@ -709,7 +709,7 @@ export class AnalisadorSemantico extends AnalisadorSemanticoBase {
         ) {
             this.aviso(
                 binario.operador,
-                `Esta comparação ocorre entre tipos texto e inteiro, e o resultado pode não ser o desejado.`
+                `Esta comparação ocorre entre tipos ${tipoEsquerda} e ${tipoDireita}, e o resultado pode não ser o desejado.`
             );
         }
     }

--- a/testes/analisador-semantico/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/analisador-semantico.test.ts
@@ -539,6 +539,33 @@ describe('Analisador semântico', () => {
             expect(errosOperacaoAritmetica.length).toBe(0);
         });
 
+        it('Comparação entre texto (retorno de leia) e inteiro - deve gerar aviso', async () => {
+            const retornoLexador = lexador.mapear(
+                [
+                    'variável salário_mensal',
+                    'variável salário_anual',
+                    'salário_mensal = leia("Digite seu salário mensal (em reais):")',
+                    'salário_anual = salário_mensal * 12',
+                    'escreva("salário_mensal = ${salário_mensal}, salário_anual=${salário_anual}")',
+                    'se salário_anual>1000000 {',
+                    '  escreva("a pessoa é rica!!!")',
+                    '}',
+                ],
+                -1
+            );
+            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+            const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
+                retornoAvaliadorSintatico.declaracoes
+            );
+
+            expect(retornoAnalisadorSemantico).toBeTruthy();
+            const avisosComparacao = retornoAnalisadorSemantico.diagnosticos.filter(
+                d => d.mensagem?.includes('Esta comparação ocorre entre tipos texto e inteiro')
+            );
+
+            expect(avisosComparacao.length).toBeGreaterThanOrEqual(1);
+        });
+
         it('Atribuição de função', async () => {
             const retornoLexador = lexador.mapear(
                 ['var f = função(a, b) {', '   escreva(a + b)', '}', 'f(1)'],
@@ -876,7 +903,8 @@ describe('Analisador semântico', () => {
                     retornoAvaliadorSintatico.declaracoes
                 );
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(4);
+                // 4 aritméticos (1 aviso de concatenação + 3 erros) + 4 avisos de comparação texto vs inteiro
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(8);
             });
 
             it('verificar operação divisão por zero', async () => {

--- a/testes/analisador-semantico/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/analisador-semantico.test.ts
@@ -560,7 +560,7 @@ describe('Analisador semântico', () => {
 
             expect(retornoAnalisadorSemantico).toBeTruthy();
             const avisosComparacao = retornoAnalisadorSemantico.diagnosticos.filter(
-                d => d.mensagem?.includes('Esta comparação ocorre entre tipos texto e inteiro')
+                d => d.mensagem?.includes('Esta comparação ocorre entre tipos')
             );
 
             expect(avisosComparacao.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
Exemplo:

```js
variável salário_mensal
variável salário_anual

salário_mensal = leia("Digite seu salário mensal (em reais):")

salário_anual = salário_mensal * 12

escreva("salário_mensal = ${salário_mensal}, salário_anual=${salário_anual}")

se salário_anual>1000000 {
  escreva("a pessoa é rica!!!")
}
```

Nenhum aviso de tipos diferentes era dado aqui:

```js
se salário_anual>1000000 {
```

Essa PR corrige isso.