### PR TITLE
[Pituguês] adiciona os métodos `arredondar()`, `raiz_quadrada()` e `truncar()`

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
@@ -19,10 +19,50 @@ export default {
             '\n\n## Formas de uso\n',
         exemploCodigo: 'numero.absoluto()',
     },
+    arredondar: {
+        tipoRetorno: 'numero',
+        argumentos: [
+            new InformacaoElementoSintatico(
+                'casasDecimais',
+                'numero',
+                false,
+                [],
+                'Número de casas decimais que o número deve ser arredondado.'
+            ),
+        ],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: number,
+            casasDecimais?: number | null
+        ): Promise<number> => {
+            if (casasDecimais !== undefined && casasDecimais !== null) {
+                return Promise.resolve(
+                    parseFloat(valor.toFixed(casasDecimais))
+                );
+            }
+
+            return Promise.resolve(Math.round(valor));
+        },
+        assinaturaFormato: 'número.arredondar(casas_decimais)',
+        documentacao:
+            '# `número.arredondar()`\n\n' +
+            'Retorna o número arredondado para o número inteiro mais próximo. Adiciona casas decimais caso o valor seja passado como parâmetro.' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```pitugues\n' +
+            'n = 2.4\n' +
+            'escreva(n.arredondar()) // 2\n```' +
+            'x = 2.468\n' +
+            'escreva(x.arredondar(2)) // 2.47\n```' +
+            '\n\n## Formas de uso\n',
+        exemploCodigo: 'numero.arredondar()',
+    },
     arredondar_para_baixo: {
         tipoRetorno: 'número',
         argumentos: [],
-        implementacao: (interpretador: InterpretadorInterface, valor: number): Promise<number> => {
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: number
+        ): Promise<number> => {
             return Promise.resolve(Math.floor(valor));
         },
         assinaturaFormato: 'número.arredondar_para_baixo()',
@@ -31,7 +71,7 @@ export default {
             'Retira as partes decimais de um número com partes decimais e retorna sua parte inteira. Se o número já é inteiro, devolve apenas o próprio número.' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var n = 2.5\n' +
+            'n = 2.5\n' +
             'escreva(n.arredondar_para_baixo()) // 2\n```' +
             '\n\n## Formas de uso\n',
         exemploCodigo: 'numero.arredondar_para_baixo()',
@@ -39,7 +79,10 @@ export default {
     arredondar_para_cima: {
         tipoRetorno: 'número',
         argumentos: [],
-        implementacao: (interpretador: InterpretadorInterface, valor: number): Promise<number> => {
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: number
+        ): Promise<number> => {
             return Promise.resolve(Math.ceil(valor));
         },
         assinaturaFormato: 'número.arredondar_para_cima()',
@@ -48,7 +91,7 @@ export default {
             'Arredonda um número com partes decimais para cima, ou seja, para o próximo número inteiro.' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var n = 2.5\n' +
+            'n = 2.5\n' +
             'escreva(n.arredondar_para_cima()) // 3\n```' +
             '\n\n## Formas de uso\n',
         exemploCodigo: 'numero.arredondar_para_cima()',
@@ -92,10 +135,50 @@ export default {
             'Formata um número para o padrão brasileiro, com separador de milhar e vírgula como separador decimal.' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var n = 1234.56\n' +
+            'n = 1234.56\n' +
             'escreva(n.formatar()) // 1.234,56\n' +
             'escreva(n.formatar({ minimoCasasDecimais: 2, maximoCasasDecimais: 3 })) // 1.234,568\n```' +
             '\n\n## Formas de uso\n',
         exemploCodigo: 'numero.formatar({ maximoCasasDecimais: 2 })',
+    },
+    raiz_quadrada: {
+        tipoRetorno: 'numero',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: number
+        ): Promise<number> => {
+            return Promise.resolve(Math.sqrt(valor));
+        },
+        assinaturaFormato: 'numero.raiz_quadrada()',
+        documentacao:
+            '# `numero.raiz_quadrada()`\n\n' +
+            'Calcula e retorna a raiz quadrada de um número.' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```pitugues\n' +
+            'n = 25\n' +
+            'escreva(n.raiz_quadrada()) // 5\n```' +
+            '\n\n## Formas de uso\n',
+        exemploCodigo: 'numero.raiz_quadrada()',
+    },
+    truncar: {
+        tipoRetorno: 'numero',
+        argumentos: [],
+        implementacao: (
+            interpretador: InterpretadorInterface,
+            valor: number,
+        ): Promise<number> => {
+            return Promise.resolve(Math.trunc(valor));
+        },
+        assinaturaFormato: 'numero.truncar()',
+        documentacao:
+            '# `numero.truncar()`\n\n' +
+            'Retorna a parte inteira de um número, descartando suas casas decimais de forma bruta, sem arredondamento.' +
+            '\n\n ## Exemplo de Código\n' +
+            '\n\n```pitugues\n' +
+            'n = 2.99\n' +
+            'escreva(n.truncar()) // 2\n```' +
+            '\n\n## Formas de uso\n',
+        exemploCodigo: 'numero.truncar()',
     },
 } as { [nome: string]: PrimitivaInterface };

--- a/testes/bibliotecas/dialetos/pitugues/primitivas-numero.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/primitivas-numero.test.ts
@@ -1,0 +1,177 @@
+import primitivasNumero from '../../../../fontes/bibliotecas/dialetos/pitugues/primitivas-numero';
+import { criarInterpretadorMock } from '../../../_mocks/interpretador.mock';
+
+describe('Primitivas de Número (Pituguês)', () => {
+    const interpretador = criarInterpretadorMock();
+
+    describe('absoluto', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar o valor absoluto de um número negativo', async () => {
+                const resultado = await primitivasNumero
+                    .absoluto
+                    .implementacao(interpretador, -5);
+
+                expect(resultado).toBe(5);
+            });
+
+            it('Deve retornar o próprio valor caso seja positivo ou zero', async () => {
+                const positivo = await primitivasNumero
+                    .absoluto
+                    .implementacao(interpretador, 10);
+                const zero = await primitivasNumero
+                    .absoluto
+                    .implementacao(interpretador, 0);
+
+                expect(positivo).toBe(10);
+                expect(zero).toBe(0);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('arredondar', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve arredondar para o inteiro mais próximo quando não passar casas decimais', async () => {
+                const paraBaixo = await primitivasNumero
+                    .arredondar
+                    .implementacao(interpretador, 2.4);
+                const paraCima = await primitivasNumero
+                    .arredondar
+                    .implementacao(interpretador, 2.6);
+
+                expect(paraBaixo).toBe(2);
+                expect(paraCima).toBe(3);
+            });
+
+            it('Deve arredondar mantendo as casas decimais informadas', async () => {
+                const resultado = await primitivasNumero
+                    .arredondar
+                    .implementacao(interpretador, 2.468, 2);
+
+                expect(resultado).toBe(2.47);
+            });
+
+            it('Deve respeitar quando passar o número 0 casas decimais', async () => {
+                const resultado = await primitivasNumero
+                    .arredondar
+                    .implementacao(interpretador, 2.6, 0);
+
+                expect(resultado).toBe(3);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('arredondar_para_baixo', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve arredondar para o inteiro inferior', async () => {
+                const positivo = await primitivasNumero
+                    .arredondar_para_baixo
+                    .implementacao(interpretador, 2.9);
+                const negativo = await primitivasNumero
+                    .arredondar_para_baixo
+                    .implementacao(interpretador, -2.1);
+
+                expect(positivo).toBe(2);
+                expect(negativo).toBe(-3);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('arredondar_para_cima', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve arredondar para o inteiro superior', async () => {
+                const positivo = await primitivasNumero
+                    .arredondar_para_cima
+                    .implementacao(interpretador, 2.1);
+                const negativo = await primitivasNumero
+                    .arredondar_para_cima
+                    .implementacao(interpretador, -2.9);
+
+                expect(positivo).toBe(3);
+                expect(negativo).toBe(-2);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('formatar', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve aplicar a formatação padrão pt-BR (2 casas) quando dicionário estiver vazio', async () => {
+                const resultado = await primitivasNumero
+                    .formatar
+                    .implementacao(interpretador, 1234.56, {});
+
+                expect(resultado).toBe('1.234,56');
+            });
+
+            it('Deve usar as opções passadas pelo dicionário', async () => {
+                const resultado = await primitivasNumero
+                    .formatar
+                    .implementacao(
+                        interpretador,
+                        1234.56,
+                        {
+                            casasDecimais: 3,
+                            maximoCasasDecimais: 3
+                        }
+                    );
+
+                expect(resultado).toBe('1.234,560');
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('raiz_quadrada', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve retornar a raiz exata', async () => {
+                const resultado = await primitivasNumero
+                    .raiz_quadrada
+                    .implementacao(interpretador, 25);
+
+                expect(resultado).toBe(5);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+
+    describe('truncar', () => {
+        describe('Cenários de sucesso', () => {
+            it('Deve remover a parte decimal sem efetuar arredondamento para cima ou baixo', async () => {
+                const positivo = await primitivasNumero
+                    .truncar
+                    .implementacao(interpretador, 2.99);
+                const negativo = await primitivasNumero
+                    .truncar
+                    .implementacao(interpretador, -2.99);
+
+                expect(positivo).toBe(2);
+                expect(negativo).toBe(-2);
+            });
+        });
+
+        describe('Cenários de falha', () => {
+
+        });
+    });
+});


### PR DESCRIPTION
Este PR diz respeito a issue #1233

Foram adicionados os métodos `arredondar()`, `raiz_quadrada()` e `truncar()`. Além disso, foram criados testes para cada método das primitivas de `número`.

Closes #1233