### PR TITLE
Corrige bug do bloco `senao` não estar funcionando em `Tente/Pegue`

### DIFF
--- a/fontes/interpretador/interpretador-base.ts
+++ b/fontes/interpretador/interpretador-base.ts
@@ -1871,40 +1871,68 @@ export class InterpretadorBase implements InterpretadorInterface {
     }
 
     /**
+     * Unifica a execução do bloco 'pegue', tratando tanto o caso de
+     * declarações simples quanto o caso de função com parâmetro de erro.
+     */
+    private async executarBlocoPegue(
+        pegue: FuncaoConstruto | Declaracao[],
+        erro: any
+    ): Promise<any> {
+        if (Array.isArray(pegue)) {
+            return await this.executarBloco(pegue);
+        }
+
+        // Caso seja FuncaoConstruto (pegue com parâmetro de erro)
+        const literalErro = new Literal(
+            pegue.hashArquivo,
+            pegue.linha,
+            erro.mensagem || erro.message || erro
+        );
+        const chamadaPegue = new Chamada(
+            pegue.hashArquivo,
+            pegue,
+            [literalErro]
+        );
+
+        return await chamadaPegue.aceitar(this);
+    }
+
+    /**
      * Interpretação de uma declaração `tente`.
      * @param declaracao O objeto da declaração.
      */
     async visitarDeclaracaoTente(declaracao: Tente): Promise<any> {
         let valorRetorno: any;
+        let sucessoNoTente = false;
+
         try {
             this.emDeclaracaoTente = true;
+
             try {
-                valorRetorno = await this.executarBloco(declaracao.caminhoTente);
+                valorRetorno = await this.executarBloco(
+                    declaracao.caminhoTente
+                );
+                sucessoNoTente = true;
             } catch (erro: any) {
                 if (declaracao.caminhoPegue !== null) {
-                    // `caminhoPegue` aqui pode ser um construto de função (se `pegue` tem parâmetros)
-                    // ou um vetor de `Declaracao` (`pegue` sem parâmetros).
-                    // As execuções, portanto, são diferentes.
-                    if (Array.isArray(declaracao.caminhoPegue)) {
-                        valorRetorno = await this.executarBloco(declaracao.caminhoPegue);
-                    } else {
-                        const literalErro = new Literal(
-                            declaracao.hashArquivo,
-                            Number(declaracao.linha),
-                            erro.mensagem
-                        );
-                        const chamadaPegue = new Chamada(
-                            declaracao.caminhoPegue.hashArquivo,
-                            declaracao.caminhoPegue,
-                            [literalErro]
-                        );
-                        valorRetorno = await chamadaPegue.aceitar(this);
-                    }
-                }
+                    valorRetorno = await this.executarBlocoPegue(
+                        declaracao.caminhoPegue,
+                        erro
+                    );
+                } else throw erro;
+            }
+
+            if (sucessoNoTente && declaracao.caminhoSenao) {
+                valorRetorno = await this.executarBloco(
+                    declaracao.caminhoSenao
+                );
             }
         } finally {
-            if (declaracao.caminhoFinalmente)
-                valorRetorno = await this.executarBloco(declaracao.caminhoFinalmente);
+            if (declaracao.caminhoFinalmente) {
+                valorRetorno = await this.executarBloco(
+                    declaracao.caminhoFinalmente
+                );
+            }
 
             this.emDeclaracaoTente = false;
         }

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -4451,6 +4451,31 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros[0].erroInterno.message).toBe('teste de falha');
                 });
             });
+
+            describe('Tente/Pegue', () => {
+                it('Deve permitir o uso de "senao"', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'tente:',
+                        '    escreva("Tente")',
+                        'pegue:',
+                        '    escreva("Pegue")',
+                        'senao:',
+                        '    escreva("Tudo certo com o tente")',
+                        'finalmente:',
+                        '    escreva("Finalizado")'
+                    ], -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico
+                        .analisar(retornoLexador, -1);
+                    const retornoInterpretador = await interpretador
+                        .interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas.length).toBe(3);
+                    expect(_saidas[0]).toBe("Tente");
+                    expect(_saidas[1]).toBe("Tudo certo com o tente");
+                    expect(_saidas[2]).toBe("Finalizado");
+                });
+            });
         });
 
         it('termina_com - sufixo encontrado no final', async () => {


### PR DESCRIPTION
Foram feitas pequenas alterações no `visitarDeclaracaoTente()` para que o bloco `senao` funcione corretamente no bloco `Tente/Pegue`.

Closes #1303