### PR TITLE
fix: corrige sustar/continua/retorne não funcionando em loops no inte…

### DIFF
--- a/fontes/interpretador/depuracao/interpretador-base-com-depuracao.ts
+++ b/fontes/interpretador/depuracao/interpretador-base-com-depuracao.ts
@@ -283,7 +283,18 @@ export class InterpretadorBaseComDepuracao
      * @returns O resultado da execução.
      */
     override async executar(declaracao: Declaracao, mostrarResultado = false): Promise<any> {
-        return await declaracao.aceitar(this);
+        const resultado = await declaracao.aceitar(this);
+        if (resultado === null || resultado === undefined) {
+            return null;
+        }
+        if (resultado.hasOwnProperty && resultado.hasOwnProperty('valorRetornado')) {
+            return resultado;
+        }
+        return {
+            hashArquivo: declaracao.hashArquivo,
+            linha: declaracao.linha,
+            valorRetornado: resultado,
+        };
     }
 
     /**

--- a/testes/interpretador/interpretador-base-com-depuracao.test.ts
+++ b/testes/interpretador/interpretador-base-com-depuracao.test.ts
@@ -39,6 +39,25 @@ describe('Interpretador Base com Depuração', () => {
                 }
             });
 
+            it('sustar deve interromper loop enquanto', async () => {
+                const retornoLexador = lexador.mapear([
+                    "var i = 0",
+                    "enquanto verdadeiro {",
+                    "    i = i + 1",
+                    "    se i >= 3 {",
+                    "        sustar",
+                    "    }",
+                    "}",
+                    "escreva(i)"
+                ], -1);
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                interpretador.prepararParaDepuracao(retornoAvaliadorSintatico.declaracoes);
+                await interpretador.instrucaoContinuarInterpretacao();
+
+                expect(_saidas[0]).toBe('3');
+            });
+
             it('Trivial', async () => {
                 const retornoLexador = lexador.mapear([
                     "const a = 1",


### PR DESCRIPTION
fix: corrige sustar/continua/retorne não funcionando em loops no interpretador com depuração

## Problema

O método `executar` de `InterpretadorBaseComDepuracao` era uma reimplementação simplificada que retornava o resultado bruto de `declaracao.aceitar(this)`:

```ts
return await declaracao.aceitar(this);
```

O interpretador base (sem depuração) embrulha o resultado em `{ hashArquivo, linha, valorRetornado, tipo }` antes de retornar.

Os handlers de loop em `depuracao/comum.ts` (`visitarDeclaracaoEnquanto`, `visitarDeclaracaoPara`, `visitarDeclaracaoFazer`) checam o sinal de quebra via:

```ts
retornoExecucao.valorRetornado instanceof SustarQuebra
```

Com o `executar` debug retornando `SustarQuebra` diretamente, sem embrulho, `.valorRetornado` era sempre `undefined`, a checagem nunca passava e o loop não era interrompido. O mesmo problema afeta `ContinuarQuebra` e a condição do `while` que usa `instanceof Quebra`.

## Correção

Alinha o contrato de retorno do `executar` debug com o do base: resultados já embrulhados passam direto, resultados brutos são embrulhados em `{ hashArquivo, linha, valorRetornado }`.

## Teste

Adicionado teste de regressão que comprova o bug (loop não era interrompido) e a correção (`sustar` interrompe corretamente o `enquanto`).
