### PR TITLE
[Pituguês]: Atualiza a documentação para seguir a sintaxe do Pituguês

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-dicionario.ts
@@ -24,7 +24,7 @@ const contem_comum = (nome: string) => {
             'Retorna verdadeiro se o elemento passado como parâmetro existe como chave do dicionário. Devolve falso em caso contrário.\n' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var d = {"a": 1, "b": 2, "c": 3}\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
             `escreva(d.${nome}("a")) // verdadeiro\n` +
             `escreva(d.${nome}("f")) // falso\n\`\`\`` +
             '\n\n## Formas de uso\n',
@@ -48,7 +48,7 @@ export default {
             'Retorna um vetor de texto com todas as chaves de um dicionário.\n' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var d = {"a": 1, "b": 2, "c": 3}\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
             'escreva(d.chaves()) // ["a", "b", "c"]\n```' +
             '\n\n## Formas de uso\n',
         exemploCodigo: 'dicionário.chaves()',
@@ -75,7 +75,7 @@ export default {
             'Funciona de maneira semelhante à função `items()` da linguagem Python.\n' +
             '\n\n## Exemplo de Código\n' +
             '\n```pitugues\n' +
-            'var d = {"a": 1, "b": 2, "c": 3}\n' +
+            'd = {"a": 1, "b": 2, "c": 3}\n' +
             'escreva(d.itens())\n' +
             '// [["a", 1], ["b", 2], ["c", 3]]\n' +
             '```\n\n' +

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-numero.ts
@@ -14,7 +14,7 @@ export default {
             'Retorna a versão absoluta de um número, ou seja, seu valor sem sinal.' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var n = -5\n' +
+            'n = -5\n' +
             'escreva(n.absoluto()) // 5\n```' +
             '\n\n## Formas de uso\n',
         exemploCodigo: 'numero.absoluto()',
@@ -50,7 +50,7 @@ export default {
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
             'n = 2.4\n' +
-            'escreva(n.arredondar()) // 2\n```' +
+            'escreva(n.arredondar()) // 2\n' +
             'x = 2.468\n' +
             'escreva(x.arredondar(2)) // 2.47\n```' +
             '\n\n## Formas de uso\n',

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-texto.ts
@@ -39,7 +39,7 @@ export default {
             '# `texto.aparar()` \n \n' +
             'Remove espaços em branco no início e no fim de um texto.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "   meu texto com espaços no início e no fim       "\n' +
+            '\n\n```pitugues\nt = "   meu texto com espaços no início e no fim       "\n' +
             'escreva("|" + t.aparar() + "|") // "|meu texto com espaços no início e no fim|"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.aparar()',
@@ -56,7 +56,7 @@ export default {
             '# `texto.aparar_fim()` \n \n' +
             'Remove espaços em branco no no fim de um texto.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "   meu texto com espaços no início e no fim       "\n' +
+            '\n\n```pitugues\nt = "   meu texto com espaços no início e no fim       "\n' +
             'escreva("|" + t.aparar_fim() + "|") // "|   meu texto com espaços no início e no fim|"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.aparar_fim()',
@@ -73,7 +73,7 @@ export default {
             '# `texto.aparar_inicio()` \n \n' +
             'Remover espaços em branco no início e no fim de um texto.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "   meu texto com espaços no início e no fim       "\n' +
+            '\n\n```pitugues\nt = "   meu texto com espaços no início e no fim       "\n' +
             'escreva("|" + t.aparar_inicio() + "|") // "|meu texto com espaços no início e no fim       |"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.aparar_inicio()',
@@ -141,8 +141,8 @@ export default {
             '# `texto.concatenar(outroTexto)` \n \n' +
             'Realiza a junção de palavras/textos.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t1 = "um"\n' +
-            'var t2 = "dois três"\n' +
+            '\n\n```pitugues\nt1 = "um"\n' +
+            't2 = "dois três"\n' +
             'escreva(t1.concatenar(t2)) // "umdois três"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.concatenar(outroTexto)',
@@ -182,7 +182,7 @@ export default {
             '# `texto.dividir(delimitador)` \n \n' +
             'Divide o texto pelo separador passado como parâmetro.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "um dois três"\n' +
+            '\n\n```pitugues\nt = "um dois três"\n' +
             "t.dividir(' ') // ['um','dois','três']\n```" +
             '\n\n ### Formas de uso  \n',
         exemploCodigo: "texto.dividir('<delimitador (, ; ' ')>')",
@@ -222,7 +222,7 @@ export default {
             '# `texto.encontrar(subtexto, indiceInicio)` \n \n' +
             'Retorna o índice inicial de um subtexto. Retorna -1 caso não encontre.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "um dois três"\n' +
+            '\n\n```pitugues\nt = "um dois três"\n' +
             't.encontrar("dois") // 3\n' +
             't.encontrar("quatro") // -1\n' +
             't.encontrar("dois", 4) // -1\n```' +
@@ -271,7 +271,7 @@ export default {
             'Retorna **-1** caso o subtexto não seja encontrado.\n\n' +
             '## Exemplo de Código\n\n' +
             '```pitugues\n' +
-            'var t = "Mi casa, su casa."\n\n' +
+            't = "Mi casa, su casa."\n\n' +
             't.encontrar_ultimo("casa")        // 12\n' +
             't.encontrar_ultimo("Mi")          // 0\n' +
             't.encontrar_ultimo("nada")        // -1\n' +
@@ -499,7 +499,7 @@ export default {
             '# `texto.inclui(elemento)` \n \n' +
             'Devolve verdadeiro se elemento passado por parâmetro está contido no texto, e falso em caso contrário.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "um dois três"\n' +
+            '\n\n```pitugues\nt = "um dois três"\n' +
             't.inclui("dois") // verdadeiro\n' +
             't.inclui("quatro") // falso\n```' +
             '\n\n ### Formas de uso \n',
@@ -517,7 +517,7 @@ export default {
             '# `texto.maiusculo()` \n \n' +
             'Converte todos os caracteres alfabéticos para suas respectivas formas em maiúsculo.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "tudo em minúsculo"\n' +
+            '\n\n```pitugues\nt = "tudo em minúsculo"\n' +
             'escreva(t.maiusculo()) // "TUDO EM MINÚSCULO"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.maiusculo()',
@@ -534,7 +534,7 @@ export default {
             '# `texto.minusculo()` \n \n' +
             'Converte todos os caracteres alfabéticos para suas respectivas formas em minúsculo.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "TUDO EM MAIÚSCULO"\n' +
+            '\n\n```pitugues\nt = "TUDO EM MAIÚSCULO"\n' +
             'escreva(t.minusculo()) // "tudo em maiúsculo"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.minusculo()',
@@ -621,7 +621,7 @@ export default {
             '# `texto.tamanho()` \n\n' +
             'Devolve um número inteiro com o número de caracteres do texto.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t = "Um dois três quatro"\n' +
+            '\n\n```pitugues\nt = "Um dois três quatro"\n' +
             't.tamanho() // 19\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'texto.tamanho()',
@@ -647,7 +647,7 @@ export default {
             '# `texto.termina_com(sufixo)` \n \n' +
             'Verifica se um texto termina com o sufixo especificado e retorna um valor lógico (verdadeiro ou falso).' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar mensagem = "Olá, bem-vindo ao meu mundo."\n' +
+            '\n\n```pitugues\nmensagem = "Olá, bem-vindo ao meu mundo."\n' +
             'escreva(mensagem.termina_com(".")) // verdadeiro\n' +
             'escreva(mensagem.termina_com("mundo")) // falso\n' +
             'escreva(mensagem.termina_com("mundo.")) // verdadeiro\n```' +
@@ -666,8 +666,8 @@ export default {
             '# `texto.tudo_maiusculo()` \n\n' +
             'Devolve verdadeiro se todos os caracteres alfabéticos do texto estão em maiúsculo, e falso em caso contrário.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t1 = "TUDO EM MAIÚSCULO"\n' +
-            'var t2 = "Tudo em Maiúsculo"\n' +
+            '\n\n```pitugues\nt1 = "TUDO EM MAIÚSCULO"\n' +
+            't2 = "Tudo em Maiúsculo"\n' +
             't1.tudo_maiusculo() // verdadeiro\n' +
             't2.tudo_maiusculo() // falso\n```' +
             '\n\n ### Formas de uso \n',
@@ -685,8 +685,8 @@ export default {
             '# `texto.tudo_minusculo()` \n\n' +
             'Devolve verdadeiro se todos os caracteres alfabéticos do texto estão em minúsculo, e falso em caso contrário.' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar t1 = "tudo em minúsculo"\n' +
-            'var t2 = "Tudo em Minúsculo"\n' +
+            '\n\n```pitugues\nt1 = "tudo em minúsculo"\n' +
+            't2 = "Tudo em Minúsculo"\n' +
             't1.tudo_minusculo() // verdadeiro\n' +
             't2.tudo_minusculo() // falso\n```' +
             '\n\n ### Formas de uso \n',

--- a/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/primitivas-vetor.ts
@@ -29,7 +29,7 @@ const contem_comum = (nome: string) => {
             'Verifica se o elemento existe no vetor. Devolve `verdadeiro` se existe, e `falso` em caso contrário.\n' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var v = [1, 2, 3]\n' +
+            'v = [1, 2, 3]\n' +
             `escreva(v.${nome}(2)) // verdadeiro\n` +
             `escreva(v.${nome}(4)) // falso\n\`\`\`` +
             '\n\n## Formas de uso\n',
@@ -126,7 +126,7 @@ export default {
             '# `vetor.concatenar(outroVetor)` \n \n' +
             'Adiciona ao conteúdo do vetor um ou mais elementos' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar v = [7, 5, 3]\n' +
+            '\n\n```pitugues\nv = [7, 5, 3]\n' +
             'escreva(v.concatenar([1, 2, 4])) // [7, 5, 3, 1, 2, 4]\n```' +
             '\n\n ### Formas de uso  \n',
         exemploCodigo: 'vetor.concatenar(...argumentos)',
@@ -217,7 +217,7 @@ export default {
             '# `vetor.fatiar(inicio, fim)` \n \n' +
             'Extrai uma fatia do vetor, dadas posições de início e fim. \n' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar v = [1, 2, 3, 4, 5]\n' +
+            '\n\n```pitugues\nv = [1, 2, 3, 4, 5]\n' +
             'escreva(v.fatiar()) // "[1, 2, 3, 4, 5]", ou seja, não faz coisa alguma.\n' +
             'escreva(v.fatiar(2, 4)) // "[3, 4]"\n' +
             'escreva(v.fatiar(2)) // "[3, 4, 5]", ou seja, extrai trecho da 3ª posição até o final do vetor.\n```' +
@@ -265,7 +265,7 @@ export default {
             'Caso o elemento não seja encontrado, devolve `-1`.\n' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n' +
-            'var v = ["maçã", "banana", "uva"]\n' +
+            'v = ["maçã", "banana", "uva"]\n' +
             'escreva(v.indice("banana")) // 1\n' +
             'escreva(v.indice("abacaxi")) // -1\n' +
             '```',
@@ -363,7 +363,7 @@ export default {
             '# `vetor.juntar(separador = ",")` \n \n' +
             'Junta todos os elementos de um vetor em um texto, separando cada elemento pelo separador passado como parâmetro.\n' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar v = [1, 2, 3]\n' +
+            '\n\n```pitugues\nv = [1, 2, 3]\n' +
             'escreva(v.juntar(":")) // "1:2:3"\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.juntar()\n' + 'vetor.juntar(<separador>)',
@@ -434,10 +434,10 @@ export default {
             'Ordena valores de um vetor em ordem crescente.\n' +
             '\n\n ## Exemplo de Código\n' +
             '\n\n```pitugues\n// A ordenação padrão é ascendente, ou seja, para o caso de números, a ordem fica do menor para o maior.\n' +
-            'var v = [4, 2, 12, 5]\n' +
+            'v = [4, 2, 12, 5]\n' +
             'escreva(v.ordenar()) // [2, 4, 5, 12]\n' +
             '// Para o caso de textos, a ordenação é feita em ordem alfabética, caractere a caractere.\n' +
-            'var v = ["aaa", "a", "aba", "abb", "abc"]\n' +
+            'v = ["aaa", "a", "aba", "abb", "abc"]\n' +
             'escreva(v.ordenar()) // ["a", "aaa", "aba", "abb", "abc"]\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.ordenar()',
@@ -468,7 +468,7 @@ export default {
             '# `vetor.remover(elemento)` \n \n' +
             'Remove um elemento do vetor caso o elemento exista no vetor.\n' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar vetor = [1, 2, 3]\n' +
+            '\n\n```pitugues\nvetor = [1, 2, 3]\n' +
             'vetor.remover(2)\n' +
             'escreva(vetor) // [1, 3]\n```' +
             '\n\n ### Formas de uso \n',
@@ -486,8 +486,8 @@ export default {
             '# `vetor.remover_primeiro()` \n \n' +
             'Remove o primeiro elemento do vetor caso o elemento exista no vetor.\n' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar vetor = [1, 2, 3]\n' +
-            'var primeiroElemento = vetor.remover_primeiro()\n' +
+            '\n\n```pitugues\nvetor = [1, 2, 3]\n' +
+            'primeiroElemento = vetor.remover_primeiro()\n' +
             'escreva(primeiroElemento) // 1\n' +
             'escreva(vetor) // [2, 3]\n```' +
             '\n\n ### Formas de uso \n',
@@ -542,8 +542,8 @@ export default {
             '# `vetor.remover_ultimo()` \n \n' +
             'Remove o último elemento do vetor caso o elemento exista no vetor.\n' +
             '\n\n ## Exemplo de Código\n' +
-            '\n\n```pitugues\nvar vetor = [1, 2, 3]\n' +
-            'var ultimoElemento = vetor.remover_ultimo()\n' +
+            '\n\n```pitugues\nvetor = [1, 2, 3]\n' +
+            'ultimoElemento = vetor.remover_ultimo()\n' +
             'escreva(ultimoElemento) // 3\n' +
             'escreva(vetor) // [1, 2]\n```' +
             '\n\n ### Formas de uso \n',
@@ -576,7 +576,7 @@ export default {
             '# `vetor.somar()` \n \n' +
             'Soma ou concatena todos os elementos do vetor (de acordo com o tipo de dados desses elementos) e retorna o resultado.\n' +
             '\n\n ### Exemplo de Código\n' +
-            '\n\n```pitugues\nvar vetor = [1, 2, 3, 4, 5]\n' +
+            '\n\n```pitugues\nvetor = [1, 2, 3, 4, 5]\n' +
             'escreva(vetor.somar()) // 15\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'vetor.somar()',


### PR DESCRIPTION
## O que foi alterado

- Atualizadas as documentações e exemplos de código das primitivas no dialeto Pituguês.

## Motivo da mudança

Alguns exemplos na documentação de primitivas ainda utilizavam palavras reservadas e sintaxe do Delégua, o que gerava inconsistências ao exibir o hover e os exemplos de uso no editor para o dialeto Pituguês.

## Issue relacionada

Resolve DesignLiquido/vscode#97
