### PR TITLE
1423: adiciona lint e build ao CI

### DIFF
--- a/.github/workflows/comentario-cobertura.yml
+++ b/.github/workflows/comentario-cobertura.yml
@@ -1,90 +1,48 @@
-name: Comentário de Cobertura
+name: Relatório de Cobertura
 
 on:
   workflow_run:
-    workflows: ["Testes Unitários"]
+    workflows: ["Integração Contínua - Principal"]
     types:
       - completed
 
-permissions:
-  pull-requests: write
-  checks: write
-
 jobs:
-  comentario:
-    runs-on: ubuntu-latest
+  relatorio:
+    name: Publicar Cobertura no PR
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
 
     steps:
-    - name: Baixar artefato de cobertura
-      uses: actions/download-artifact@v4
-      with:
-        name: coverage-report
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        run-id: ${{ github.event.workflow_run.id }}
+      - name: Baixar artefatos
+        uses: actions/download-artifact@v4
+        with:
+          name: relatorio-testes
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Obter número do PR
-      id: pr
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
-      with:
-        result-encoding: string
-        script: |
-          const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            commit_sha: context.payload.workflow_run.head_sha
-          });
-          return response.data.length > 0 ? response.data[0].number : '';
+      - name: Ler número do PR
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> $GITHUB_OUTPUT
 
-    - name: Criar comentário de cobertura
-      if: steps.pr.outputs.result != ''
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
-      with:
-        script: |
-          const fs = require('fs');
-          const coverage = JSON.parse(fs.readFileSync('coverage-summary.json', 'utf8'));
+      - name: Gerar relatório de cobertura
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        id: coverage
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file: report.json
+          base-coverage-file: report.json
+          prnumber: ${{ steps.pr.outputs.number }}
+          skip-step: all
+          output: report-markdown
 
-          const total = coverage.total;
-          const lines = total.lines.pct;
-          const statements = total.statements.pct;
-          const functions = total.functions.pct;
-          const branches = total.branches.pct;
-
-          const comment = `## 📊 Cobertura de Código
-
-          | Métrica     | Cobertura      |
-          |-------------|----------------|
-          | Linhas      | ${lines}%      |
-          | Declarações | ${statements}% |
-          | Funções     | ${functions}%  |
-          | Branches    | ${branches}%   |
-          `;
-
-          const prNumber = '${{ steps.pr.outputs.result }}';
-
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-          });
-
-          const botComment = comments.find(comment =>
-            comment.user.type === 'Bot' &&
-            comment.body.includes('📊 Cobertura de Código')
-          );
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: comment
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: comment
-            });
-          }
+      - name: Publicar comentário no PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.pr.outputs.number }}
+          message: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/principal.yml
+++ b/.github/workflows/principal.yml
@@ -1,4 +1,4 @@
-name: Testes Unitários
+name: Integração Contínua - Principal
 
 on:
   pull_request:
@@ -10,27 +10,63 @@ permissions:
   contents: read
 
 jobs:
-  testes-unitarios:
+  checks:
+    name: Verificações (Lint e Build)
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '24'
-        cache: 'yarn'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
 
-    - name: Yarn - Dependências
-      run: yarn install --frozen-lockfile
+      - name: Instalar dependências
+        run: yarn install --frozen-lockfile
 
-    - name: Testes unitários com cobertura
-      run: yarn testes-unitarios --coverage --coverageReporters=json-summary --coverageReporters=text
+      - name: Lint
+        run: yarn lint
 
-    - name: Salvar resultados de cobertura
-      if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: coverage/coverage-summary.json
-        retention-days: 1
+      - name: Build / Empacotamento
+        run: yarn empacotar
+
+  testes-unitarios:
+    name: Testes Unitários
+    needs: checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Instalar dependências
+        run: yarn install --frozen-lockfile
+
+      - name: Executar testes unitários com cobertura
+        run: |
+          yarn testes-unitarios \
+            --ci \
+            --coverageReporters=json-summary \
+            --coverageReporters=text \
+            --json \
+            --testLocationInResults \
+            --outputFile=report.json
+
+      - name: Salvar número do PR
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr-number.txt
+
+      - name: Salvar artefatos de testes e cobertura
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: relatorio-testes
+          path: |
+            report.json
+            pr-number.txt
+          retention-days: 1

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
+import globals from "globals";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -39,6 +40,7 @@ export default defineConfig([globalIgnores([
 
     languageOptions: {
         parser: tsParser,
+        globals: globals.node,
     },
 
     rules: {

--- a/fontes/avaliador-sintatico/avaliador-sintatico.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico.ts
@@ -5413,7 +5413,6 @@ export class AvaliadorSintatico
 
         if (this.performance) {
             const deltaAnalise: [number, number] = hrtime(inicioAnalise);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Avaliador Sintático] Tempo para análise: ${deltaAnalise[0] * 1e9 + deltaAnalise[1]}ns`
             );

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-pitugues.ts
@@ -3229,7 +3229,6 @@ export class AvaliadorSintaticoPitugues extends AvaliadorSintaticoBase implement
 
         if (this.performance) {
             const deltaAnalise: [number, number] = hrtime(inicioAnalise);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Avaliador Sintático] Tempo para análise: ${deltaAnalise[0] * 1e9 + deltaAnalise[1]}ns`
             );

--- a/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-tenda.ts
+++ b/fontes/avaliador-sintatico/dialetos/avaliador-sintatico-tenda.ts
@@ -1776,7 +1776,6 @@ export class AvaliadorSintaticoTenda extends AvaliadorSintaticoBase {
 
         if (this.performance) {
             const deltaAnalise: [number, number] = hrtime(inicioAnalise);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Avaliador Sintático Tenda] Tempo para análise: ${deltaAnalise[0] * 1e9 + deltaAnalise[1]}ns`
             );

--- a/fontes/lexador/dialetos/lexador-pitugues.ts
+++ b/fontes/lexador/dialetos/lexador-pitugues.ts
@@ -654,7 +654,6 @@ export class LexadorPitugues implements LexadorInterface<SimboloInterface> {
 
         if (this.performance) {
             const deltaMapeamento: [number, number] = hrtime(inicioMapeamento);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Lexador] Tempo para mapeamento: ${deltaMapeamento[0] * 1e9 + deltaMapeamento[1]}ns`
             );

--- a/fontes/lexador/dialetos/lexador-tenda.ts
+++ b/fontes/lexador/dialetos/lexador-tenda.ts
@@ -472,7 +472,6 @@ export class LexadorTenda implements LexadorInterface<SimboloInterface> {
 
         if (this.performance) {
             const deltaMapeamento: [number, number] = hrtime(inicioMapeamento);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Lexador] Tempo para mapeamento: ${deltaMapeamento[0] * 1e9 + deltaMapeamento[1]}ns`
             );

--- a/fontes/lexador/lexador.ts
+++ b/fontes/lexador/lexador.ts
@@ -608,7 +608,6 @@ export class Lexador extends LexadorBase {
 
         if (this.performance) {
             const deltaMapeamento: [number, number] = hrtime(inicioMapeamento);
-            // eslint-disable-next-line no-undef
             console.log(
                 `[Lexador] Tempo para mapeamento: ${deltaMapeamento[0] * 1e9 + deltaMapeamento[1]}ns`
             );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "testes-unitarios:insignias": "yarn jest-coverage-badges --output ./recursos/imagens",
         "observar-testes-unitarios": "yarn jest --watchAll",
         "observar-testes-unitarios-com-coverage": "yarn jest --coverage --watchAll",
-        "lint": "yarn eslint . --ext .ts --fix",
+        "lint": "yarn eslint . --ext .ts",
+        "lint:fix": "yarn eslint . --ext .ts --fix",
         "deixar-codigo-bonito": "yarn prettier --config .prettierrc --write fontes/**/*.ts",
         "umd": "yarn browserify dist/index.js --s Delegua -o dist/umd/delegua.js"
     },


### PR DESCRIPTION
## O que foi alterado

CI:

* Substituído o workflow de testes unitários por um workflow de integração contínua.
* Adicionadas etapas de lint e build/empacotamento.
* Ajustada a execução dos testes unitários para gerar o relatório JSON utilizado na publicação da cobertura.
* Salvos os artefatos necessários para o relatório de cobertura.

ESLint:

* Adicionados os globals do Node.js à configuração do ESLint.
* Separados os scripts de lint e correção automática em `lint` e `lint:fix`.
* Corrigidos os problemas apontados pelo linter no código existente.

Cobertura:

* Ajustado o workflow de comentário de cobertura para utilizar os artefatos gerados pelo novo workflow de CI.
* Substituída a identificação do PR via API pelo número do PR salvo como artifact.
* Substituída a geração manual do comentário pela action `jest-coverage-report-action`.
* Utilizado comentário fixo no PR para atualizar o relatório de cobertura em novas execuções.

## Motivo da mudança

Ampliar as verificações executadas pelo CI, adicionando lint e build/empacotamento aos checks realizados em PRs e pushes para `principal`.

## Resultado

Localmente:

* `yarn lint` executando sem erros.
* `yarn empacotar` executando sem erros.
* Testes unitários executando com cobertura.

CI:

* Workflow configurado para validar lint, empacotamento e testes unitários em PRs e pushes para `principal`.
* Relatório de cobertura publicado automaticamente no PR.

## Issue relacionada

#1423 