### PR TITLE
[Delégua & Pituguês] adiciona validação de quantidade mínima de argumentos em chamadas de função

### DIFF
--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -1265,11 +1265,13 @@ export class InterpretadorBase implements InterpretadorInterface {
      */
     async visitarExpressaoDeChamada(expressao: Chamada): Promise<any> {
         try {
-            let variavelEntidadeChamada: VariavelInterface | any = await this.avaliar(
-                expressao.entidadeChamada
-            );
+            let variavelEntidadeChamada: VariavelInterface | any = await this
+                .avaliar(expressao.entidadeChamada);
 
-            if (variavelEntidadeChamada === null || variavelEntidadeChamada === undefined) {
+            if (
+                variavelEntidadeChamada === null ||
+                variavelEntidadeChamada === undefined
+            ) {
                 return Promise.reject(
                     new ErroEmTempoDeExecucao(
                         (expressao as any).parentese,
@@ -1280,7 +1282,11 @@ export class InterpretadorBase implements InterpretadorInterface {
                 );
             }
 
-            if (Object.prototype.hasOwnProperty.call(variavelEntidadeChamada, 'valorRetornado')) {
+            if (
+                Object.prototype.hasOwnProperty.call(
+                    variavelEntidadeChamada, 'valorRetornado'
+                )
+            ) {
                 variavelEntidadeChamada = variavelEntidadeChamada.valorRetornado;
             }
 
@@ -1302,11 +1308,14 @@ export class InterpretadorBase implements InterpretadorInterface {
             }
 
             if (entidadeChamada instanceof MetodoPrimitiva) {
-                return await this.chamarMetodoPrimitiva(expressao, entidadeChamada);
+                return await this.chamarMetodoPrimitiva(
+                    expressao,
+                    entidadeChamada
+                );
             }
 
-            const argumentos: ArgumentoInterface[] =
-                await this.resolverArgumentosChamada(expressao);
+            const argumentos: ArgumentoInterface[] = await this
+                .resolverArgumentosChamada(expressao);
             const aridade = entidadeChamada.aridade
                 ? entidadeChamada.aridade()
                 : entidadeChamada.length;
@@ -1319,6 +1328,29 @@ export class InterpretadorBase implements InterpretadorInterface {
                 entidadeChamada instanceof MetodoPolimorfico ||
                 (entidadeChamada instanceof DescritorTipoClasse &&
                     entidadeChamada.encontrarMetodo('construtor') instanceof MetodoPolimorfico);
+
+            if (
+                entidadeChamada instanceof DeleguaFuncao && entidadeChamada.declaracao
+            ) {
+                // Pega os parâmetros da declaração e filtra apenas os obrigatórios
+                // (ignora os que têm valor padrão ou são rest parameters)
+                const parametros = entidadeChamada.declaracao.parametros || [];
+                const parametrosObrigatorios = parametros.filter(
+                    (p) => !p.valorPadrao && p.abrangencia !== 'multiplo'
+                ).length;
+
+                if (argumentos.length < parametrosObrigatorios) {
+                    const nomeFuncao = entidadeChamada.nome || 'anônima';
+
+                    return Promise.reject(
+                        new ErroEmTempoDeExecucao(
+                            (expressao as any).parentese,
+                            `A função '${nomeFuncao}' esperava no mínimo ${parametrosObrigatorios} argumento(s), mas recebeu ${argumentos.length}.`,
+                            expressao.linha
+                        )
+                    );
+                }
+            }
 
             if (!ehPolimorfico && argumentos.length < aridade) {
                 const diferenca = aridade - argumentos.length;

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -3780,6 +3780,25 @@ describe('Interpretador', () => {
                     expect(_saidas).toHaveLength(1);
                     expect(_saidas[0]).toBe('3');
                 });
+
+                it('deve lançar erro ao chamar função sem todos os parâmetros obrigatórios', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'funcao saudacao(nome, sobrenome) {',
+                        '    escreva("Olá, " + nome + " " + sobrenome)',
+                        '}',
+                        'saudacao("Victor")',
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico
+                        .analisar(retornoLexador, -1);
+
+                    expect(retornoAvaliadorSintatico.erros).toHaveLength(0);
+
+                    const retornoInterpretador = await interpretador
+                        .interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(1);
+                });
             });
 
             describe('Entrada e saída', () => {


### PR DESCRIPTION
Foi identificado que o bug mencionado em #1260 também ocorre em Delégua. Com as alterações feitas, esse bug é corrigido em Delégua e também no Pituguês.

Closes #1260