### PR TITLE
#1199: Adiciona funções nativas ao Analisador Semântico de Pituguês

### DIFF
--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -48,6 +48,42 @@ import { FuncaoHipoteticaInterface } from '../funcao-hipotetica-interface';
 import { GerenciadorEscopos } from '../gerenciador-escopos';
 import { PilhaVariaveis } from '../pilha-variaveis';
 
+const FUNCOES_NATIVAS_PITUGUES = [
+    'aleatorio',
+    'aleatorio_entre',
+    'algum',
+    'arredondar',
+    'encontrar',
+    'encontrar_indice',
+    'encontrar_ultimo',
+    'encontrar_ultimo_indice',
+    'filtrar_por',
+    'incluido',
+    'inteiro',
+    'intervalo',
+    'enumerar',
+    'mapear',
+    'maximo',
+    'minimo',
+    'numero',
+    'número',
+    'ordenar',
+    'para_cada',
+    'primeiro_em_condicao',
+    'real',
+    'reduzir',
+    'somar',
+    'tamanho',
+    'texto',
+    'todos',
+    'todos_em_condicao',
+    'tupla',
+    'vetor',
+    'leia',
+    'escreva',
+    'tipo',
+];
+
 /**
  * O Analisador Semântico de Pituguês.
  */
@@ -271,7 +307,7 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
     visitarChamadaPorVariavel(entidadeChamadaVariavel: Variavel, argumentos: Construto[]) {
         const variavel = entidadeChamadaVariavel as Variavel;
         const nomeFuncao = variavel.simbolo.lexema;
-        const funcoesNativas = ['inteiro', 'real', 'numero', 'número', 'texto', 'leia', 'escreva', 'tipo'];
+        const funcoesNativas = FUNCOES_NATIVAS_PITUGUES;
         const pareceSerClasse = nomeFuncao[0] === nomeFuncao[0].toUpperCase();
 
         if (funcoesNativas.includes(nomeFuncao) || pareceSerClasse) {
@@ -929,17 +965,7 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
             case Variavel:
                 let entidadeChamadaVariavel = chamada.entidadeChamada as Variavel;
                 const nomeFuncao = entidadeChamadaVariavel.simbolo.lexema;
-
-                const funcoesBuiltIn = [
-                    'inteiro',
-                    'real',
-                    'numero',
-                    'número',
-                    'texto',
-                    'leia',
-                    'escreva',
-                    'tipo',
-                ];
+                const funcoesBuiltIn = FUNCOES_NATIVAS_PITUGUES;
 
                 const pareceSerClasse = nomeFuncao[0] === nomeFuncao[0].toUpperCase();
 

--- a/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
+++ b/testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts
@@ -28,6 +28,25 @@ describe('Analisador semântico', () => {
                 expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
             });
 
+            it('Funções globais do dialeto Pituguês não geram erro de inexistência', async () => {
+                const retornoLexador = lexador.mapear([
+                    `numeros = [1, 2, 3]`,
+                    `numero_aleatorio = aleatorio()`,
+                    `numero_aleatorio_entre = aleatorio_entre(1, 9)`,
+                    `soma = somar(numeros)`,
+                    `todos_resultado = todos(numeros)`,
+                    `escreva(numero_aleatorio, numero_aleatorio_entre, soma, todos_resultado)`,
+                ], -1);
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = await analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                const diagnosticosDeInexistencia = retornoAnalisadorSemantico.diagnosticos.filter((d) =>
+                    d.mensagem?.includes("não existe")
+                );
+                expect(diagnosticosDeInexistencia).toHaveLength(0);
+            });
+
             it('Função sem corpo', async () => {
                 const retornoLexador = lexador.mapear([
                     `funcao minhaFuncao():`


### PR DESCRIPTION
## O que foi alterado
A validação passou a usar uma lista centralizada (`FUNCOES_NATIVAS_PITUGUES`) com todas as funções nativas do dialeto, em vez de manter uma lista incompleta e duplicada no fluxo de verificação.

## Motivo da mudança
Para alinhar o analisador semântico com as funções realmente disponíveis no Pituguês e eliminar o erro indevido no editor ao usar aleatorio() e outras funções globais.

## Resultado
Nenhum erro semântico exibido no editor:
<img width="242" height="89" alt="image" src="https://github.com/user-attachments/assets/04da8f42-c42d-4887-bb78-4c856775c6f6" />

## Issue relacionada
Resolve #1199 