### PR TITLE
Corrige decoradores com acesso a propriedades no Pitugues

### DIFF
--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -424,6 +424,49 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         return Promise.resolve(pontoEntradaAjuda(declaracao.funcao, declaracao.elemento));
     }
 
+    private criarSimboloDecorador(
+        lexema: string,
+        linha: number,
+        hashArquivo: number
+    ): SimboloInterface {
+        return {
+            lexema,
+            tipo: 'IDENTIFICADOR',
+            literal: null,
+            linha,
+            hashArquivo,
+        };
+    }
+
+    protected async resolverFuncaoDecoradora(
+        nomeDecorador: string,
+        linha: number,
+        hashArquivo: number
+    ): Promise<DeleguaFuncao> {
+        const partesNome = nomeDecorador.split('.');
+
+        if (partesNome.length === 1) {
+            const variavelDecoradora =
+                this.pilhaEscoposExecucao.obterVariavelPorNome(nomeDecorador);
+            return variavelDecoradora.valor as DeleguaFuncao;
+        }
+
+        let expressaoDecoradora: ConstrutoInterface = new Variavel(
+            hashArquivo,
+            this.criarSimboloDecorador(partesNome[0], linha, hashArquivo)
+        );
+
+        for (const parteNome of partesNome.slice(1)) {
+            expressaoDecoradora = new AcessoMetodoOuPropriedade(
+                hashArquivo,
+                expressaoDecoradora,
+                this.criarSimboloDecorador(parteNome, linha, hashArquivo)
+            );
+        }
+
+        return this.resolverValor(await this.avaliar(expressaoDecoradora), true) as DeleguaFuncao;
+    }
+
     override async visitarDeclaracaoDefinicaoFuncao(
         declaracao: FuncaoDeclaracao
     ): Promise<any> {
@@ -436,9 +479,11 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
         if (declaracao.decoradores && declaracao.decoradores.length > 0) {
             for (const decorador of [...declaracao.decoradores].reverse()) {
                 const nomeDecorador = decorador.nome.slice(1);
-                const variavelDecoradora =
-                    this.pilhaEscoposExecucao.obterVariavelPorNome(nomeDecorador);
-                const funcaoDecoradora: DeleguaFuncao = variavelDecoradora.valor;
+                const funcaoDecoradora = await this.resolverFuncaoDecoradora(
+                    nomeDecorador,
+                    decorador.linha,
+                    decorador.hashArquivo
+                );
                 const argumentosDecorador: ArgumentoInterface[] = [
                     { nome: '', valor: funcao }
                 ];

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -4128,6 +4128,65 @@ describe('Interpretador (Pituguês)', () => {
                         'Tchau, Victor'
                     ]);
                 });
+
+                it('Suporta o uso de Decoradores acessados por propriedade', async () => {
+                    const codigo = [
+                        'classe Aplicacao:',
+                        '   funcao rota(decorado):',
+                        '       retorna funcao():',
+                        '           escreva("Antes")',
+                        '           decorado()',
+                        '           escreva("Depois")',
+                        '',
+                        'App = Aplicacao()',
+                        '',
+                        '@App.rota',
+                        'função ola_mundo():',
+                        '   escreva("Olá, Mundo!")',
+                        '',
+                        'ola_mundo()'
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliador.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toEqual(['Antes', 'Olá, Mundo!', 'Depois']);
+                });
+
+                it('Suporta o uso de Decoradores acessados por propriedade com parâmetros', async () => {
+                    const codigo = [
+                        'classe Aplicacao:',
+                        '   funcao rota(decorado, caminho):',
+                        '       retorna funcao():',
+                        '           escreva(caminho)',
+                        '           decorado()',
+                        '',
+                        'App = Aplicacao()',
+                        '',
+                        '@App.rota("/inicio")',
+                        'função ola_mundo():',
+                        '   escreva("Olá, Mundo!")',
+                        '',
+                        'ola_mundo()'
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliador = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliador.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toEqual(['/inicio', 'Olá, Mundo!']);
+                });
             });
 
             it('aleatorio()', async () => {


### PR DESCRIPTION
## Resumo
- Resolve nomes de decoradores com pontos, como `@App.rota`, avaliando a cadeia de acesso antes de chamar a função decoradora.
- Mantém o caminho existente para decoradores simples, como `@meu_decorador`.
- Adiciona regressões para `@App.rota` e `@App.rota("/inicio")`.

## Validação
- `node_modules\.bin\jest.cmd testes\interpretador\dialetos\pitugues\interpretador-pitugues.test.ts --runInBand`
- `node_modules\.bin\tsc.cmd --noEmit --pretty false`

Closes #1336
