### PR TITLE
[Pituguês] Propriedades criadas dentro do método `construtor` agora podem ser acessadas

### DIFF
--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -40,6 +40,7 @@ export class InterpretadorPitugues extends Interpretador {
         }
         this.pilhaEscoposExecucao = pilhaPitugues;
         this.lancarErroPorDivisaoPorZero = true;
+        this.requerDeclaracaoPropriedades = false;
     }
 
     protected override pontoInicializacaoBibliotecasGlobais() {

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -1529,6 +1529,36 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas[0]).toBe('Amigo, onde está você?');
                     expect(_saidas[1]).toBe('Amigo, estou aqui!');
                 });
+
+                it('Classes - declaração de propriedades', async () => {
+                    const codigo = [
+                        'classe Animal:',
+                        '    construtor(nome, idade):',
+                        '        isto.nome = nome',
+                        '        isto.idade = idade',
+                        '    função meuNome():',
+                        '        escreva(isto.nome)',
+                        '    função minhaIdade():',
+                        '        escreva(isto.idade)',
+                        'animalLegal = Animal("animal1", 10)',
+                        'animalLegal.meuNome()',
+                        'animalLegal.minhaIdade()',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(2);
+                    expect(_saidas[0]).toBe('animal1');
+                    expect(_saidas[1]).toBe('10');
+                });
             });
 
             describe('Declaração e chamada de funções', () => {


### PR DESCRIPTION
Com esta pequena correção, todas as propriedades criadas dentro do método `construtor()` conseguem ser acessadas pelas instâncias das classes.

Closes #1191