### PR TITLE
[Pituguês] adiciona os métodos `limpar()`, `mesclar()`, `obter()` e `popular()`

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
@@ -36,7 +36,10 @@ export default {
     chaves: {
         tipoRetorno: 'texto[]',
         argumentos: [],
-        implementacao: (interpretador: InterpretadorInterface, valor: object): Promise<any> => {
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object
+        ): Promise<any> => {
             return Promise.resolve(Object.keys(valor));
         },
         assinaturaFormato: 'dicionário.chaves()',
@@ -55,10 +58,14 @@ export default {
     itens: {
         tipoRetorno: '(texto|qualquer)[][]',
         argumentos: [],
-        implementacao: (interpretador: InterpretadorInterface, valor: object): Promise<any> => {
-            const pares = Object.entries(valor).map(([chave, valor]) => {
-                return [chave, valor];
-            });
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object
+        ): Promise<any> => {
+            const pares = Object.entries(valor).map(
+                ([chave, valor]) => [chave, valor]
+            );
+
             return Promise.resolve(pares);
         },
         assinaturaFormato: 'dicionário.itens()',
@@ -75,6 +82,148 @@ export default {
             '## Formas de uso\n',
         exemploCodigo: 'dicionário.itens()',
     },
+    limpar: {
+        tipoRetorno: 'nulo',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object
+        ): Promise<any> => {
+            for (const chave in valor) {
+                delete valor[chave];
+            }
+
+            return Promise.resolve();
+        },
+        assinaturaFormato: 'dicionário.limpar()',
+        documentacao:
+            '# `dicionário.limpar()`\n\n' +
+            'Remove todas as entradas do dicionário, deixando-o vazio.\n' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
+            'd.limpar()\n' +
+            'escreva(d) // {}\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.limpar()',
+    },
+    mesclar: {
+        tipoRetorno: 'dicionário',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'outro',
+                'dicionário',
+                true,
+                [],
+                'O dicionário a ser mesclado.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object,
+            outro: object
+        ): Promise<object> => {
+            return Promise.resolve(Object.assign(valor, outro));
+        },
+        assinaturaFormato: 'dicionário.mesclar(outro: dicionário)',
+        documentacao:
+            '# `dicionário.mesclar(outro)`\n\n' +
+            'Copia todas as entradas do dicionário passado como parâmetro para o dicionário atual. ' +
+            'Em caso de chaves duplicadas, os valores do parâmetro sobrescrevem os do dicionário original.\n' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
+            'd.mesclar({"b": 99, "c": 3})\n' +
+            'escreva(d) // {"a": 1, "b": 99, "c": 3}\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.mesclar(outro)',
+    },
+    obter: {
+        tipoRetorno: 'qualquer',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'chave',
+                'texto',
+                true,
+                [],
+                'A chave a ser buscada no dicionário.'
+            ),
+            new InformacaoElementoSintatico(
+                'padrao',
+                'qualquer',
+                false,
+                [],
+                'Valor retornado caso a chave não exista. Padrão: nulo.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object,
+            chave: string,
+            padrao: any = null
+        ): Promise<any> => {
+            return Promise.resolve(chave in valor ? valor[chave] : padrao);
+        },
+        assinaturaFormato: 'dicionário.obter(chave: texto, padrao?: qualquer)',
+        documentacao:
+            '# `dicionário.obter(chave, padrao?)`\n\n' +
+            'Retorna o valor associado à chave. Se a chave não existir, retorna o valor padrão ' +
+            '(ou nulo se nenhum padrão for fornecido).\n' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1, "b": 2}\n' +
+            'escreva(d.obter("a", 0)) // 1\n' +
+            'escreva(d.obter("z", 0)) // 0\n' +
+            'escreva(d.obter("z")) // nulo\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.obter("minhaChave", valorPadrao)',
+    },
+    popular: {
+        tipoRetorno: 'qualquer',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'chave',
+                'texto',
+                true,
+                [],
+                'A chave a ser verificada ou inserida.'
+            ),
+            new InformacaoElementoSintatico(
+                'padrao',
+                'qualquer',
+                true,
+                [],
+                'O valor a ser inserido caso a chave não exista.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object,
+            chave: string,
+            padrao: any
+        ): Promise<any> => {
+            if (!(chave in valor)) valor[chave] = padrao;
+
+            return Promise.resolve(valor[chave]);
+        },
+        assinaturaFormato: 'dicionário.popular(chave: texto, padrao: qualquer)',
+        documentacao:
+            '# `dicionário.popular(chave, padrao)`\n\n' +
+            'Se a chave não existir no dicionário, insere-a com o valor padrão. ' +
+            'Retorna o valor atual da chave (seja ele preexistente ou recém-inserido).\n' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1}\n' +
+            'escreva(d.popular("a", 99)) // 1 (chave já existia)\n' +
+            'escreva(d.popular("b", 99)) // 99 (chave foi inserida)\n' +
+            'escreva(d) // {"a": 1, "b": 99}\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.popular("minhaChave", valorPadrao)',
+    },
     remover: {
         tipoRetorno: 'lógico',
         argumentos: [new InformacaoElementoSintatico('chave', 'texto')],
@@ -84,12 +233,37 @@ export default {
             chave: string
         ): Promise<boolean> => Promise.resolve(delete valor[chave]),
         assinaturaFormato: `dicionário.remover(chave: qualquer)`,
+        documentacao:
+            '# `dicionário.remover(chave)`\n\n' +
+            'Remove uma chave do dicionário. ' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
+            'escreva(d.remover("b")) // verdadeiro\n' +
+            'escreva(d) // {"a": 1, "c": 3}\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.remover(chave)',
     },
     valores: {
         tipoRetorno: '<T>[]',
         argumentos: [],
-        implementacao: (interpretador: InterpretadorInterface, valor: object): Promise<any> => {
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: object
+        ): Promise<any> => {
             return Promise.resolve(Object.values(valor));
         },
+        assinaturaFormato: `dicionário.valores()`,
+        documentacao:
+            '# `dicionário.valores()`\n\n' +
+            'Retorna os valores de cada chave do dicionário. ' +
+            '\n\n## Exemplo de Código\n' +
+            '\n```pitugues\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
+            'escreva(d.valores()) // [1, 2, 3]\n' +
+            '```\n\n' +
+            '## Formas de uso\n',
+        exemploCodigo: 'dicionário.valores()',
     },
 } as { [nome: string]: PrimitivaInterface };

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-dicionario.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-dicionario.test.ts
@@ -1,0 +1,211 @@
+import primitivasDicionario from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario';
+import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
+
+describe('Primitivas de Dicionário (Pituguês)', () => {
+    const interpretador = criarInterpretadorMock();
+
+    describe('chaves', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar um vetor com todas as chaves do dicionário', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .chaves
+                    .implementacao(interpretador, dicionario);
+
+                expect(resultado).toEqual(["a", "b", "c"]);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('contem/contém', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar verdadeiro quando a chave existe', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .contem
+                    .implementacao(interpretador, dicionario, 'a');
+
+                expect(resultado).toBe(true);
+            });
+
+            it('Deve retornar falso quando a chave não existe', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .contem
+                    .implementacao(interpretador, dicionario, 'z');
+
+                expect(resultado).toBe(false);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('itens', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar um vetor de pares [chave, valor]', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .itens
+                    .implementacao(interpretador, dicionario);
+
+                expect(resultado).toEqual([['a', 1], ['b', 2], ['c', 3]]);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('limpar', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve remover todas as entradas do dicionário', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                await primitivasDicionario
+                    .limpar
+                    .implementacao(interpretador, dicionario);
+
+                expect(dicionario).toEqual({});
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('mesclar', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve adicionar as entradas do segundo dicionário ao primeiro', async () => {
+                const dicionario = { a: 1, b: 2 };
+                await primitivasDicionario.mesclar.implementacao(
+                    interpretador,
+                    dicionario,
+                    { c: 3, d: 4 }
+                );
+
+                expect(dicionario).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+            });
+
+            it('Deve sobrescrever chaves duplicadas com os valores do segundo dicionário', async () => {
+                const dicionario = { a: 1, b: 2 };
+                await primitivasDicionario.mesclar.implementacao(
+                    interpretador,
+                    dicionario,
+                    { b: 99, c: 3 }
+                );
+
+                expect(dicionario).toEqual({ a: 1, b: 99, c: 3 });
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('obter', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar o valor associado à chave quando ela existe', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .obter
+                    .implementacao(interpretador, dicionario, 'a', 0);
+
+                expect(resultado).toBe(1);
+            });
+
+            it('Deve retornar o valor padrão quando a chave não existe', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .obter
+                    .implementacao(interpretador, dicionario, 'z', 0);
+
+                expect(resultado).toBe(0);
+            });
+
+            it('Deve retornar nulo quando a chave não existe e nenhum padrão for fornecido', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .obter
+                    .implementacao(interpretador, dicionario, 'z');
+
+                expect(resultado).toBeNull();
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('popular', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar o valor existente quando a chave já existe', async () => {
+                const dicionario = { a: 1 };
+                const resultado = await primitivasDicionario
+                    .popular
+                    .implementacao(interpretador, dicionario, 'a', 99);
+
+                expect(resultado).toBe(1);
+                expect(dicionario).toEqual({ a: 1 });
+            });
+
+            it('Deve inserir e retornar o valor padrão quando a chave não existe', async () => {
+                const dicionario = { a: 1 };
+                const resultado = await primitivasDicionario
+                    .popular
+                    .implementacao(interpretador, dicionario, 'b', 99);
+
+                expect(resultado).toBe(99);
+                expect(dicionario).toEqual({ a: 1, b: 99 });
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('remover', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve remover a chave do dicionário e retornar verdadeiro', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .remover
+                    .implementacao(interpretador, dicionario, 'b');
+
+                expect(resultado).toBe(true);
+                expect(dicionario).toEqual({ a: 1, c: 3 });
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('valores', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar um vetor com todos os valores do dicionário', async () => {
+                const dicionario = { a: 1, b: 2, c: 3 };
+                const resultado = await primitivasDicionario
+                    .valores
+                    .implementacao(interpretador, dicionario);
+
+                expect(resultado).toEqual([1, 2, 3]);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+});


### PR DESCRIPTION
Este PR diz respeito a issue #1232 que tem como objetivo refatorar os métodos do tipo `dicionário` do Pituguês.

4 métodos foram adicionados, sendo eles:
- `limpar()` que deixa o dicionário vazio.
- `mesclar()` que junta um dicionário com outro.
- `obter()` que retorna o valor associado a chave que está sendo buscada. O valor passado como segundo parâmetro é retornado caso a chave buscada não exista.
- `popular()` que retorna o valor associado a chave que está sendo buscada. A chave e o valor passado como segundo parâmetro irão ser adicionados ao dicionário caso a chave buscada não exista.

Foram criados testes de sucesso pra cada método de `dicionário`.

Closes #1232