### PR TITLE
Funcionalidade de testes para Delégua.

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -2586,8 +2586,18 @@ export class AvaliadorSintatico
         const importar = new Importar(construtoCaminhoModulo);
         if (identificadorDeTudo !== null) {
             importar.simboloTudo = identificadorDeTudo;
+            this.pilhaEscopos.definirInformacoesVariavel(
+                identificadorDeTudo.lexema,
+                new InformacaoElementoSintatico(identificadorDeTudo.lexema, 'módulo')
+            );
         } else {
             importar.elementosImportacao = elementosImportacao;
+            for (const elemento of elementosImportacao) {
+                this.pilhaEscopos.definirInformacoesVariavel(
+                    elemento.lexema,
+                    new InformacaoElementoSintatico(elemento.lexema, 'qualquer')
+                );
+            }
         }
 
         return Promise.resolve(importar);

--- a/fontes/bibliotecas/testes/modulo-afirmar.ts
+++ b/fontes/bibliotecas/testes/modulo-afirmar.ts
@@ -1,0 +1,125 @@
+import { InterpretadorInterface, SimboloInterface } from '../../interfaces';
+import { ErroDeAssertiva } from '../../excecoes/erro-de-assertiva';
+import { FuncaoPadrao } from '../../interpretador/estruturas/funcao-padrao';
+import { DeleguaModulo } from '../../interpretador/estruturas/modulo';
+
+function simboloAtual(interpretador: InterpretadorInterface): SimboloInterface {
+    return {
+        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+        linha: interpretador.linhaDeclaracaoAtual,
+    } as SimboloInterface;
+}
+
+export function construirModuloAfirmar(): DeleguaModulo {
+    const modulo = new DeleguaModulo('afirmar');
+
+    modulo.componentes['igual'] = new FuncaoPadrao(
+        2,
+        function (interpretador: InterpretadorInterface, valorTestado: any, obtidoTestado: any) {
+            const esperado = interpretador.resolverValor(valorTestado);
+            const obtido = interpretador.resolverValor(obtidoTestado);
+            if (esperado !== obtido) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        `Esperava ${String(esperado)}, mas obteve ${String(obtido)}.`,
+                        esperado,
+                        obtido
+                    )
+                );
+            }
+        }
+    );
+
+    modulo.componentes['diferente'] = new FuncaoPadrao(
+        2,
+        function (interpretador: InterpretadorInterface, valorATestado: any, valorBTestado: any) {
+            const valorA = interpretador.resolverValor(valorATestado);
+            const valorB = interpretador.resolverValor(valorBTestado);
+            if (valorA === valorB) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        `Esperava valores diferentes, mas ambos são ${String(valorA)}.`,
+                        undefined,
+                        valorA
+                    )
+                );
+            }
+        }
+    );
+
+    modulo.componentes['verdadeiro'] = new FuncaoPadrao(
+        1,
+        function (interpretador: InterpretadorInterface, valorTestado: any) {
+            const valor = interpretador.resolverValor(valorTestado);
+            if (!valor) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        `Esperava verdadeiro, mas obteve ${String(valor)}.`,
+                        true,
+                        valor
+                    )
+                );
+            }
+        }
+    );
+
+    modulo.componentes['falso'] = new FuncaoPadrao(
+        1,
+        function (interpretador: InterpretadorInterface, valorTestado: any) {
+            const valor = interpretador.resolverValor(valorTestado);
+            if (valor) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        `Esperava falso, mas obteve ${String(valor)}.`,
+                        false,
+                        valor
+                    )
+                );
+            }
+        }
+    );
+
+    modulo.componentes['nulo'] = new FuncaoPadrao(
+        1,
+        function (interpretador: InterpretadorInterface, valorTestado: any) {
+            const valor = interpretador.resolverValor(valorTestado);
+            if (valor !== null && valor !== undefined) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        `Esperava nulo, mas obteve ${String(valor)}.`,
+                        null,
+                        valor
+                    )
+                );
+            }
+        }
+    );
+
+    modulo.componentes['erro'] = new FuncaoPadrao(
+        1,
+        async function (interpretador: InterpretadorInterface, funcaoTestada: any) {
+            const funcao = interpretador.resolverValor(funcaoTestada);
+            let erroLancado = false;
+            try {
+                await funcao.chamar(interpretador, [], null);
+            } catch (_) {
+                erroLancado = true;
+            }
+            if (!erroLancado) {
+                return Promise.reject(
+                    new ErroDeAssertiva(
+                        simboloAtual(interpretador),
+                        'Esperava que a função lançasse um erro, mas ela completou sem erros.'
+                    )
+                );
+            }
+        }
+    );
+
+    return modulo;
+}

--- a/fontes/bibliotecas/testes/modulo-testes.ts
+++ b/fontes/bibliotecas/testes/modulo-testes.ts
@@ -1,0 +1,79 @@
+import { SimboloInterface } from '../../interfaces';
+import { ErroDeAssertiva } from '../../excecoes/erro-de-assertiva';
+import { FuncaoPadrao } from '../../interpretador/estruturas/funcao-padrao';
+import { DeleguaModulo } from '../../interpretador/estruturas/modulo';
+import { RegistroTestes } from './registro-testes';
+import { construirModuloAfirmar } from './modulo-afirmar';
+
+function simboloAtual(interpretador: any): SimboloInterface {
+    return {
+        hashArquivo: interpretador.hashArquivoDeclaracaoAtual,
+        linha: interpretador.linhaDeclaracaoAtual,
+    } as SimboloInterface;
+}
+
+export function construirModuloDeTestes(interpretador: any, registro: RegistroTestes): DeleguaModulo {
+    const modulo = new DeleguaModulo('testes');
+
+    (modulo.componentes as any)['afirmar'] = construirModuloAfirmar();
+
+    modulo.componentes['grupo'] = new FuncaoPadrao(
+        2,
+        async function (_visitante: any, nomeRaw: any, funcaoRaw: any) {
+            const nome: string = interpretador.resolverValor(nomeRaw);
+            const funcao = interpretador.resolverValor(funcaoRaw);
+            const suiteAnterior = registro.suiteAtual;
+            registro.suiteAtual = suiteAnterior ? `${suiteAnterior} > ${nome}` : nome;
+            const emDeclaracaoTenteAnterior = interpretador.emDeclaracaoTente;
+            interpretador.emDeclaracaoTente = true;
+            try {
+                await funcao.chamar(interpretador, [], null);
+            } finally {
+                registro.suiteAtual = suiteAnterior;
+                interpretador.emDeclaracaoTente = emDeclaracaoTenteAnterior;
+            }
+        }
+    );
+
+    modulo.componentes['teste'] = new FuncaoPadrao(
+        2,
+        async function (_visitante: any, nomeRaw: any, funcaoRaw: any) {
+            const nome: string = interpretador.resolverValor(nomeRaw);
+            const funcao = interpretador.resolverValor(funcaoRaw);
+            const inicio = Date.now();
+            const emDeclaracaoTenteAnterior = interpretador.emDeclaracaoTente;
+            interpretador.emDeclaracaoTente = true;
+            try {
+                await funcao.chamar(interpretador, [], null);
+                registro.resultados.push({
+                    nomeSuite: registro.suiteAtual,
+                    nomeTeste: nome,
+                    status: 'passou',
+                    tempoMs: Date.now() - inicio,
+                });
+            } catch (e: any) {
+                registro.resultados.push({
+                    nomeSuite: registro.suiteAtual,
+                    nomeTeste: nome,
+                    status: 'falhou',
+                    mensagemErro: e.mensagem || e.message || String(e),
+                    tempoMs: Date.now() - inicio,
+                });
+            } finally {
+                interpretador.emDeclaracaoTente = emDeclaracaoTenteAnterior;
+            }
+        }
+    );
+
+    modulo.componentes['lancarErro'] = new FuncaoPadrao(
+        1,
+        function (_visitante: any, mensagemRaw: any) {
+            const mensagem: string = interpretador.resolverValor(mensagemRaw);
+            return Promise.reject(
+                new ErroDeAssertiva(simboloAtual(interpretador), String(mensagem))
+            );
+        }
+    );
+
+    return modulo;
+}

--- a/fontes/bibliotecas/testes/registro-testes.ts
+++ b/fontes/bibliotecas/testes/registro-testes.ts
@@ -1,0 +1,12 @@
+export interface ResultadoTeste {
+    nomeSuite: string;
+    nomeTeste: string;
+    status: 'passou' | 'falhou';
+    mensagemErro?: string;
+    tempoMs: number;
+}
+
+export class RegistroTestes {
+    resultados: ResultadoTeste[] = [];
+    suiteAtual: string = '';
+}

--- a/fontes/excecoes/erro-de-assertiva.ts
+++ b/fontes/excecoes/erro-de-assertiva.ts
@@ -1,0 +1,14 @@
+import { SimboloInterface } from '../interfaces';
+import { ErroEmTempoDeExecucao } from './erro-em-tempo-de-execucao';
+
+export class ErroDeAssertiva extends ErroEmTempoDeExecucao {
+    esperado?: any;
+    obtido?: any;
+
+    constructor(simbolo?: SimboloInterface, mensagem?: string, esperado?: any, obtido?: any) {
+        super(simbolo, mensagem);
+        this.esperado = esperado;
+        this.obtido = obtido;
+        Object.setPrototypeOf(this, ErroDeAssertiva.prototype);
+    }
+}

--- a/fontes/excecoes/index.ts
+++ b/fontes/excecoes/index.ts
@@ -1,1 +1,2 @@
+export * from './erro-de-assertiva';
 export * from './erro-em-tempo-de-execucao';

--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -1309,17 +1309,21 @@ export class InterpretadorBase implements InterpretadorInterface {
 
             if (entidadeChamada instanceof FuncaoPadrao) {
                 try {
-                    return entidadeChamada.chamar(
+                    return await entidadeChamada.chamar(
                         this,
                         argumentos.map((a) => a && this.resolverValor(a.valor)),
                         (expressao.entidadeChamada as any).simbolo // TODO: O que exatamente pode ser aqui?
                     );
                 } catch (erro: any) {
+                    if (this.emDeclaracaoTente) {
+                        return Promise.reject(erro);
+                    }
                     this.erros.push({
                         erroInterno: erro,
                         linha: expressao.linha,
                         hashArquivo: expressao.hashArquivo,
                     });
+                    return;
                 }
             }
 

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -65,6 +65,7 @@ import {
     Escreva,
     Fazer,
     FuncaoDeclaracao,
+    Importar,
     InterfaceDeclaracao,
     Para,
     ParaCada,
@@ -83,6 +84,8 @@ import {
 } from '../interfaces/delegua';
 
 import { carregarBibliotecasGlobais, pontoEntradaAjuda } from './comum';
+import { construirModuloDeTestes } from '../bibliotecas/testes/modulo-testes';
+import { RegistroTestes } from '../bibliotecas/testes/registro-testes';
 
 import primitivasDicionario from '../bibliotecas/primitivas-dicionario';
 import primitivasNumero from '../bibliotecas/primitivas-numero';
@@ -101,6 +104,7 @@ import tiposDeSimbolos from '../tipos-de-simbolos/delegua';
 export class Interpretador extends InterpretadorBase implements VisitanteDeleguaInterface {
     montao: Montao;
     acumularRetornos = false;
+    registroTestes: RegistroTestes = new RegistroTestes();
 
     constructor(
         diretorioBase: string,
@@ -342,6 +346,39 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
     visitarDeclaracaoInterface(_declaracao: InterfaceDeclaracao): Promise<any> {
         // Interfaces não possuem comportamento em tempo de execução.
         return Promise.resolve();
+    }
+
+    override async visitarDeclaracaoImportar(declaracao: Importar): Promise<DeleguaModulo> {
+        const resultadoCaminho = await this.avaliar(declaracao.caminho);
+        const caminho: string = this.resolverValor(resultadoCaminho);
+
+        if (caminho === 'testes') {
+            this.registroTestes = new RegistroTestes();
+            const modulo = construirModuloDeTestes(this, this.registroTestes);
+
+            if (declaracao.simboloTudo !== null) {
+                this.pilhaEscoposExecucao.definirVariavel(
+                    (declaracao.simboloTudo as any).lexema,
+                    modulo
+                );
+            } else {
+                for (const elemento of declaracao.elementosImportacao) {
+                    const componente = modulo.componentes[(elemento as any).lexema];
+                    if (componente !== undefined) {
+                        this.pilhaEscoposExecucao.definirVariavel(
+                            (elemento as any).lexema,
+                            componente
+                        );
+                    }
+                }
+            }
+
+            return modulo;
+        }
+
+        return Promise.reject(
+            'Importação de arquivos não suportada neste interpretador. Use delegua-node para importações de arquivos.'
+        );
     }
 
     async visitarDeclaracaoAjuda(declaracao: Ajuda): Promise<any> {

--- a/testes/interpretador/biblioteca-testes.test.ts
+++ b/testes/interpretador/biblioteca-testes.test.ts
@@ -1,0 +1,237 @@
+import { AvaliadorSintatico } from '../../fontes/avaliador-sintatico';
+import { ErroDeAssertiva } from '../../fontes/excecoes/erro-de-assertiva';
+import { Interpretador } from '../../fontes/interpretador';
+import { Lexador } from '../../fontes/lexador';
+
+describe('Biblioteca de testes', () => {
+    let lexador: Lexador;
+    let avaliadorSintatico: AvaliadorSintatico;
+    let interpretador: Interpretador;
+
+    beforeEach(() => {
+        lexador = new Lexador();
+        avaliadorSintatico = new AvaliadorSintatico();
+        interpretador = new Interpretador(process.cwd(), false, undefined, undefined);
+    });
+
+    async function executar(linhas: string[]) {
+        const retornoLexador = lexador.mapear(linhas, -1);
+        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+        return await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+    }
+
+    describe('importar', () => {
+        it('importar { afirmar } de "testes" resolve sem erros', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('importar { afirmar, teste, grupo, lancarErro } de "testes" resolve sem erros', async () => {
+            const retorno = await executar([
+                'importar { afirmar, teste, grupo, lancarErro } de "testes"',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+    });
+
+    describe('afirmar.igual', () => {
+        it('passa quando os valores são iguais', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.igual(4, 4)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('passa quando o resultado de uma expressão é igual ao esperado', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.igual(4, 2 + 2)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva quando os valores diferem', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.igual(4, 5)',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('afirmar.diferente', () => {
+        it('passa quando os valores são diferentes', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.diferente(1, 2)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva quando os valores são iguais', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.diferente(1, 1)',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('afirmar.verdadeiro', () => {
+        it('passa para valor verdadeiro', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.verdadeiro(verdadeiro)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva para valor falso', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.verdadeiro(falso)',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('afirmar.falso', () => {
+        it('passa para valor falso', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.falso(falso)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva para valor verdadeiro', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.falso(verdadeiro)',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('afirmar.nulo', () => {
+        it('passa para nulo', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.nulo(nulo)',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva para valor não nulo', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.nulo(1)',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('afirmar.erro', () => {
+        it('passa quando a função lança um erro', async () => {
+            const retorno = await executar([
+                'importar { afirmar, falhar } de "testes"',
+                'afirmar.erro(funcao() { falhar("erro esperado") })',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+        });
+
+        it('lança ErroDeAssertiva quando a função não lança erro', async () => {
+            const retorno = await executar([
+                'importar { afirmar } de "testes"',
+                'afirmar.erro(funcao() { var x = 1 })',
+            ]);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+        });
+    });
+
+    describe('lancarErro', () => {
+        it('lança ErroDeAssertiva com a mensagem informada', async () => {
+            const retornoLexador = lexador.mapear(['importar { lancarErro } de "testes"', 'lancarErro("falha intencional")'], -1);
+            const retornoAS = await avaliadorSintatico.analisar(retornoLexador, -1);
+            const retorno = await interpretador.interpretar(retornoAS.declaracoes);
+            expect(retorno.erros).toHaveLength(1);
+            expect(retorno.erros[0].erroInterno).toBeInstanceOf(ErroDeAssertiva);
+            expect(retorno.erros[0].erroInterno.mensagem).toBe('falha intencional');
+        });
+    });
+
+    describe('teste', () => {
+        it('registra um teste que passou', async () => {
+            const retorno = await executar([
+                'importar { afirmar, teste } de "testes"',
+                'teste("soma funciona", funcao() {',
+                '    afirmar.igual(4, 2 + 2)',
+                '})',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+            expect(interpretador.registroTestes.resultados).toHaveLength(1);
+            expect(interpretador.registroTestes.resultados[0].status).toBe('passou');
+            expect(interpretador.registroTestes.resultados[0].nomeTeste).toBe('soma funciona');
+        });
+
+        it('registra um teste que falhou', async () => {
+            const retorno = await executar([
+                'importar { afirmar, teste } de "testes"',
+                'teste("soma errada", funcao() {',
+                '    afirmar.igual(4, 5)',
+                '})',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+            expect(interpretador.registroTestes.resultados).toHaveLength(1);
+            expect(interpretador.registroTestes.resultados[0].status).toBe('falhou');
+        });
+    });
+
+    describe('grupo', () => {
+        it('registra testes dentro de um grupo', async () => {
+            const retorno = await executar([
+                'importar { afirmar, teste, grupo } de "testes"',
+                'grupo("Matemática", funcao() {',
+                '    teste("adição", funcao() {',
+                '        afirmar.igual(4, 2 + 2)',
+                '    })',
+                '    teste("subtração", funcao() {',
+                '        afirmar.igual(0, 1 - 1)',
+                '    })',
+                '})',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+            expect(interpretador.registroTestes.resultados).toHaveLength(2);
+            expect(interpretador.registroTestes.resultados[0].nomeSuite).toBe('Matemática');
+            expect(interpretador.registroTestes.resultados[0].status).toBe('passou');
+            expect(interpretador.registroTestes.resultados[1].status).toBe('passou');
+        });
+
+        it('restaura o suite anterior após executar o grupo', async () => {
+            const retorno = await executar([
+                'importar { afirmar, teste, grupo } de "testes"',
+                'grupo("Grupo A", funcao() {',
+                '    teste("teste dentro de A", funcao() {',
+                '        afirmar.verdadeiro(verdadeiro)',
+                '    })',
+                '})',
+                'teste("teste fora de grupo", funcao() {',
+                '    afirmar.verdadeiro(verdadeiro)',
+                '})',
+            ]);
+            expect(retorno.erros).toHaveLength(0);
+            expect(interpretador.registroTestes.resultados).toHaveLength(2);
+            expect(interpretador.registroTestes.resultados[0].nomeSuite).toBe('Grupo A');
+            expect(interpretador.registroTestes.resultados[1].nomeSuite).toBe('');
+        });
+    });
+});


### PR DESCRIPTION
Ideia:

```js
importar { grupo, teste, afirmar } de "testes"

grupo("matemática", funcao() {
    teste("soma dois números", funcao() {
        afirmar.igual(4, 2 + 2)
    })

    teste("lança erro em divisão inválida", funcao() {
        afirmar.erro(funcao() {
            afirmar.falso(verdadeiro)
        })
    })
})
```