### PR TITLE
1344: adotar tabela-verdade padrão do Python no dialeto Pituguês

### DIFF
--- a/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
+++ b/fontes/interpretador/dialetos/pitugues/interpretador-pitugues.ts
@@ -48,6 +48,31 @@ export class InterpretadorPitugues extends Interpretador {
         this.requerDeclaracaoPropriedades = false;
     }
 
+    override eVerdadeiro(objeto: any): boolean {
+        const valorResolvido = this.resolverValor(objeto);
+
+        if (valorResolvido === null || valorResolvido === undefined) return false;
+        if (typeof valorResolvido === 'boolean') return valorResolvido;
+        if (typeof valorResolvido === 'number') return valorResolvido !== 0;
+        if (typeof valorResolvido === 'string') return valorResolvido.length > 0;
+        if (Array.isArray(valorResolvido)) return valorResolvido.length > 0;
+        if (valorResolvido instanceof TuplaN) return valorResolvido.elementos.length > 0;
+
+        if (
+            valorResolvido.constructor === Object &&
+            !('valor' in valorResolvido) &&
+            !('tipo' in valorResolvido)
+        ) {
+            return Object.keys(valorResolvido).length > 0;
+        }
+
+        if (valorResolvido.hasOwnProperty?.('valor')) {
+            return this.eVerdadeiro(valorResolvido.valor);
+        }
+
+        return true;
+    }
+
     protected override pontoInicializacaoBibliotecasGlobais() {
         for (const [nome, valor] of Object.entries(bibliotecaGlobalPitugues)) {
             if (typeof valor === 'function') {

--- a/fontes/interpretador/interpretador.ts
+++ b/fontes/interpretador/interpretador.ts
@@ -2162,7 +2162,7 @@ export class Interpretador extends InterpretadorBase implements VisitanteDelegua
     async visitarExpressaoSeTernario(expressao: SeTernario): Promise<any> {
         const avaliacaoCondicao = await this.avaliar(expressao.condicao);
         const valorAvaliacaoCondicao = this.resolverValor(avaliacaoCondicao);
-        if (valorAvaliacaoCondicao) {
+        if (this.eVerdadeiro(valorAvaliacaoCondicao)) {
             return this.avaliar(expressao.expressaoSe);
         }
 

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -1289,6 +1289,106 @@ describe('Interpretador (Pituguês)', () => {
 
                     expect(retornoInterpretador.erros).toHaveLength(0);
                 });
+
+                it('usa a mesma coercao booleana para colecoes em condicionais, negacao, retorno e ternario', async () => {
+                    const codigo = [
+                        'pilha = []',
+                        'se ! pilha:',
+                        "   escreva('vazia')",
+                        'se pilha:',
+                        "   escreva('nao deveria')",
+                        'senao:',
+                        "   escreva('lista falsa')",
+                        'se [1]:',
+                        "   escreva('lista verdadeira')",
+                        'se "":',
+                        "   escreva('nao deveria')",
+                        'senao:',
+                        "   escreva('texto falso')",
+                        'se "x":',
+                        "   escreva('texto verdadeiro')",
+                        'se {}:',
+                        "   escreva('nao deveria')",
+                        'senao:',
+                        "   escreva('dicionario falso')",
+                        'se {"a": 1}:',
+                        "   escreva('dicionario verdadeiro')",
+                        'se tupla([]):',
+                        "   escreva('nao deveria')",
+                        'senao:',
+                        "   escreva('tupla falsa')",
+                        'se tupla([1]):',
+                        "   escreva('tupla verdadeira')",
+                        'se 0:',
+                        "   escreva('nao deveria')",
+                        'senao:',
+                        "   escreva('zero falso')",
+                        'se 1:',
+                        "   escreva('numero verdadeiro')",
+                        '',
+                        'funcao teste_vazio():',
+                        '   pilha = []',
+                        '   retorna ! pilha',
+                        '',
+                        'funcao teste_preenchido():',
+                        '   pilha = [1]',
+                        '   retorna ! pilha',
+                        '',
+                        'escreva(teste_vazio())',
+                        'escreva(teste_preenchido())',
+                        'escreva("ternario verdadeiro" se [1] senao "nao deveria")',
+                        'escreva("nao deveria" se [] senao "ternario falso")',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toEqual([
+                        'vazia',
+                        'lista falsa',
+                        'lista verdadeira',
+                        'texto falso',
+                        'texto verdadeiro',
+                        'dicionario falso',
+                        'dicionario verdadeiro',
+                        'tupla falsa',
+                        'tupla verdadeira',
+                        'zero falso',
+                        'numero verdadeiro',
+                        'verdadeiro',
+                        'falso',
+                        'ternario verdadeiro',
+                        'ternario falso',
+                    ]);
+                });
+
+                it('usa colecoes vazias para encerrar enquanto', async () => {
+                    const codigo = [
+                        'lista = [1]',
+                        'enquanto lista:',
+                        "   escreva('iteracao')",
+                        '   lista = []',
+                    ];
+                    const retornoLexador = lexador.mapear(codigo, -1);
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                        retornoLexador,
+                        -1
+                    );
+
+                    const retornoInterpretador = await interpretador.interpretar(
+                        retornoAvaliadorSintatico.declaracoes
+                    );
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toEqual(['iteracao']);
+                });
             });
 
             describe('Laços de repetição', () => {


### PR DESCRIPTION
## O que foi alterado

* Criada a sobrescrita do método `eVerdadeiro()` no arquivo `interpretador-pitugues.ts`.
* Implementada a tabela-verdade (*truthiness*) inspirada no Python padrão para avaliar como falsos: `0`, `""` (strings vazias), `[]` (vetores vazios), `{}` (dicionários vazios), `null`, `undefined` e instâncias vazias de `TuplaN`.
* Adicionado teste de regressão no arquivo `interpretador-pitugues.test.ts` para validar a coerção booleana em condicionais e retornos de função.

## Motivo da mudança

O dialeto Pituguês herdava o método `eVerdadeiro()` do interpretador base (Delégua), que segue a semântica do JavaScript. No JavaScript, um array vazio `[]` ou dicionário `{}` são considerados objetos existentes (*truthy*), o que gerava inconsistências ao utilizar o operador `!` fora de estruturas condicionais (ex: `retorna ! pilha`), falhando em avaliar listas vazias como falsas. 

Conforme alinhado na discussão do projeto, o dialeto deve seguir a tabela-verdade do Python, onde coleções e valores vazios são nativamente *falsy*.

## Resultado
```
pilha = []
se ! pilha:
    imprima('vazia') // imprime 'vazia'

funcao teste_vazio():
    pilha = []
    retorna ! pilha // retorna 'verdadeiro'
```

## Issue relacionada

Resolve #1344

## Referência

- Discussão: [Alinhamento de coerção booleana (truthiness) com o Python padrão](https://github.com/DesignLiquido/delegua/discussions/1354)