### PR TITLE
Cria a função `obterMensagemErro()` para padronizar a captura de mensagens de erro

### DIFF
--- a/fontes/excecoes/index.ts
+++ b/fontes/excecoes/index.ts
@@ -1,2 +1,3 @@
 export * from './erro-de-assertiva';
 export * from './erro-em-tempo-de-execucao';
+export * from './mensagem-erro';

--- a/fontes/excecoes/mensagem-erro.ts
+++ b/fontes/excecoes/mensagem-erro.ts
@@ -1,0 +1,33 @@
+/**
+ * Obtém a mensagem de erro de forma padronizada, independentemente do tipo de erro.
+ *
+ * Apenas erros do ecossistema Delégua (que possuem a propriedade `mensagem`)
+ * têm sua mensagem extraída diretamente. Demais erros e valores são convertidos
+ * para string via `String()`, que para erros nativos do JavaScript produz o
+ * formato "NomeDoErro: mensagem" (ex: "Error: algo deu errado").
+ *
+ * O uso de `unknown` como tipo do parâmetro garante que a função seja segura
+ * para qualquer valor que venha de `catch` blocks ou da propriedade `erroInterno`
+ * (tipada como `any`), sem perder informações por type narrowing excessivo.
+ *
+ * @param erro O valor a ser convertido em mensagem (qualquer tipo)
+ * @returns A mensagem de erro como string
+ */
+export function obterMensagemErro(erro: unknown): string {
+    if (
+        typeof erro === 'object'
+        && erro !== null
+        && 'mensagem' in erro
+    ) {
+        const mensagem = (erro as Record<string, unknown>).mensagem;
+
+        if (
+            typeof mensagem === 'string'
+            && mensagem
+        ) {
+            return mensagem;
+        }
+    }
+
+    return String(erro);
+}

--- a/fontes/interpretador/depuracao/avaliador-expressao-depuracao.ts
+++ b/fontes/interpretador/depuracao/avaliador-expressao-depuracao.ts
@@ -9,6 +9,7 @@ import { inferirTipoVariavel } from '../../inferenciador';
 import { ConstrutoInterface } from '../../interfaces/construtos';
 import { ResultadoAvaliacao } from '../../interfaces/depuracao';
 import { InterpretadorComDepuracao } from './interpretador-com-depuracao';
+import { obterMensagemErro } from '../../excecoes';
 
 /**
  * Verifica se uma expressão tem efeitos colaterais que não devem ser executados
@@ -134,7 +135,7 @@ export class AvaliadorExpressaoDepuracao {
         } catch (erro: any) {
             return {
                 sucesso: false,
-                erro: erro.message || String(erro),
+                erro: obterMensagemErro(erro),
             };
         }
     }

--- a/testes/excecoes/mensagem-erro.test.ts
+++ b/testes/excecoes/mensagem-erro.test.ts
@@ -1,0 +1,135 @@
+import { obterMensagemErro } from '../../fontes/excecoes';
+import { ErroEmTempoDeExecucao } from '../../fontes/excecoes';
+
+describe('obterMensagemErro()', () => {
+    describe('Erros com propriedade padrão Delégua (.mensagem)', () => {
+        it('Deve retornar .mensagem de ErroEmTempoDeExecucao', () => {
+            const erro = new ErroEmTempoDeExecucao(undefined, 'Operando precisa ser um número.');
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('Operando precisa ser um número.');
+        });
+
+        it('Deve retornar .mensagem de objeto comum com propriedade mensagem', () => {
+            const erro = { mensagem: 'Erro personalizado' };
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('Erro personalizado');
+        });
+    });
+
+    describe('Erros nativos do JavaScript (fallback para String())', () => {
+        it('Deve usar String() como fallback para Error nativo', () => {
+            const erro = new Error('Algo deu errado');
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('Error: Algo deu errado');
+        });
+
+        it('Deve usar String() como fallback para TypeError', () => {
+            const erro = new TypeError('Valor inválido');
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('TypeError: Valor inválido');
+        });
+
+        it('Deve usar String() como fallback para RangeError', () => {
+            const erro = new RangeError('Fora do intervalo permitido');
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('RangeError: Fora do intervalo permitido');
+        });
+    });
+
+    describe('Erro com ambas propriedades (.mensagem e .message)', () => {
+        it('Deve priorizar .mensagem sobre .message', () => {
+            const erro = {
+                mensagem: 'Mensagem em português',
+                message: 'Message in english',
+            };
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('Mensagem em português');
+        });
+
+        it('ErroEmTempoDeExecucao retorna .mensagem (ignorando .message herdado)', () => {
+            const erro = new ErroEmTempoDeExecucao(undefined, 'Prioridade portuguesa');
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toBe('Prioridade portuguesa');
+        });
+    });
+
+    describe('Valores nulos e indefinidos', () => {
+        it('Deve retornar "null" para null', () => {
+            const resultado = obterMensagemErro(null);
+            expect(resultado).toBe('null');
+        });
+
+        it('Deve retornar "undefined" para undefined', () => {
+            const resultado = obterMensagemErro(undefined);
+            expect(resultado).toBe('undefined');
+        });
+    });
+
+    describe('Tipos primitivos', () => {
+        it('Deve retornar o próprio valor para string', () => {
+            const resultado = obterMensagemErro('Mensagem direta');
+            expect(resultado).toBe('Mensagem direta');
+        });
+
+        it('Deve converter número para string', () => {
+            const resultado = obterMensagemErro(42);
+            expect(resultado).toBe('42');
+        });
+
+        it('Deve converter booleano para string', () => {
+            const resultado = obterMensagemErro(true);
+            expect(resultado).toBe('true');
+        });
+
+        it('Deve retornar string vazia para string vazia', () => {
+            const resultado = obterMensagemErro('');
+            expect(resultado).toBe('');
+        });
+    });
+
+    describe('Objetos sem mensagem ou message', () => {
+        it('Deve retornar representação string de objeto simples', () => {
+            const erro = { codigo: 500, descricao: 'Erro interno' };
+            const resultado = obterMensagemErro(erro);
+            expect(resultado).toContain('[object Object]');
+        });
+
+        it('Deve retornar representação string de array', () => {
+            const resultado = obterMensagemErro([1, 2, 3]);
+            expect(resultado).toBe('1,2,3');
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('Deve usar String(erro) como fallback quando .mensagem é vazio', () => {
+            const erro = { mensagem: '' };
+            const resultado = obterMensagemErro(erro);
+            // '' é falsy, então cai em String(erro)
+            expect(resultado).toBe('[object Object]');
+        });
+
+        it('Deve usar String(erro) como fallback para objeto sem .mensagem', () => {
+            const erro = { message: '' };
+            const resultado = obterMensagemErro(erro);
+            // não tem .mensagem, cai em String(erro)
+            expect(resultado).toBe('[object Object]');
+        });
+
+        it('Deve usar String(erro) como fallback quando .mensagem é vazio e objeto tem .message', () => {
+            const erro = { mensagem: '', message: '' };
+            const resultado = obterMensagemErro(erro);
+            // .mensagem é falsy, cai em String(erro)
+            expect(resultado).toBe('[object Object]');
+        });
+
+        it('Deve retornar string comum quando ela é passada diretamente', () => {
+            const resultado = obterMensagemErro('Mensagem direta');
+            expect(resultado).toBe('Mensagem direta');
+        });
+
+        it('Deve retornar número como string', () => {
+            const resultado = obterMensagemErro(0);
+            expect(resultado).toBe('0');
+        });
+    });
+});

--- a/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
+++ b/testes/interpretador/dialetos/pitugues/interpretador-pitugues.test.ts
@@ -2,6 +2,7 @@ import { AvaliadorSintaticoPitugues } from "../../../../fontes/avaliador-sintati
 import { LexadorPitugues } from "../../../../fontes/lexador";
 import { InterpretadorPitugues } from "../../../../fontes/interpretador/dialetos/pitugues"
 import { Iteravel } from "../../../../fontes/interpretador/estruturas/iteravel";
+import { obterMensagemErro } from "../../../../fontes/excecoes";
 
 describe('Interpretador (Pituguês)', () => {
     describe('interpretar()', () => {
@@ -2299,7 +2300,7 @@ describe('Interpretador (Pituguês)', () => {
                         );
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-                        const mensagemErro = retornoInterpretador.erros[0].erroInterno?.mensagem || retornoInterpretador.erros[0].mensagem;
+                        const mensagemErro = obterMensagemErro(retornoInterpretador.erros[0].erroInterno) || retornoInterpretador.erros[0].mensagem;
                         expect(mensagemErro).toContain('só pode ser usado com dicionários');
                     });
 
@@ -2316,7 +2317,7 @@ describe('Interpretador (Pituguês)', () => {
                         );
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-                        const mensagemErro = retornoInterpretador.erros[0].erroInterno?.mensagem || retornoInterpretador.erros[0].mensagem;
+                        const mensagemErro = obterMensagemErro(retornoInterpretador.erros[0].erroInterno) || retornoInterpretador.erros[0].mensagem;
                         expect(mensagemErro).toContain('vetor');
                     });
 
@@ -2333,7 +2334,7 @@ describe('Interpretador (Pituguês)', () => {
                         );
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-                        const mensagemErro = retornoInterpretador.erros[0].erroInterno?.mensagem || retornoInterpretador.erros[0].mensagem;
+                        const mensagemErro = obterMensagemErro(retornoInterpretador.erros[0].erroInterno) || retornoInterpretador.erros[0].mensagem;
                         expect(mensagemErro).toContain('dicionários');
                     });
 
@@ -2350,7 +2351,7 @@ describe('Interpretador (Pituguês)', () => {
                         );
 
                         expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-                        const mensagemErro = retornoInterpretador.erros[0].erroInterno?.mensagem || retornoInterpretador.erros[0].mensagem;
+                        const mensagemErro = obterMensagemErro(retornoInterpretador.erros[0].erroInterno) || retornoInterpretador.erros[0].mensagem;
                         expect(mensagemErro).toContain('nulo');
                     });
                 });
@@ -4735,7 +4736,7 @@ describe('Interpretador (Pituguês)', () => {
                     );
 
                     expect(retornoInterpretador.erros.length).toBe(1);
-                    expect(retornoInterpretador.erros[0].erroInterno.message).toBe('teste de falha');
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('teste de falha');
                 });
 
                 it('Trivial com atribuição', async () => {
@@ -4755,7 +4756,7 @@ describe('Interpretador (Pituguês)', () => {
                     console.log(retornoInterpretador.erros)
 
                     expect(retornoInterpretador.erros.length).toBe(1);
-                    expect(retornoInterpretador.erros[0].erroInterno.message).toBe('teste de falha');
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('teste de falha');
                 });
             });
 
@@ -5102,7 +5103,7 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
 
                     const erro = retornoInterpretador.erros[0];
-                    const mensagem = erro.erroInterno['message'] || String(erro.erroInterno);
+                    const mensagem = erro.erroInterno.mensagem;
 
                     expect(mensagem).toContain('tamanho diferente');
                 });
@@ -5136,7 +5137,7 @@ describe('Interpretador (Pituguês)', () => {
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
 
                     const erro = retornoInterpretador.erros[0];
-                    expect(erro.erroInterno.message).toContain('só é suportado em vetores, textos e tuplas.');
+                    expect(erro.erroInterno.mensagem).toContain('só é suportado em vetores, textos e tuplas.');
                 });
 
                 it('Tentar fatiar booleano', async () => {
@@ -5266,7 +5267,7 @@ describe('Interpretador (Pituguês)', () => {
                 );
 
                 expect(retornoInterpretador.erros).toHaveLength(1);
-                expect(retornoInterpretador.erros[0].erroInterno.message).toContain('imutáveis');
+                expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain('imutáveis');
             });
 
             describe('Uso de primitivas de texto', () => {
@@ -5549,7 +5550,7 @@ describe('Interpretador (Pituguês)', () => {
                     const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes, true);
 
                     expect(retornoInterpretador.erros.length).toBeGreaterThan(0);
-                    expect(retornoInterpretador.erros[0].erroInterno.message).toContain("não encontrado");
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toContain("não encontrado");
                 });
 
                 it('Falha - Tentar limpar um vetor nulo', async () => {

--- a/testes/interpretador/interpretador.test.ts
+++ b/testes/interpretador/interpretador.test.ts
@@ -4459,7 +4459,7 @@ describe('Interpretador', () => {
                     );
 
                     expect(retornoInterpretador.erros.length).toBe(1);
-                    expect(retornoInterpretador.erros[0].erroInterno.message).toBe('teste de falha');
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('teste de falha');
                 });
 
                 it('Trivial com atribuição', async () => {
@@ -4474,7 +4474,7 @@ describe('Interpretador', () => {
                     );
 
                     expect(retornoInterpretador.erros.length).toBe(1);
-                    expect(retornoInterpretador.erros[0].erroInterno.message).toBe('teste de falha');
+                    expect(retornoInterpretador.erros[0].erroInterno.mensagem).toBe('teste de falha');
                 });
             });
 


### PR DESCRIPTION
Closes #1386