### PR TITLE
Corrige falso positivo de variável não usada em blocos `para cada`

### DIFF
--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -20,6 +20,7 @@ import {
     Vetor,
     TuplaN,
     AcessoIndiceVariavel,
+    Dupla,
 } from '../../construtos';
 import {
     Const,
@@ -30,6 +31,7 @@ import {
     Expressao,
     Falhar,
     FuncaoDeclaracao,
+    ParaCada,
     Retorna,
     Var,
 } from '../../declaracoes';
@@ -196,39 +198,40 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
         return this.verificarTipoDe(expressao.valor);
     }
 
-    private verificarTipoDe(valor: Construto): Promise<any> {
+    private async verificarTipoDe(valor: Construto): Promise<any> {
         switch (valor.constructor) {
             case Agrupamento:
                 const valorAgrupamento = valor as Agrupamento;
-                return this.verificarTipoDe(valorAgrupamento.expressao);
+                return await this.verificarTipoDe(valorAgrupamento.expressao);
             case Binario:
                 const valorBinario = valor as Binario;
-                this.verificarTipoDe(valorBinario.direita);
-                this.verificarTipoDe(valorBinario.esquerda);
+                await this.verificarTipoDe(valorBinario.direita);
+                await this.verificarTipoDe(valorBinario.esquerda);
                 break;
             case Variavel:
                 const valorVariavel = valor as Variavel;
-                return this.verificarVariavel(valorVariavel);
+                return await this.verificarVariavel(valorVariavel);
         }
 
         return Promise.resolve();
     }
 
-    visitarExpressaoFalhar(expressao: Falhar): Promise<any> {
-        return this.verificarFalhar(expressao.explicacao);
+    async visitarExpressaoFalhar(expressao: Falhar): Promise<any> {
+        return await this.verificarFalhar(expressao.explicacao);
     }
 
-    private verificarFalhar(valor: Construto): Promise<any> {
+    private async verificarFalhar(valor: Construto): Promise<any> {
         if (valor instanceof Binario) {
-            this.verificarFalhar(valor.direita);
-            this.verificarFalhar(valor.esquerda);
+            await this.verificarFalhar(valor.direita);
+            await this.verificarFalhar(valor.esquerda);
         }
         if (valor instanceof Agrupamento) {
-            return this.verificarFalhar(valor.expressao);
+            return await this.verificarFalhar(valor.expressao);
         }
         if (valor instanceof Variavel) {
-            return this.verificarVariavel(valor);
+            return await this.verificarVariavel(valor);
         }
+
         return Promise.resolve();
     }
 
@@ -288,6 +291,8 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
     }
 
     visitarExpressaoDeChamada(expressao: Chamada) {
+        this.marcarVariaveisUsadasEmExpressao(expressao.entidadeChamada);
+
         // Garante que toda a árvore de argumentos seja validada e marcada como usada.
         for (const argumento of expressao.argumentos) {
             this.marcarVariaveisUsadasEmExpressao(argumento);
@@ -506,6 +511,86 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
 
     override visitarDeclaracaoEnquanto(declaracao: Enquanto) {
         return this.verificarCondicao(declaracao.condicao);
+    }
+
+    override async visitarDeclaracaoParaCada(declaracao: ParaCada) {
+        this.marcarVariaveisUsadasEmExpressao(declaracao.vetorOuDicionario);
+
+        if (declaracao.vetorOuDicionario) {
+            await declaracao.vetorOuDicionario.aceitar(this);
+        }
+
+        this.gerenciadorEscopos.empilharEscopo();
+
+        try {
+            if (declaracao.variavelIteracao) {
+                if (declaracao.variavelIteracao instanceof Variavel) {
+                    const nomeVariavel = declaracao.variavelIteracao.simbolo.lexema;
+
+                    this.gerenciadorEscopos.declarar(nomeVariavel, {
+                        nome: nomeVariavel,
+                        tipo: 'qualquer',
+                        imutavel: false,
+                        valor: null,
+                        inicializada: true,
+                        usada: false,
+                        hashArquivo: declaracao.hashArquivo,
+                        linha: declaracao.linha
+                    });
+                } else if (declaracao.variavelIteracao instanceof Dupla) {
+                    const dupla = declaracao.variavelIteracao;
+
+                    const primeiraVariavel = dupla.primeiro;
+                    const segundaVariavel = dupla.segundo;
+
+                    if (primeiraVariavel instanceof Variavel) {
+                        const nome = primeiraVariavel.simbolo.lexema;
+                        this.gerenciadorEscopos.declarar(nome, {
+                            nome,
+                            tipo: 'qualquer',
+                            imutavel: false,
+                            valor: null,
+                            inicializada: true,
+                            usada: false,
+                            hashArquivo: declaracao.hashArquivo,
+                            linha: declaracao.linha
+                        });
+                    }
+
+                    if (segundaVariavel instanceof Variavel) {
+                        const nome = segundaVariavel.simbolo.lexema;
+                        this.gerenciadorEscopos.declarar(nome, {
+                            nome,
+                            tipo: 'qualquer',
+                            imutavel: false,
+                            valor: null,
+                            inicializada: true,
+                            usada: false,
+                            hashArquivo: declaracao.hashArquivo,
+                            linha: declaracao.linha
+                        });
+                    }
+                }
+            }
+
+            if (declaracao.corpo) {
+                if (Array.isArray(declaracao.corpo)) {
+                    for (const instrucao of declaracao.corpo) {
+                        await instrucao.aceitar(this);
+                    }
+                } else if ((declaracao.corpo as any).declaracoes) {
+                    for (const instrucao of (declaracao.corpo as any).declaracoes) {
+                        await instrucao.aceitar(this);
+                    }
+                } else {
+                    await declaracao.corpo.aceitar(this);
+                }
+            }
+        } finally {
+            this.gerenciadorEscopos.desempilharEscopo();
+        }
+
+        return Promise.resolve();
     }
 
     private verificarCondicao(condicao: Construto): Promise<void> {

--- a/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
@@ -5,60 +5,61 @@ import { Atribuir } from '../../../../fontes/construtos/atribuir';
 import { Variavel } from '../../../../fontes/construtos/variavel';
 import { Literal } from '../../../../fontes/construtos/literal';
 import { SimboloInterface } from '../../../../fontes/interfaces';
+
 describe('Analisador semântico', () => {
     let lexador: LexadorPitugues;
     let avaliadorSintatico: AvaliadorSintaticoPitugues;
     let analisadorSemantico: AnalisadorSemanticoPitugues;
-    
+
     beforeEach(() => {
         lexador = new LexadorPitugues();
         avaliadorSintatico = new AvaliadorSintaticoPitugues();
         analisadorSemantico = new AnalisadorSemanticoPitugues();
     });
-    
+
     describe('analisar()', () => {
         describe('Cenários de diagnósticos zerados', () => {
             it('Olá Mundo', async () => {
                 const retornoLexador = lexador.mapear(["escreva('Olá mundo')"], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
-            });            
-            
+            });
+
             it('Função sem corpo', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao minhaFuncao():`
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);  
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Absoluto', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao maior(x, y):`,
                     `    retorna (x + y + (x - y).absoluto()) \ 2`,
-                    
+
                     ` x = inteiro(leia("Digite o primeiro número: "))`,
                     ` y = inteiro(leia("Digite o segundo número: "))`,
                     ` z = inteiro(leia("Digite o terceiro número: "))`,
                     ` maior_numero = maior(x, maior(y, z))`,
                     `escreva("\${maior_numero} eh o maior")`,
                 ], -1);
-                
+
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Funções sem tipo de retorno declarado podem retornar valores (tratados como 'qualquer')
                 // As variáveis x, y, z são corretamente marcadas como usadas na interpolação e nas chamadas
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             describe('Declaração se ... senão se ... senão', () => {
                 it('Caso com os três blocos', async () => {
                     const retornoLexador = lexador.mapear(
@@ -75,13 +76,13 @@ describe('Analisador semântico', () => {
                     );
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
             });
         });
-        
+
         describe('Cenários de diagnósticos detectados', () => {
             it('Atribuição e reatribuição de variável', async () => {
                 const retornoLexador = lexador.mapear([
@@ -90,12 +91,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
-            
+
+
             it('Não retornando o tipo que a função definiu - texto', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao executar(valor1, valor2):`,
@@ -104,11 +105,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Não retornando o tipo que a função definiu - inteiro', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao executar(valor1, valor2):`,
@@ -117,11 +118,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Função sem retorno de valor', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao executar(valor1, valor2):`,
@@ -129,11 +130,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Escolha com tipos diferentes em \'caso\'', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao facaAlgumaCoisa():`,
@@ -146,29 +147,29 @@ describe('Analisador semântico', () => {
                     `    caso '1':`,
                     `        facaAlgumaCoisa()`,
                 ], -1);
-                
+
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(3);
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe('\'caso 0:\' não é do mesmo tipo esperado em \'escolha\' (esperado: texto, atual: número).');
                 expect(retornoAnalisadorSemantico.diagnosticos[1].mensagem).toBe('\'caso 1:\' não é do mesmo tipo esperado em \'escolha\' (esperado: texto, atual: número).');
                 expect(retornoAnalisadorSemantico.diagnosticos[2].mensagem).toBe("Variável 'opcao' foi declarada mas nunca usada.");
             });
-            
+
             it('Leia por padrão retorna texto', async () => {
                 const retornoLexador = lexador.mapear([
                     ' opcao = leia(\'Digite a opção desejada: \')',
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe("Variável 'opcao' foi declarada mas nunca usada.");
             });
-            
-            
+
+
             it('Chamada de função direta', async () => {
                 const retornoLexador = lexador.mapear([
                     `função f(a, b):`,
@@ -177,12 +178,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe('Função \'f\' espera 2 parâmetros. Atual: 1.');
             });
-            
+
             it('Chamada de função com tipos inválidos na passagem dos parametros', async () => {
                 const retornoLexador = lexador.mapear([
                     `função f(a, b, c, d):`,
@@ -191,11 +192,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
 
 
             it('Chamada de função com variáveis declaradas como argumentos, sem espaços e com comentário', async () => {
@@ -223,19 +224,19 @@ describe('Analisador semântico', () => {
                 for (let i = 1; i <= 256; i++) {
                     acumulador += 'a' + i + ', ';
                 }
-                
+
                 acumulador = acumulador.substring(0, acumulador.length - 2);
-                
+
                 const funcaoCom256Argumentos1 = ' f1 = funcao(' + acumulador + ') {}';
                 const funcaoCom256Argumentos2 = 'funcao f2(' + acumulador + ') {}';
-                
+
                 const retornoLexador = lexador.mapear([
                     funcaoCom256Argumentos1,
                     funcaoCom256Argumentos2
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -244,19 +245,19 @@ describe('Analisador semântico', () => {
                 for (let i = 1; i <= 256; i++) {
                     acumulador += 'a' + i + ', ';
                 }
-                
+
                 acumulador = acumulador.substring(0, acumulador.length - 2);
-                
+
                 const funcaoCom256Argumentos1 = ' f1 = funcao(' + acumulador + ') {}';
                 const funcaoCom256Argumentos2 = 'funcao f2(' + acumulador + ') {}';
-                
+
                 const retornoLexador = lexador.mapear([
                     funcaoCom256Argumentos1,
                     funcaoCom256Argumentos2
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -268,17 +269,15 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
             });
-            
+
         });
-        
+
         describe('Cenários enquanto', () => {
             describe('Cenários de diagnósiticos zerados', () => {
-                
-                
                 it('com condicional verdadeiro', async () => {
                     const retornoLexador = lexador.mapear([
                         `enquanto verdadeiro:`,
@@ -287,11 +286,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('com condicional falso', async () => {
                     const retornoLexador = lexador.mapear([
                         `enquanto falso:`,
@@ -300,11 +299,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('com variável definida com valor válido', async () => {
                     const retornoLexador = lexador.mapear([
                         `const condicional = verdadeiro`,
@@ -314,11 +313,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('com variável e expressão binária', async () => {
                     const retornoLexador = lexador.mapear([
                         `const valor = 1`,
@@ -328,11 +327,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('com variável e agrupamento', async () => {
                     const retornoLexador = lexador.mapear([
                         `valor = 1`,
@@ -342,7 +341,7 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
@@ -356,11 +355,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('sucesso - verificar valores lógicos nas operações binárias', async () => {
                     const retornoLexador = lexador.mapear([
                         ` x = 5 > 2`,
@@ -374,8 +373,8 @@ describe('Analisador semântico', () => {
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
-                
+
+
                 it('sucesso - verificar operações aritméticas', async () => {
                     const retornoLexador = lexador.mapear([
                         ` x = 1`,
@@ -390,7 +389,7 @@ describe('Analisador semântico', () => {
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('sucesso - verificar função declarada', async () => {
                     const retornoLexador = lexador.mapear([
                         `funcao funcaoExistente():`,
@@ -406,7 +405,7 @@ describe('Analisador semântico', () => {
                 });
             });
             describe('Cenários de diagnósticos detectados', () => {
-                
+
                 it('com iavel definida com valor inválido', async () => {
                     const retornoLexador = lexador.mapear([
                         `const condicional = "invalido"`,
@@ -416,11 +415,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 // TODO: Mudar este teste ao reimplementar operações bit a bit com números.
                 it('verificar valores lógicos nas operações binárias e agrupamento', async () => {
                     const retornoLexador = lexador.mapear([
@@ -432,11 +431,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
                 });
-                
+
                 it('verificar valores lógicos nas operações binárias sem agrupamento', async () => {
                     const retornoLexador = lexador.mapear([
                         ` x = 5`,
@@ -447,11 +446,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
                 });
-                
+
                 it('verificar operações aritméticas', async () => {
                     const retornoLexador = lexador.mapear([
                         ` x = 'texto'`,
@@ -466,7 +465,7 @@ describe('Analisador semântico', () => {
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(4);
                 });
-                
+
                 it('verificar operação divisão por zero', async () => {
                     const retornoLexador = lexador.mapear([
                         " x = 3",
@@ -498,7 +497,49 @@ describe('Analisador semântico', () => {
                 });
             });
         });
-        
+
+        describe('Cenários para cada', () => {
+            it('Iteração simples em texto não deve gerar falso positivo de variável não usada', async () => {
+                const retornoLexador = lexador.mapear([
+                    'frase = "Venha aprender Pituguês na Python Brasil 2025!"',
+                    'piramide = []',
+                    'para cada palavra em frase.dividir(" "):',
+                    '    escreva(palavra)',
+                    '    piramide.adicionar(palavra)'
+                ], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
+                    retornoAvaliadorSintatico.declaracoes
+                );
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+
+            it('Iteração dupla em dicionário não deve gerar falso positivo de variável não usada', async () => {
+                const retornoLexador = lexador.mapear([
+                    'meus_dados = {"nome": "Victor", "linguagem": "Pituguês"}',
+                    'para cada chave, valor em meus_dados:',
+                    '    escreva(chave, valor)'
+                ], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                    retornoLexador,
+                    -1
+                );
+                const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
+                    retornoAvaliadorSintatico.declaracoes
+                );
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+        });
+
         describe('Cenários tipo de', () => {
             describe('Cenários de diagnósticos zerados', () => {
                 it('tipo de literal simples deve cair no retorno padrão', async () => {
@@ -506,22 +547,22 @@ describe('Analisador semântico', () => {
                         ['escreva(tipo (1))'],
                         -1
                     );
-                    
+
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
 
                             retornoAvaliadorSintatico.declaracoes
                     );
-                    
+
                     const retorno = await analisadorSemantico.analisar(
                         retornoAvaliadorSintatico.declaracoes
                     );
-                    
+
                     expect(retorno).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
-                
+
+
                 it('com variável definida com valor válido', async () => {
                     const retornoLexador = lexador.mapear(
                         [' condicional = verdadeiro     ', 'escreva(tipo(condicional))                '],
@@ -534,8 +575,8 @@ describe('Analisador semântico', () => {
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
-                
+
+
                 it('tipo de com variável definida e agrupamento', async () => {
                     const retornoLexador = lexador.mapear([
                         "a = 1      ",
@@ -549,7 +590,7 @@ describe('Analisador semântico', () => {
                 });
             });
         });
-        
+
     describe('Cenários falhar', () => {
         describe('Cenários de diagnósticos zerados', () => {
             it('Sucesso - falhar com variável definida com valor válido', async () => {
@@ -590,7 +631,7 @@ describe('Analisador semântico', () => {
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
         });
-        
+
 
             describe('Cenários conversão implicita', () => {
                 describe('Cenários de diagnósticos zerados', () => {
@@ -601,12 +642,12 @@ describe('Analisador semântico', () => {
                         ], -1);
                         const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                         const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                        
+
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
                 });
-                
+
                 describe('Cenários de aviso', () => {
                     it('Aviso - conversão implicita com variável definida com valor válido', async () => {
                         const retornoLexador = lexador.mapear([
@@ -614,7 +655,7 @@ describe('Analisador semântico', () => {
                         ], -1);
                         const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                         const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                        
+
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(2);
                         const mensagens = retornoAnalisadorSemantico.diagnosticos.map((d: any) => d.mensagem);
@@ -627,7 +668,7 @@ describe('Analisador semântico', () => {
                     });
                 });
             });
-            
+
             describe('Cenários variáveis não inicializada', () => {
                 describe('Cenários de diagnósticos zerados', () => {
                     it('Sucesso - variável de classe inicializada na declaração', async () => {
@@ -641,7 +682,7 @@ describe('Analisador semântico', () => {
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
-                    
+
                     it('Sucesso - variável de classe inicializada após declaração', async () => {
                         const retornoLexador = lexador.mapear([
                             "classe Teste:",
@@ -654,7 +695,7 @@ describe('Analisador semântico', () => {
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
-                    
+
                     it('Sucesso - variável tipo texto inicializada na declaração', async () => {
                         const retornoLexador = lexador.mapear([
                             "classe Teste:",
@@ -666,7 +707,7 @@ describe('Analisador semântico', () => {
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
-                    
+
                     it('Sucesso - variável tipo texto inicializada após declaração', async () => {
                         const retornoLexador = lexador.mapear([
                             "classe Teste:",
@@ -676,7 +717,7 @@ describe('Analisador semântico', () => {
                         ], -1);
                         const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                         const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                        
+
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
@@ -690,11 +731,11 @@ describe('Analisador semântico', () => {
                         ], -1);
                         const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                         const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                        
+
                         expect(retornoAnalisadorSemantico).toBeTruthy();
                         expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                     });
-                    
+
                     it('Erro - escreva sem parâmetro', async () => {
                         const retornoLexador = lexador.mapear([
                             "escreva() ",
@@ -706,7 +747,7 @@ describe('Analisador semântico', () => {
                     });
                 });
             });
-            
+
             describe('Cenários de chamadas de método em variáveis', () => {
                 it('Sucesso - variável usada em chamada de método e resultado atribuído a outra variável', async () => {
                     const retornoLexador = lexador.mapear([
@@ -716,7 +757,7 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     // Não deve haver diagnósticos porque:
                     // 1. 'tex' é usada na chamada de método .dividir()
@@ -724,7 +765,7 @@ describe('Analisador semântico', () => {
                     // 3. O inicializador de 'div' é uma Chamada (método que retorna array), não um Vetor literal
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('Sucesso - múltiplas variáveis com chamadas de método encadeadas', async () => {
                     const retornoLexador = lexador.mapear([
                         `texto = "olá-mundo-teste"`,
@@ -733,11 +774,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('Sucesso - variável usada em expressão binária simples', async () => {
                     const retornoLexador = lexador.mapear([
                         `x = 1`,
@@ -747,12 +788,12 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     // Não deve haver avisos: x e y são usadas em z = x + y, z é usada em escreva
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('Sucesso - variável usada em função embutida', async () => {
                     const retornoLexador = lexador.mapear([
                         `x = 1`,
@@ -761,13 +802,13 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     // x é usada em inteiro(x), y é usada em escreva(y)
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
-                
+
+
                 it('Sucesso - variável usada em chamada de método COM argumento', async () => {
                     const retornoLexador = lexador.mapear([
                         `abc = "teste"`,
@@ -776,11 +817,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
-                
+
                 it('Sucesso - variável usada em chamada de método SEM argumento', async () => {
                     const retornoLexador = lexador.mapear([
                         `abc = "teste"`,
@@ -789,7 +830,7 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
                 });
@@ -833,7 +874,7 @@ describe('Analisador semântico', () => {
                 });
             });
         });
-        
+
         describe('Cenários de redeclaração e atribuição', () => {
             it('Sucesso - atribuição de variável não declarada cria nova variável', async () => {
                 const retornoLexador = lexador.mapear([
@@ -842,12 +883,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 const diagnosticoValor = retornoAnalisadorSemantico.diagnosticos.some(d => d.mensagem?.includes("'valor' foi declarada mas nunca usada"));
                 expect(diagnosticoValor || retornoAnalisadorSemantico.diagnosticos.length === 0).toBeTruthy();
             });
-            
+
             it('Sucesso - reatribuição de variável existente', async () => {
                 const retornoLexador = lexador.mapear([
                     `valor = 10`,
@@ -856,11 +897,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - múltiplas atribuições em sequência', async () => {
                 const retornoLexador = lexador.mapear([
                     `a = 1`,
@@ -870,13 +911,13 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("'b' foi declarada mas nunca usada");
                 expect(retornoAnalisadorSemantico.diagnosticos.length).toBe(1);
             });
         });
-        
+
         describe('Cenários de interpolação de texto', () => {
             it('não deve gerar erro quando interpolação referencia função existente', async () => {
                 const retornoLexador = lexador.mapear(
@@ -908,7 +949,7 @@ describe('Analisador semântico', () => {
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos.some(d => d.mensagem?.includes('usada em interpolação não existe'))).toBe(false);
             });
-            
+
             it('Sucesso - interpolação com variável declarada sem valor inicial', async () => {
                 const retornoLexador = lexador.mapear([
                     `x = nulo`,
@@ -916,11 +957,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - interpolação com variável válida', async () => {
                 const retornoLexador = lexador.mapear([
                     `nome = 'Mundo'`,
@@ -928,12 +969,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 const diagnosticoValor = retornoAnalisadorSemantico.diagnosticos.some(d => d.mensagem?.includes("Variável 'nome' foi declarada mas nunca usada") || d.mensagem?.includes("'nome' foi declarada mas nunca usada"));
                 expect(diagnosticoValor || retornoAnalisadorSemantico.diagnosticos.length === 0).toBeTruthy();
             });
-            
+
             it('Sucesso - interpolação com múltiplas variáveis', async () => {
                 const retornoLexador = lexador.mapear([
                     `x = 10`,
@@ -942,7 +983,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -953,12 +994,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
         });
-        
+
         describe('Cenários de acesso a intervalo de variável', () => {
             it('Chamada de visitarExpressaoAcessoIntervaloVariavel com índices literais', async () => {
                 const retornoLexador = lexador.mapear([
@@ -968,12 +1009,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Atualmente, acesso a intervalo não marca variável como usada
                 expect(retornoAnalisadorSemantico.diagnosticos.length).toBeGreaterThanOrEqual(0);
             });
-            
+
             it('Chamada de visitarExpressaoAcessoIntervaloVariavel com variáveis nos índices', async () => {
                 const retornoLexador = lexador.mapear([
                     `texto = 'abcdef'`,
@@ -984,12 +1025,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Testa que o método visitarExpressaoAcessoIntervaloVariavel é chamado
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Chamada de visitarExpressaoAcessoIntervaloVariavel apenas com início', async () => {
                 const retornoLexador = lexador.mapear([
                     `texto = 'abcdef'`,
@@ -998,11 +1039,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Chamada de visitarExpressaoAcessoIntervaloVariavel apenas com fim', async () => {
                 const retornoLexador = lexador.mapear([
                     `texto = 'abcdef'`,
@@ -1011,12 +1052,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
         });
-        
+
         describe('Cenários de tuplas', () => {
             it('Sucesso - criação e uso de tupla simples com literais', async () => {
                 const retornoLexador = lexador.mapear([
@@ -1025,11 +1066,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Chamada de visitarExpressaoTuplaN com variáveis', async () => {
                 const retornoLexador = lexador.mapear([
                     `x = 10`,
@@ -1039,12 +1080,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Verifica que o código foi executado (tuplas podem ou não marcar variáveis como usadas)
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Chamada de visitarExpressaoTuplaN com expressões binárias', async () => {
                 const retornoLexador = lexador.mapear([
                     `a = 5`,
@@ -1054,14 +1095,14 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Testa que o método visitarExpressaoTuplaN é chamado
                 // Nota: atualmente as variáveis dentro de expressões em tuplas podem não ser marcadas como usadas
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
         });
-        
+
         describe('Cenários de escreva com variáveis', () => {
             it('Sucesso - escreva com variável válida', async () => {
                 const retornoLexador = lexador.mapear([
@@ -1070,11 +1111,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - escreva com múltiplos argumentos', async () => {
                 const retornoLexador = lexador.mapear([
                     `a = 1`,
@@ -1083,11 +1124,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - escreva com função existente', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao teste():`,
@@ -1096,12 +1137,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
         });
-        
+
         describe('Cenários de uso de variáveis em expressões', () => {
             it('Sucesso - variável usada em expressão com operador de exponenciação', async () => {
                 const retornoLexador = lexador.mapear([
@@ -1112,11 +1153,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - variável usada em chamada de método', async () => {
                 const retornoLexador = lexador.mapear([
                     `tex = "teste"`,
@@ -1125,11 +1166,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - variáveis usadas em expressões binárias com exponenciação', async () => {
                 const retornoLexador = lexador.mapear([
                     `x1 = 3`,
@@ -1141,7 +1182,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Todas as variáveis são usadas:
                 // - x1, y1, x2, y2: usadas na expressão binária
@@ -1149,7 +1190,7 @@ describe('Analisador semântico', () => {
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
         });
-        
+
         describe('Cenários adicionais de funções', () => {
             it('Sucesso - função sem tipo de retorno declarado mas que retorna valor', async () => {
                 const retornoLexador = lexador.mapear([
@@ -1159,7 +1200,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -1168,16 +1209,16 @@ describe('Analisador semântico', () => {
                     ['minhaFuncao()'],
                     -1
                 );
-                
+
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-                
+
                 const retorno = await analisadorSemantico.analisar(
                     retornoAvaliadorSintatico.declaracoes
                 );
-                
+
                 expect(retorno.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - função que não retorna valor', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao imprimir(mensagem):`,
@@ -1186,11 +1227,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - função com múltiplos parâmetros e corpo complexo', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao processar(x, y, z):`,
@@ -1204,11 +1245,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - função recursiva simples', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao fatorial(n):`,
@@ -1221,23 +1262,23 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
             it('Erro - função embutida inexistente', async () => {
                 const retornoLexador = lexador.mapear([
                     `x = 10`,
-                    
+
                     `escreva(x.inexistente())`,
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Sucesso - função que retorna vetor', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao criarVetor():`,
@@ -1247,11 +1288,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Função sem retorno de valor', async () => {
                 const retornoLexador = lexador.mapear(
                     [
@@ -1265,14 +1306,14 @@ describe('Analisador semântico', () => {
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
                     retornoAvaliadorSintatico.declaracoes
                 );
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
-                
+
             });
         });
         describe('Vetores', () => {
-            
+
             it('Vetores com múltiplos tipos', async () => {
                 const retornoLexador = lexador.mapear([
                     `lista = [1, 2, 3, 4, 5, "texto", verdadeiro]`,
@@ -1280,7 +1321,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -1306,7 +1347,7 @@ describe('Analisador semântico', () => {
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
-            }); 
+            });
             it('Vetores com tipos mistos', async () => {
                 const retornoLexador = lexador.mapear([
                     `lista = [1, 2, 3, 4, 5, "texto", verdadeiro]`,
@@ -1314,7 +1355,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -1327,11 +1368,11 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('Sucesso - vetor inteiro[] com valores texto', async () => {
                     const retornoLexador = lexador.mapear([
                         'numeros: inteiro[] = [1, "texto", 3]',
@@ -1339,36 +1380,36 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
-                    
+
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('Sucesso - vetor inteiro[] com valores reais', async () => {
                     const retornoLexador = lexador.mapear([
                         'numeros: inteiro[] = [1.5, 2.7, 3.14]'
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('Sucesso - vetor inteiro[] sendo atribuído como Literal não vetor', async () => {
                     const retornoLexador = lexador.mapear([
                         'numeros: inteiro[] = "não é um vetor"'
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
-                    
+
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
             });
-            
+
             describe('Tipo texto[]', () => {
                 it('Sucesso - vetor com valores texto', async () => {
                     const retornoLexador = lexador.mapear([
@@ -1376,36 +1417,36 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('Sucesso - vetor texto[] com valores numéricos misturados', async () => {
                     const retornoLexador = lexador.mapear([
                         'palavras: texto[] = ["olá", 123, "teste"]'
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
-                    
+
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('Sucesso - vetor texto[] com todos os valores numéricos', async () => {
                     const retornoLexador = lexador.mapear([
                         'numeros: texto[] = [1, 2, 3]'
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
-                    
+
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
             });
-            
+
             describe('Tipo qualquer[]', () => {
                 it('Sucesso - vetor qualquer[] com valores mistos', async () => {
                     const retornoLexador = lexador.mapear([
@@ -1413,12 +1454,12 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
             });
-            
+
             describe('Tipo vetor (genérico)', () => {
                 it('Sucesso - vetor genérico com valores inteiros', async () => {
                     const retornoLexador = lexador.mapear([
@@ -1426,14 +1467,14 @@ describe('Analisador semântico', () => {
                     ], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                     const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                    
+
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
             });
         });
         describe('Cenários adicionais de cobertura completa', () => {
-            
+
             it('Classes com métodos e propriedades', async () => {
                 const retornoLexador = lexador.mapear([
                     `classe Pessoa:`,
@@ -1447,11 +1488,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Dicionários com acesso de chaves', async () => {
                 const retornoLexador = lexador.mapear([
                     `dicionario = {"chave1": 10, "chave2": 20}`,
@@ -1460,11 +1501,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Operações lógicas complexas', async () => {
                 const retornoLexador = lexador.mapear([
                     `a = verdadeiro`,
@@ -1476,11 +1517,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos.some(d => d.mensagem?.includes("'c' foi declarada mas nunca usada"))).toBe(true);
             });
-            
+
             it('Operações com strings', async () => {
                 const retornoLexador = lexador.mapear([
                     `texto1 = "Olá"`,
@@ -1492,11 +1533,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Condicional se com múltiplas ramificações', async () => {
                 const retornoLexador = lexador.mapear([
                     `valor = 50`,
@@ -1512,12 +1553,12 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("Variável 'valor' foi declarada mas nunca usada");
             });
-            
+
             it('Para-cada com iteração', async () => {
                 const retornoLexador = lexador.mapear([
                     `lista = [1, 2, 3, 4, 5]`,
@@ -1526,11 +1567,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Incremento e decremento em loop', async () => {
                 const retornoLexador = lexador.mapear([
                     `i = 0`,
@@ -1544,11 +1585,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
-            
+
             it('Variáveis globais versus locais', async () => {
                 const retornoLexador = lexador.mapear([
                     `global_var = 100`,
@@ -1560,11 +1601,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Expressões ternárias', async () => {
                 const retornoLexador = lexador.mapear([
                     `idade = 20`,
@@ -1573,11 +1614,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Operações com valores nulos', async () => {
                 const retornoLexador = lexador.mapear([
                     `valor = nulo`,
@@ -1589,11 +1630,11 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
-            
+
             it('Leia por padrão retorna texto', async () => {
                 const retornoLexador = lexador.mapear(
                     ["opcao: inteiro = leia('Digite a opção desejada: ')"],
@@ -1603,14 +1644,14 @@ describe('Analisador semântico', () => {
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(
                     retornoAvaliadorSintatico.declaracoes
                 );
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain(
                     "Atribuição inválida para 'opcao', Função 'leia()' sempre retorna 'texto'."
                 );
             });
-            
+
             it('Atribuição múltipla e operações compostas', async () => {
                 const retornoLexador = lexador.mapear([
                     `a = 10`,
@@ -1621,7 +1662,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -1639,7 +1680,7 @@ describe('Analisador semântico', () => {
                     expect(retornoAnalisadorSemantico).toBeTruthy();
                     expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
                 });
-                
+
                 it('tipo de com variável definida e agrupamento', async () => {
                     const retornoLexador = lexador.mapear(
                         ['a = 1      ', 'b = 2      ', 'tipo de (a + b)  '],
@@ -1657,20 +1698,20 @@ describe('Analisador semântico', () => {
                         ['tipo de 1'],
                         -1
                     );
-                    
+
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
-                    
+
                     const retorno = await analisadorSemantico.analisar(
                         retornoAvaliadorSintatico.declaracoes
                     );
-                    
+
                     expect(retorno).toBeTruthy();
                 });
-                
+
             });
         });
         describe('calcularOperacaoBinaria', () => {
-            
+
             test('operações aritméticas básicas', () => {
                 const analisador: any = analisadorSemantico as any;
                 expect(analisador.calcularOperacaoBinaria('ADICAO', 1, 2)).toBe(3);
@@ -1687,35 +1728,35 @@ describe('Analisador semântico', () => {
                 expect(analisador.calcularOperacaoBinaria('DIFERENTE', 2, '2')).toBe(true);
                 expect(analisador.calcularOperacaoBinaria('DIFERENTE', 2, 2)).toBe(false);
             });
-            
+
             test('divisão por zero (comportamento JS)', () => {
                 const analisador: any = analisadorSemantico as any;
                 const resultado = analisador.calcularOperacaoBinaria('DIVISAO', 1, 0)
                 expect(resultado).toBe(Infinity);
             });
-            
+
             test('concatenação de textos com ADICAO', () => {
                 const analisador: any = analisadorSemantico as any;
                 expect(analisador.calcularOperacaoBinaria('ADICAO', 'a', 'b')).toBe('ab');
             });
-            
+
             test('comparações e igualdade estrita', () => {
                 const analisador: any = analisadorSemantico as any;
                 expect(analisador.calcularOperacaoBinaria('MAIOR', 5, 3)).toBe(true);
                 expect(analisador.calcularOperacaoBinaria('MENOR_IGUAL', 2, 2)).toBe(true);
-                expect(analisador.calcularOperacaoBinaria('IGUAL', 2, '2')).toBe(false); 
+                expect(analisador.calcularOperacaoBinaria('IGUAL', 2, '2')).toBe(false);
                 expect(analisador.calcularOperacaoBinaria('DIFERENTE', 2, '2')).toBe(true);
-                
+
             });
-            
+
            it('operador desconhecido retorna null', () => {
                 const analisador: any = analisadorSemantico as any;
                 expect(analisador.calcularOperacaoBinaria('XYZ', 1, 2)).toBeNull();
             });
-            
+
                     it('visitarExpressaoDeAtribuicao: variável não declarada e variável imutável e tipo inválido', async () => {
                         const analisador = new AnalisadorSemanticoPitugues();
-            
+
                         const simbX: SimboloInterface = {
                             lexema: 'x',
                             tipo: 'inteiro',
@@ -1725,11 +1766,11 @@ describe('Analisador semântico', () => {
                         };
                         const varX = new Variavel(1, simbX, 'inteiro');
                         const atribX = new Atribuir(1, varX, new Literal(1, 10, 1, 'inteiro'));
-            
+
                         // Caso: variável ainda não foi declarada
                         await analisador.visitarExpressaoDeAtribuicao(atribX);
                         expect(analisador).toBeTruthy();
-            
+
                         // Caso: variável imutável
                         // Declarar uma variável imutável no escopo
                         analisador.gerenciadorEscopos.declarar('y', {
@@ -1741,7 +1782,7 @@ describe('Analisador semântico', () => {
                             hashArquivo: 1,
                             linha: 20,
                         });
-            
+
                         const simbY: SimboloInterface = {
                             lexema: 'y',
                             tipo: 'inteiro',
@@ -1751,12 +1792,12 @@ describe('Analisador semântico', () => {
                         };
                         const varY = new Variavel(1, simbY, 'inteiro');
                         const atribY = new Atribuir(1, varY, new Literal(1, 20, 2, 'inteiro'));
-            
+
                         await analisador.visitarExpressaoDeAtribuicao(atribY);
                         expect(
                             analisador
                         ).toBeTruthy();
-            
+
                         // Caso: tipo inválido (atribuição de número para texto)
                         analisador.gerenciadorEscopos.declarar('z', {
                             nome: 'z',
@@ -1767,7 +1808,7 @@ describe('Analisador semântico', () => {
                             hashArquivo: 1,
                             linha: 30,
                         });
-            
+
                         const simbZ: SimboloInterface = {
                             lexema: 'z',
                             tipo: 'texto',
@@ -1777,7 +1818,7 @@ describe('Analisador semântico', () => {
                         };
                         const varZ = new Variavel(1, simbZ, 'texto');
                         const atribZ = new Atribuir(1, varZ, new Literal(1, 30, 123, 'inteiro'));
-            
+
                         await analisador.visitarExpressaoDeAtribuicao(atribZ);
                         expect(
                             analisador.diagnosticos[0].mensagem?.includes("Esperado tipo 'texto' na atribuição.")
@@ -1793,9 +1834,9 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                
+
             });
 
             it('Erro - atribuir vetor a variável com tipo escalar (texto)', async () => {
@@ -1805,9 +1846,9 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                
+
             });
 
             it('Erro - atribuir texto a variável com tipo inteiro', async () => {
@@ -1817,9 +1858,9 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                
+
             });
 
             it('Erro - atribuir número a variável com tipo texto', async () => {
@@ -1829,7 +1870,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("Esperado tipo 'texto' na atribuição.");
             });
@@ -1841,7 +1882,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("Esperado tipo 'texto[]' na atribuição.");
             });
@@ -1853,9 +1894,9 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("Esperado tipo 'inteiro[]' na atribuição."); 
+                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain("Esperado tipo 'inteiro[]' na atribuição.");
             });
             it('Sucesso - atribuir qualquer[] aceita valores mistos', async () => {
                 const retornoLexador = lexador.mapear([
@@ -1864,7 +1905,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -1877,7 +1918,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -1894,7 +1935,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -1909,7 +1950,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos.length).toBe(0);
             });
@@ -1922,9 +1963,9 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
-            
+
             });
 
             it('Erro - função com tipo retorno inteiro mas retorna texto', async () => {
@@ -1935,7 +1976,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
             });
 
@@ -1948,7 +1989,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -1963,7 +2004,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain('Variável \'f1\' foi declarada mas nunca usada.');
             });
@@ -1976,7 +2017,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain('Variável \'f1\' foi declarada mas nunca usada.');
             });
@@ -1989,7 +2030,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain('Atribuição inválida para \'nome\': é esperado um valor do tipo texto. Atual: número.');
             });
@@ -2000,7 +2041,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toContain('Atribuição inválida para \'valor\': é esperado um valor do tipo número. Atual: texto.');
             });
@@ -2013,7 +2054,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
             });
             it('Aviso - escreva com variável não inicializada', async () => {
@@ -2023,7 +2064,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
             });
         });
@@ -2038,7 +2079,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
@@ -2052,7 +2093,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -2065,7 +2106,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -2080,7 +2121,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -2095,7 +2136,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -2111,7 +2152,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos.length).toBeGreaterThanOrEqual(1);
             });
@@ -2125,7 +2166,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 // Nomes que começam com maiúscula parecem ser classes e não geram erro de função inexistente
                 const temErroDeFuncao = retornoAnalisadorSemantico.diagnosticos[0]?.mensagem?.includes("não existe") ?? false;
@@ -2141,7 +2182,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico).toBeDefined();
             });
@@ -2156,7 +2197,7 @@ describe('Analisador semântico', () => {
                 ], -1);
                 const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
                 const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-                
+
                 expect(retornoAnalisadorSemantico).toBeTruthy();
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });


### PR DESCRIPTION
Este PR aplica correções no `analisador-semantico-pitugues.ts` para corrigir o problema descrito na issue #1170

Closes #1170