### PR TITLE
Corrige bug de `enumerar()` não assumir o valor `0` como padrão para o parâmetro `início`

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/biblioteca-global.ts
@@ -761,8 +761,9 @@ export async function enumerar(
     }
 
     const valorInicioResolvido = interpretador.resolverValor(inicio);
+
     if (
-        valorInicioResolvido !== undefined &&
+        valorInicioResolvido != null &&
         (typeof valorInicioResolvido !== 'number' || Number.isNaN(valorInicioResolvido))
     ) {
         throw new ErroEmTempoDeExecucao(

--- a/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
+++ b/testes/bibliotecas/dialetos/pitugues/biblioteca-global.test.ts
@@ -1245,5 +1245,43 @@ describe('biblioteca-global (pituguês)', () => {
 
             expect(retornoInterpretador.erros).toHaveLength(0);
         });
+
+        it('enumerar sem parâmetro inicio (deve assumir 0 como padrão)', async () => {
+            const codigo = [
+                'frutas = ["maçã", "banana", "uva"]',
+                'resultado = enumerar(frutas)',
+                'escreva(resultado)',
+            ];
+
+            const retornoLexador = lexador.mapear(codigo, -1);
+            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                retornoLexador,
+                -1
+            );
+            const retornoInterpretador = await interpretador.interpretar(
+                retornoAvaliadorSintatico.declaracoes
+            );
+
+            expect(retornoInterpretador.erros).toHaveLength(0);
+        });
+
+        it('enumerar com inicio personalizado (via interpretador completo)', async () => {
+            const codigo = [
+                'frutas = ["maçã", "banana", "uva"]',
+                'resultado = enumerar(frutas, 1)',
+                'escreva(resultado)',
+            ];
+
+            const retornoLexador = lexador.mapear(codigo, -1);
+            const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(
+                retornoLexador,
+                -1
+            );
+            const retornoInterpretador = await interpretador.interpretar(
+                retornoAvaliadorSintatico.declaracoes
+            );
+
+            expect(retornoInterpretador.erros).toHaveLength(0);
+        });
     });
 });


### PR DESCRIPTION
Closes #1383