### PR TITLE
Reconhece `nao` como negacao unaria no Pitugues

### DIFF
--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -1235,6 +1235,7 @@ export class AvaliadorSintaticoPitugues extends AvaliadorSintaticoBase implement
 
         if (
             this.verificarSeSimboloAtualEIgualA(
+                tiposDeSimbolos.NAO,
                 tiposDeSimbolos.NEGACAO,
                 tiposDeSimbolos.SUBTRACAO,
                 tiposDeSimbolos.BIT_NOT

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -1177,6 +1177,31 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
 
+                it('Operacoes logicas - nao como negacao unaria', async () => {
+                    const retornoLexador = lexador.mapear(
+                        [
+                            'funcao valor_negado():',
+                            '    valor = falso',
+                            '    retorna nao valor',
+                            'se nao falso:',
+                            '    escreva(valor_negado())',
+                        ],
+                        -1
+                    );
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(1);
+                    expect(_saidas[0]).toBe('verdadeiro');
+                });
+
                 it('Operações lógicas - em', async () => {
                     const retornoLexador = lexador.mapear(['escreva(2 em [1, 2, 3])'], -1);
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(


### PR DESCRIPTION
## Resumo
- Adiciona `nao` a analise de expressoes unarias do dialeto Pitugues.
- Cobre o uso de `nao` em retorno de funcao e em condicional `se`.

## Validacao
- `corepack yarn jest testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts --runInBand` (306 testes)
- `corepack yarn jest testes/analisador-semantico/dialetos/pitugues/analisador-semantico.test.ts --runInBand` (158 testes)
- `corepack yarn tsc --noEmit`

Closes #1343