### PR TITLE
Escrever atribuições mostra a representação XML da operação, ao invés do valor resolvido.

### DIFF
--- a/fontes/interpretador/depuracao/interpretador-com-depuracao.ts
+++ b/fontes/interpretador/depuracao/interpretador-com-depuracao.ts
@@ -6,7 +6,7 @@ import { ComandoDepurador, InterpretadorComDepuracaoInterface } from '../../inte
 import { TipoEscopoExecucao } from '../../interfaces/escopo-execucao';
 import { RetornoQuebra } from '../../quebras';
 import { RetornoInterpretadorInterface } from '../../interfaces/retornos/retorno-interpretador-interface';
-import { Binario, Chamada, Construto } from '../../construtos';
+import { AtribuicaoPorIndice, Atribuir, Binario, Chamada, Construto } from '../../construtos';
 import { Interpretador } from '../interpretador';
 import { EspacoMemoria } from '../espaco-memoria';
 
@@ -102,10 +102,20 @@ export class InterpretadorComDepuracao
     }
 
     override async avaliarArgumentosEscreva(argumentos: Construto[]): Promise<string> {
+        if (this.constructor !== InterpretadorComDepuracao) {
+            return await super.avaliarArgumentosEscreva(argumentos);
+        }
+
         let formatoTexto: string = '';
 
         for (const argumento of argumentos) {
             const resultadoAvaliacao = await this.avaliar(argumento);
+
+            if (argumento instanceof Atribuir || argumento instanceof AtribuicaoPorIndice) {
+                formatoTexto += `${argumento.paraTexto()} `;
+                continue;
+            }
+
             let valor = this.resolverValor(resultadoAvaliacao);
             formatoTexto += `${this.paraTexto(valor)} `;
         }

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -3,6 +3,7 @@ import {
     AcessoMetodo,
     AcessoMetodoOuPropriedade,
     AcessoPropriedade,
+    Construto,
     Agrupamento,
     AtribuicaoPorIndice,
     Atribuir,
@@ -113,6 +114,35 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
      */
     protected pontoInicializacaoBibliotecasGlobais() {
         carregarBibliotecasGlobais(this.pilhaEscoposExecucao);
+    }
+
+    protected override async avaliarArgumentosEscreva(argumentos: Construto[]): Promise<string> {
+        if (this.constructor !== Interpretador) {
+            return await super.avaliarArgumentosEscreva(argumentos);
+        }
+
+        let formatoTexto = '';
+
+        for (const argumento of argumentos) {
+            let resultadoAvaliacao = await this.avaliar(argumento);
+            if (
+                resultadoAvaliacao &&
+                resultadoAvaliacao.hasOwnProperty &&
+                resultadoAvaliacao.hasOwnProperty('valorRetornado')
+            ) {
+                resultadoAvaliacao = resultadoAvaliacao.valorRetornado;
+            }
+
+            if (argumento instanceof Atribuir || argumento instanceof AtribuicaoPorIndice) {
+                formatoTexto += `${argumento.paraTexto()} `;
+                continue;
+            }
+
+            const valor = this.resolverValor(resultadoAvaliacao);
+            formatoTexto += `${this.paraTexto(valor)} `;
+        }
+
+        return formatoTexto.trimEnd();
     }
 
     protected resolverReferenciaMontao(referenciaMontao: ReferenciaMontao) {

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -22,6 +22,26 @@ describe('Interpretador (Pituguês)', () => {
 
         describe('Cenários de sucesso', () => {
             describe('Atribuições', () => {
+                it('Atribuição como expressão em escreva mantém valor em Pituguês', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'x = 10',
+                        'escreva(x = 99)',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('99');
+                });
+
                 it('Trivial', async () => {
                     const retornoLexador = lexador.mapear([
                         'a = 1',

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -366,6 +366,48 @@ describe('Interpretador', () => {
             });
 
             describe('Atribuições', () => {
+                it('Atribuição como expressão em escreva retorna representação XML (issue #1138)', async () => {
+                    const saidas: string[] = [];
+                    const retornoLexador = lexador.mapear(['var x = 10', 'escreva(x = 99)'], -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: string) => {
+                        saidas.push(saida);
+                    };
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(saidas).toHaveLength(1);
+                    expect(saidas[0]).toContain('<atribuir alvo=<variável nome=x tipo=número />');
+                    expect(saidas[0]).toContain('valor=<literal valor=99 tipo=número />');
+                });
+
+                it('Atribuição por índice em escreva retorna representação XML', async () => {
+                    const saidas: string[] = [];
+                    const retornoLexador = lexador.mapear(
+                        ['var lista = [1, 2, 3]', 'escreva(lista[0] = 99)', 'escreva(lista[0])'],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetorno = (saida: string) => {
+                        saidas.push(saida);
+                    };
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(saidas).toHaveLength(2);
+                    expect(saidas[0]).toContain('<atribuição-por-índice objeto=<variável nome=lista');
+                    expect(saidas[0]).toContain('valor=<literal valor=99 tipo=número />');
+                    expect(saidas[1]).toBe('99');
+                });
+
                 it('Trivial var/variavel', async () => {
                     const retornoLexador = lexador.mapear(
                         [


### PR DESCRIPTION
Resolve https://github.com/DesignLiquido/delegua/issues/1138.