### PR TITLE
[Pituguês] adiciona operador bote (`~>`)

### DIFF
--- a/fontes/analisador-semantico/analisador-semantico-base.ts
+++ b/fontes/analisador-semantico/analisador-semantico-base.ts
@@ -36,6 +36,7 @@ import {
     AcessoIntervaloVariavel,
     TuplaN,
     Morsa,
+    Bote,
 } from '../construtos';
 import {
     Declaracao,
@@ -695,7 +696,11 @@ export abstract class AnalisadorSemanticoBase implements AnalisadorSemanticoInte
         return Promise.resolve();
     }
 
-    async visitarExpressaoMorsa(expressao: Morsa): Promise<any> {
+    visitarExpressaoMorsa(expressao: Morsa): Promise<any> {
+        return Promise.resolve();
+    }
+
+    visitarExpressaoBote(expressao: Bote): Promise<any> {
         return Promise.resolve();
     }
 }

--- a/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
+++ b/fontes/analisador-semantico/dialetos/analisador-semantico-pitugues.ts
@@ -22,6 +22,7 @@ import {
     AcessoIndiceVariavel,
     Dupla,
     Morsa,
+    Bote,
 } from '../../construtos';
 import {
     Const,
@@ -1344,6 +1345,18 @@ export class AnalisadorSemanticoPitugues extends AnalisadorSemanticoBase {
 
         if (expressao.variavel) {
             this.registrarVariavelExpressaoMorsa(expressao.variavel);
+        }
+
+        return Promise.resolve();
+    }
+
+    async visitarExpressaoBote(expressao: Bote): Promise<any> {
+        if (expressao.esquerda) {
+            await expressao.esquerda.aceitar(this);
+        }
+
+        if (expressao.direita) {
+            await expressao.direita.aceitar(this);
         }
 
         return Promise.resolve();

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -43,6 +43,7 @@ import {
     Trio,
     TuplaN,
     Morsa,
+    Bote,
 } from '../../construtos';
 import {
     Escreva,
@@ -1349,8 +1350,26 @@ export class AvaliadorSintaticoPitugues implements AvaliadorSintaticoInterface<
         return new TuplaN(this.hashArquivo, expressao.linha, elementos);
     }
 
+    async bote(): Promise<Construto> {
+        let expressao = await this.seTernario();
+
+        while (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.BOTE)) {
+            const operadorBote = this.simboloAnterior();
+            const direita = await this.seTernario();
+
+            expressao = new Bote(
+                this.hashArquivo,
+                Number(operadorBote.linha),
+                expressao,
+                direita
+            );
+        }
+
+        return expressao;
+    }
+
     async atribuir(): Promise<Construto> {
-        const expressao = await this.seTernario();
+        const expressao = await this.bote();
 
         if (this.verificarSeSimboloAtualEIgualA(tiposDeSimbolos.MORSA)) {
             const operadorMorsa = this.simboloAnterior();

--- a/fontes/construtos/bote.ts
+++ b/fontes/construtos/bote.ts
@@ -1,0 +1,33 @@
+import { Construto } from './construto';
+import { VisitantePituguesInterface } from '../interfaces/visitante-pitugues-interface';
+
+export class Bote implements Construto {
+    linha: number;
+    hashArquivo: number;
+    esquerda: Construto;
+    direita: Construto;
+
+    constructor(
+        hashArquivo: number,
+        linha: number,
+        esquerda: Construto,
+        direita: Construto
+    ) {
+        this.linha = linha;
+        this.hashArquivo = hashArquivo;
+        this.esquerda = esquerda;
+        this.direita = direita;
+    }
+
+    async aceitar(visitante: VisitantePituguesInterface): Promise<any> {
+        return await visitante.visitarExpressaoBote(this);
+    }
+
+    paraTexto(): string {
+        return `<bote />`;
+    }
+
+    paraTextoSaida(): string {
+        throw new Error('Método não implementado.');
+    }
+}

--- a/fontes/construtos/index.ts
+++ b/fontes/construtos/index.ts
@@ -11,6 +11,7 @@ export * from './atribuicao-por-indice';
 export * from './atribuicao-por-indices-matriz';
 export * from './atribuir';
 export * from './binario';
+export * from './bote';
 export * from './chamada';
 export * from './comentario-como-construto';
 export * from './componente-linguagem';

--- a/fontes/formatadores/formatador-pitugues.ts
+++ b/fontes/formatadores/formatador-pitugues.ts
@@ -19,6 +19,7 @@ import {
     AcessoIntervaloVariavel,
     TuplaN,
     Morsa,
+    Bote,
 } from '../construtos';
 
 import {
@@ -550,6 +551,13 @@ export class FormatadorPitugues implements VisitantePituguesInterface {
         const valor = await expressao.valor.aceitar(this);
 
         return `${variavel} := ${valor}`;
+    }
+
+    async visitarExpressaoBote(expressao: Bote): Promise<any> {
+        const esquerda = await expressao.esquerda.aceitar(this);
+        const direita = await expressao.direita.aceitar(this);
+
+        return `${esquerda} ~> ${direita}`;
     }
 
     private mapearOperador(tipo: any): string {

--- a/fontes/interfaces/visitante-pitugues-interface.ts
+++ b/fontes/interfaces/visitante-pitugues-interface.ts
@@ -1,6 +1,7 @@
-import { Morsa } from "../construtos";
+import { Morsa, Bote } from "../construtos";
 import { VisitanteComumInterface } from "./visitante-comum-interface";
 
 export interface VisitantePituguesInterface extends VisitanteComumInterface {
     visitarExpressaoMorsa(expressao: Morsa): Promise<any> | void;
+    visitarExpressaoBote(expressao: Bote): Promise<any> | void;
 }

--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -13,6 +13,8 @@ import {
     DefinirValor,
     AcessoPropriedade,
     Morsa,
+    Bote,
+    Chamada,
 } from '../../../construtos';
 import { Interpretador } from '../../interpretador';
 import { ErroEmTempoDeExecucao } from '../../../excecoes';
@@ -87,7 +89,9 @@ export class InterpretadorPitugues extends Interpretador {
         return super.executarBloco(declaracoes, ambiente);
     }
 
-    override async visitarExpressaoAcessoMetodo(expressao: AcessoMetodo): Promise<any> {
+    override async visitarExpressaoAcessoMetodo(
+        expressao: AcessoMetodo
+    ): Promise<any> {
         const variavelObjeto = await this.avaliar(expressao.objeto);
         const objeto = this.resolverValor(variavelObjeto, true);
 
@@ -134,7 +138,9 @@ export class InterpretadorPitugues extends Interpretador {
         return comum.visitarExpressaoTuplaN(this, expressao);
     }
 
-    override async visitarExpressaoDeAtribuicao(expressao: Atribuir): Promise<any> {
+    override async visitarExpressaoDeAtribuicao(
+        expressao: Atribuir
+    ): Promise<any> {
         if (expressao.alvo.constructor === Variavel) {
             const alvoVariavel = expressao.alvo as Variavel;
             try {
@@ -263,7 +269,10 @@ export class InterpretadorPitugues extends Interpretador {
      * Resolve a lógica de atribuição das variáveis no escopo.
      * Suporta variáveis simples ou pares (Dupla).
      */
-    private definirVariaveisIteracao(variavel: Variavel | Dupla, elemento: any): void {
+    private definirVariaveisIteracao(
+        variavel: Variavel | Dupla,
+        elemento: any
+    ): void {
         if (variavel instanceof Variavel) {
             this.pilhaEscoposExecucao.definirVariavel(
                 variavel.simbolo.lexema,
@@ -340,7 +349,9 @@ export class InterpretadorPitugues extends Interpretador {
         return retornoExecucao;
     }
 
-    override async visitarExpressaoRetornar(declaracao: Retorna): Promise<RetornoQuebra> {
+    override async visitarExpressaoRetornar(
+        declaracao: Retorna
+    ): Promise<RetornoQuebra> {
         let valor = null;
         if (declaracao.valor !== null && declaracao.valor !== undefined) {
             valor = await this.avaliar(declaracao.valor);
@@ -378,7 +389,9 @@ export class InterpretadorPitugues extends Interpretador {
         return descritor;
     }
 
-    override async visitarExpressaoDefinirValor(expressao: DefinirValor): Promise<any> {
+    override async visitarExpressaoDefinirValor(
+        expressao: DefinirValor
+    ): Promise<any> {
         const variavelObjeto = await this.avaliar(expressao.objeto);
         const objeto = this.resolverValor(variavelObjeto, true);
 
@@ -413,5 +426,30 @@ export class InterpretadorPitugues extends Interpretador {
         }
 
         return valorResolvido;
+    }
+
+    async visitarExpressaoBote(expressao: Bote): Promise<any> {
+        if (!(expressao.direita instanceof Chamada)) {
+            return Promise.reject(
+                new ErroEmTempoDeExecucao(
+                    {
+                        linha: expressao.linha,
+                        hashArquivo: expressao.hashArquivo,
+                        lexema: '~>'
+                    } as any,
+                    'O lado direito do operador bote (~>) deve ser uma chamada de função.',
+                    expressao.linha
+                )
+            );
+        }
+
+        const chamadaOriginal = expressao.direita as Chamada;
+        const novaChamada = new Chamada(
+            chamadaOriginal.hashArquivo,
+            chamadaOriginal.entidadeChamada,
+            [expressao.esquerda, ...chamadaOriginal.argumentos]
+        );
+
+        return await this.avaliar(novaChamada);
     }
 }

--- a/fontes/lexador/dialetos/lexador-pitugues.ts
+++ b/fontes/lexador/dialetos/lexador-pitugues.ts
@@ -537,8 +537,15 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
                 break;
 
             case '~':
-                this.adicionarSimbolo(tiposDeSimbolos.BIT_NOT);
-                this.avancar();
+                if (this.proximoSimbolo() === '>') {
+                    this.avancar();
+                    this.avancar();
+                    this.adicionarSimbolo(tiposDeSimbolos.BOTE);
+                } else {
+                    this.adicionarSimbolo(tiposDeSimbolos.BIT_NOT);
+                    this.avancar();
+                }
+
                 break;
 
             case '|':

--- a/fontes/tipos-de-simbolos/pitugues.ts
+++ b/fontes/tipos-de-simbolos/pitugues.ts
@@ -5,6 +5,7 @@ export default {
     BIT_OR: 'BIT_OR',
     BIT_XOR: 'BIT_XOR',
     BIT_NOT: 'BIT_NOT',
+    BOTE: 'BOTE',
     CADA: 'CADA',
     CASO: 'CASO',
     CHAVE_DIREITA: 'CHAVE_DIREITA',

--- a/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico/dialetos/pitugues/avaliador-sintatico.test.ts
@@ -1,5 +1,5 @@
 import { AvaliadorSintaticoPitugues } from "../../../../fontes/avaliador-sintatico/dialetos";
-import { Morsa, Logico, Vetor } from "../../../../fontes/construtos";
+import { Morsa, Logico, Vetor, Bote, Chamada, Variavel, Literal } from "../../../../fontes/construtos";
 import { Escreva, Importar, Se, Var } from "../../../../fontes/declaracoes";
 import { LexadorPitugues } from "../../../../fontes/lexador/dialetos";
 
@@ -503,6 +503,59 @@ describe('Avaliador sintático (Pituguês)', () => {
                     expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
                     expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(1);
                     expect(retornoAvaliadorSintatico.declaracoes[0].constructor).toBe(Se);
+                });
+            });
+
+            describe('Operador Bote (~>)', () => {
+                it('Uso básico', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'resultado = "victor" ~> tamanho() ~> texto()',
+                        'escreva(resultado)'
+                    ], -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+                    expect(retornoAvaliadorSintatico.declaracoes).toHaveLength(
+                        2
+                    );
+
+                    const declaracaoVar = retornoAvaliadorSintatico
+                        .declaracoes[0] as Var;
+
+                    expect(declaracaoVar.simbolo.lexema).toBe('resultado');
+
+                    const boteExterno = declaracaoVar.inicializador as Bote;
+
+                    expect(boteExterno.constructor.name).toBe('Bote');
+
+                    const chamadaTexto = boteExterno.direita as Chamada;
+
+                    expect(chamadaTexto.constructor.name).toBe('Chamada');
+                    expect((chamadaTexto.entidadeChamada as Variavel).simbolo.lexema).toBe('texto');
+
+                    const boteInterno = boteExterno.esquerda as Bote;
+
+                    expect(boteInterno.constructor.name).toBe('Bote');
+
+                    const chamadaTamanho = boteInterno.direita as Chamada;
+
+                    expect(chamadaTamanho.constructor.name).toBe('Chamada');
+                    expect((chamadaTamanho.entidadeChamada as Variavel).simbolo.lexema).toBe('tamanho');
+
+                    const literalOriginal = boteInterno.esquerda as Literal;
+
+                    expect(literalOriginal.constructor.name).toBe('Literal');
+                    expect(literalOriginal.valor).toBe('victor');
+
+                    const escreva = retornoAvaliadorSintatico
+                        .declaracoes[1] as Escreva;
+
+                    expect(escreva.argumentos).toHaveLength(1);
+                    expect((escreva.argumentos[0] as Variavel).simbolo.lexema).toBe('resultado');
                 });
             });
         });

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -4284,6 +4284,26 @@ describe('Interpretador (Pituguês)', () => {
                     expect(_saidas[1]).toBe('2');
                 });
             });
+
+            describe('Operador Bote (~>)', () => {
+                it('Deve retornar quantidade de caracteres no nome', async () => {
+                    const codigo = [
+                        'resultado = "victor" ~> tamanho() ~> texto()',
+                        'escreva(resultado)'
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliador.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas[0]).toBe('6');
+                });
+            });
         });
 
         it('termina_com - sufixo encontrado no final', async () => {

--- a/testes/lexador/dialetos/pitugues/lexador.test.ts
+++ b/testes/lexador/dialetos/pitugues/lexador.test.ts
@@ -330,6 +330,70 @@ describe('Lexador (Pituguês)', () => {
                     );
                 });
             });
+
+            describe('Operador Bote (~>)', () => {
+                it('Deve mapear o operador bote em uma atribuição simples', async () => {
+                    const codigo = [
+                        'resultado = "victor" ~> tamanho() ~> texto()',
+                        'escreva(resultado)'
+                    ];
+                    const resultado = lexador.mapear(codigo, -1);
+
+                    expect(resultado.erros).toHaveLength(0);
+                    expect(resultado.simbolos).toEqual(
+                        expect.arrayContaining([
+                            // Linha 1
+                            expect.objectContaining({
+                                lexema: 'resultado', tipo: tiposDeSimbolos.IDENTIFICADOR
+                            }),
+                            expect.objectContaining({
+                                lexema: '=', tipo: tiposDeSimbolos.IGUAL
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.TEXTO
+                            }),
+                            expect.objectContaining({
+                                lexema: '~>', tipo: tiposDeSimbolos.BOTE
+                            }),
+                            expect.objectContaining({
+                                lexema: 'tamanho', tipo: tiposDeSimbolos.IDENTIFICADOR
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_ESQUERDO
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_DIREITO
+                            }),
+                            expect.objectContaining({
+                                lexema: '~>', tipo: tiposDeSimbolos.BOTE
+                            }),
+                            expect.objectContaining({
+                                lexema: 'texto', tipo: tiposDeSimbolos.IDENTIFICADOR
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_ESQUERDO
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_DIREITO
+                            }),
+
+                            // Linha 2
+                            expect.objectContaining({
+                                lexema: 'escreva', tipo: tiposDeSimbolos.ESCREVA
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_ESQUERDO
+                            }),
+                            expect.objectContaining({
+                                lexema: 'resultado', tipo: tiposDeSimbolos.IDENTIFICADOR
+                            }),
+                            expect.objectContaining({
+                                tipo: tiposDeSimbolos.PARENTESE_DIREITO
+                            }),
+                        ])
+                    );
+                });
+            });
         });
 
         describe('Cenários de falha', () => {


### PR DESCRIPTION
Este PR implementa o operador bote (`~>`) que possui a mesma funcionalidade de um operador pipe (`|>`).

Foram realizados pequenos testes no lexador, avaliador sintático e interpretador para garantir que o operador está funcionando corretamente.

Closes #1217