### PR TITLE
Operador `tipo()`/`tipo de` retorna o tipo exato de cada dado em laços `para cada` sobre dicionários

### DIFF
--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -2126,7 +2126,17 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
                 const alvoTipoDe = await this.avaliar(valorTipoDe);
                 return `tipo de<${alvoTipoDe}>`;
             case Variavel:
-                return valorTipoDe.tipo || inferirTipoVariavel(await this.avaliar(valorTipoDe));
+                const tipoEstatico = valorTipoDe.tipo;
+                if (tipoEstatico !== 'qualquer') return tipoEstatico;
+
+                const valorAvaliado = await this.avaliar(valorTipoDe);
+                const valorResolvido = this.resolverValor(valorAvaliado);
+
+                if (valorResolvido === undefined || valorResolvido === null) {
+                    return 'qualquer';
+                }
+
+                return inferirTipoVariavel(valorResolvido) as string;
             case Vetor:
                 const vetor = valorTipoDe as Vetor;
                 const apenasValores = vetor.valores.filter(

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -1439,6 +1439,23 @@ describe('Interpretador (Pituguês)', () => {
                             expect(_saidas[2]).toBe('("c", 3)');
                         });
                     });
+
+                    it('Deve retornar o tipo correto do dado ao usar operador "tipo()"', async () => {
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'dicionario = {"a": 1, "b": 2}',
+                                'para cada chave, valor em dicionario:',
+                                '    escreva(tipo(chave), tipo(valor))',
+                            ], -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(2);
+                        expect(_saidas[0]).toBe('texto número');
+                        expect(_saidas[1]).toBe('texto número');
+                    });
                 });
 
                 it('Iterando texto', async () => {

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -2784,6 +2784,24 @@ describe('Interpretador', () => {
                         expect(_saidas).toHaveLength(1);
                         expect(_saidas[0]).toBe('[15, 45, 75, 35, 150]');
                     });
+
+                    it('Deve retornar o tipo correto do dado ao usar operador "tipo de"', async () => {
+                        const retornoLexador = lexador.mapear(
+                            [
+                                'var dicionario = {"a": 1, "b": 2}',
+                                'para cada {chave, valor} em dicionario {',
+                                '    escreva(tipo de chave, tipo de valor)',
+                                '}'
+                            ], -1
+                        );
+                        const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                        const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                        expect(retornoInterpretador.erros).toHaveLength(0);
+                        expect(_saidas).toHaveLength(2);
+                        expect(_saidas[0]).toBe('texto número');
+                        expect(_saidas[1]).toBe('texto número');
+                    });
                 });
 
                 describe('Para tradicional', () => {


### PR DESCRIPTION
Closes #1324